### PR TITLE
Document the desktop contributor workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,8 +7,20 @@ Read the `README.md` for repo context first.
 - Build the maintained desktop utility as a Tauri shell with a React + TypeScript renderer.
 - Keep desktop-runtime code in `src-tauri/` and renderer code in `src/`.
 - Keep developer-facing documentation in `docs/` and active planning artifacts in `planning/`.
+- Treat all UI copy and content as player-facing production copy. Do not ship text that reads like developer notes, setup placeholders, implementation breadcrumbs, or future-feature narration.
+- Write desktop UI copy for non-technical players in a friendly, helpful tone that matches the rest of the Board Enthusiasts product experience.
+- Keep desktop styling aligned with the maintained Board Enthusiasts visual language, especially the `frontend` UI, unless the platform or interaction model requires a deliberate deviation.
+- Prefer reusing or extracting shared BE styling primitives, tokens, and patterns over duplicating or independently re-creating similar styles in the desktop app.
 - Do not redistribute `bdb` in source control, packaged releases, or local bootstrap artifacts. The utility must download the correct Board-hosted `bdb` binary for the current platform as part of setup.
 - Preserve an offline-capable local experience for device checks, local APK inventory, install, uninstall, and launch flows after first-time setup completes.
 - Treat Board Enthusiasts account features as optional enhancements on top of the account-free local utility path.
 - Always provide a manual APK selection or install override path even when automatic Board-APK detection is available.
 - Translate device, file-system, network, and CLI failures into plain-language product guidance suitable for non-technical players.
+
+## GitHub Workflow
+
+- Work GitHub tickets in dependency order instead of skipping ahead to blocked work.
+- Keep the linked issue thread updated as work moves into progress, PR open, and merge-ready states.
+- Open a dedicated PR for each ticket-sized change set instead of batching unrelated ticket work together.
+- Do not start a blocked or dependent ticket until every prerequisite ticket has at least an active PR open.
+- When a prerequisite PR is still unmerged, branch the dependent work from that prerequisite branch rather than from `main` so the dependency chain stays explicit in Git history.

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ The desktop stack needs both JavaScript and Rust toolchains.
 - Rust toolchain (`rustup`, `cargo`, `rustc`) for the Tauri host app
 - Platform-specific Tauri prerequisites for Windows, macOS, or Linux packaging/signing
 
+If Rust is not installed yet, you can still work on the renderer-only parts of the desktop app, but not the full Tauri host.
+
 ## Local Development
 
 Install dependencies and launch the desktop shell:
@@ -68,6 +70,26 @@ npm run build
 npm run test
 ```
 
+If you are still missing Rust locally, these repo-local commands remain useful:
+
+```bash
+npm install
+npm run dev
+npm run test:renderer
+```
+
+These commands still require the Rust toolchain:
+
+```bash
+npm run tauri dev
+npm run test:host
+npm run test
+```
+
 ## Planning
 
 Active planning lives in [`planning/`](planning/README.md).
+
+## Docs
+
+Contributor-facing desktop workflow notes live in [`docs/`](docs/README.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,4 +2,8 @@
 
 This directory is reserved for maintained developer-facing documentation for `be-home-for-desktop`.
 
+## Available Guides
+
+- [`local-development.md`](local-development.md): supported repo-local setup, dev, build, and test workflow
+
 Use [`planning/`](../planning/README.md) for active MVP planning and delivery breakdowns.

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -1,0 +1,77 @@
+# Local Development
+
+This guide explains the maintained local workflow for `be-home-for-desktop`.
+
+## Prerequisites
+
+- Node.js and npm
+- Rust toolchain (`rustup`, `cargo`, `rustc`)
+- The platform-specific prerequisites required by Tauri for your OS
+
+## Repo-Local Commands
+
+Install dependencies:
+
+```bash
+npm install
+```
+
+Run the renderer-only Vite dev server:
+
+```bash
+npm run dev
+```
+
+Run the full Tauri desktop shell:
+
+```bash
+npm run tauri dev
+```
+
+Build the renderer bundle:
+
+```bash
+npm run build
+```
+
+Run renderer tests only:
+
+```bash
+npm run test:renderer
+```
+
+Run Rust host tests only:
+
+```bash
+npm run test:host
+```
+
+Run the maintained desktop test suite:
+
+```bash
+npm run test
+```
+
+## What Works Before Rust Is Installed
+
+If Rust tooling is not available yet, these commands still work for renderer-only work:
+
+```bash
+npm install
+npm run dev
+npm run test:renderer
+```
+
+These commands require the Rust toolchain because they invoke the Tauri host or Cargo:
+
+```bash
+npm run tauri dev
+npm run test:host
+npm run test
+```
+
+## Contributor Notes
+
+- Keep the repo-local `npm` scripts current and discoverable.
+- Prefer updating this guide when the supported local workflow changes.
+- Keep player-facing copy in runtime code and contributor-facing guidance in `docs/`.


### PR DESCRIPTION
## Summary
- document the maintained repo-local desktop workflow in `docs/local-development.md`
- explain what still works before Rust is installed and what requires the Rust toolchain
- add AGENTS guidance for ticket order, issue-thread updates, PR-per-ticket, and dependent branch ancestry

## Testing
- not run (documentation-only changes)

Refs #4

Note: this PR is intentionally based on `feature/desktop-3-scaffold` because #4 depends on the scaffold work in PR #40.