### PR TITLE
Add the first desktop CI baseline

### DIFF
--- a/.github/workflows/desktop-validation.yml
+++ b/.github/workflows/desktop-validation.yml
@@ -1,0 +1,65 @@
+name: Desktop Validation
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  validate:
+    name: Validate (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-24.04
+          - macos-15
+          - windows-2025
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install Linux system dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt update
+          sudo apt install -y \
+            libwebkit2gtk-4.1-dev \
+            build-essential \
+            curl \
+            wget \
+            file \
+            libxdo-dev \
+            libssl-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust build outputs
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Typecheck renderer
+        run: npm run typecheck
+
+      - name: Build renderer bundle
+        run: npm run build
+
+      - name: Run renderer tests
+        run: npm run test:renderer
+
+      - name: Run host tests
+        run: cargo test --manifest-path src-tauri/Cargo.toml

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,5 +5,6 @@ This directory is reserved for maintained developer-facing documentation for `be
 ## Available Guides
 
 - [`local-development.md`](local-development.md): supported repo-local setup, dev, build, and test workflow
+- [`continuous-integration.md`](continuous-integration.md): current desktop pull-request validation scope and known release gaps
 
 Use [`planning/`](../planning/README.md) for active MVP planning and delivery breakdowns.

--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -1,0 +1,31 @@
+# Continuous Integration
+
+This repository uses a small but real desktop validation baseline so follow-on feature work lands against visible checks.
+
+## Current Validation Scope
+
+The maintained pull-request workflow runs on Windows, macOS, and Linux and currently verifies:
+
+- `npm ci`
+- `npm run typecheck`
+- `npm run build`
+- `npm run test:renderer`
+- `cargo test --manifest-path src-tauri/Cargo.toml`
+
+This keeps the early baseline focused on renderer correctness, Rust host correctness, and cross-platform compile confidence without turning the first CI pass into a full release pipeline.
+
+## Current Gaps
+
+The CI baseline does **not** yet do the following:
+
+- build signed installers
+- notarize or sign macOS releases
+- sign Windows installers
+- produce Linux release artifacts for distribution
+- publish checksums or packaged desktop releases
+
+Those release concerns are intentionally staged for the later packaging and signing tickets in Epic 1.
+
+## Linux Notes
+
+The Linux workflow installs the system packages Tauri requires to compile on Debian/Ubuntu-based runners. Keep that package list aligned with the maintained Tauri prerequisites when the desktop stack evolves.


### PR DESCRIPTION
## Summary
- add the first desktop pull-request validation workflow for Windows, macOS, and Linux
- run renderer typecheck/build/tests plus Rust host tests on native runners
- document the intentional gap between early CI validation and later signing/release automation

## Testing
- `npm run build`
- `npm run test`

Refs #5

Note: this PR is intentionally based on `feature/desktop-4-workflow-docs` because #5 depends on the earlier scaffold and workflow-doc branches already being active.