### PR TITLE
Define the maintained bdb source map

### DIFF
--- a/config/bdb-sources.json
+++ b/config/bdb-sources.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": 1,
+  "platforms": {
+    "linux-x86_64": "https://dev.board.fun/downloads/bdb/linux/bdb",
+    "macos-universal": "https://dev.board.fun/downloads/bdb/macos-universal/bdb",
+    "windows-x86_64": "https://dev.board.fun/downloads/bdb/windows/bdb.exe"
+  }
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,5 +6,6 @@ This directory is reserved for maintained developer-facing documentation for `be
 
 - [`local-development.md`](local-development.md): supported repo-local setup, dev, build, and test workflow
 - [`continuous-integration.md`](continuous-integration.md): current desktop pull-request validation scope and known release gaps
+- [`bdb-source-manifest.md`](bdb-source-manifest.md): maintained `bdb` source map schema, hosting target, and fallback policy
 
 Use [`planning/`](../planning/README.md) for active MVP planning and delivery breakdowns.

--- a/docs/bdb-source-manifest.md
+++ b/docs/bdb-source-manifest.md
@@ -1,0 +1,65 @@
+# `bdb` Source Manifest
+
+This repository keeps the maintained `bdb` source map in [`config/bdb-sources.json`](../config/bdb-sources.json).
+
+## Purpose
+
+- keep the current Board-hosted download URLs in one small, reviewable file
+- allow the desktop app to ship with a bundled fallback manifest
+- provide a repo-hosted JSON file that future runtime refresh logic can fetch without requiring a new desktop app release
+
+## Current Remote Manifest URL
+
+The planned remote manifest URL for runtime checks is:
+
+[`https://raw.githubusercontent.com/board-enthusiasts/be-home-for-desktop/main/config/bdb-sources.json`](https://raw.githubusercontent.com/board-enthusiasts/be-home-for-desktop/main/config/bdb-sources.json)
+
+## Schema
+
+The manifest intentionally stays simple:
+
+```json
+{
+  "schemaVersion": 1,
+  "platforms": {
+    "linux-x86_64": "https://dev.board.fun/downloads/bdb/linux/bdb",
+    "macos-universal": "https://dev.board.fun/downloads/bdb/macos-universal/bdb",
+    "windows-x86_64": "https://dev.board.fun/downloads/bdb/windows/bdb.exe"
+  }
+}
+```
+
+## Current Platform Rules
+
+- `macos-universal`: used for both Intel and Apple Silicon macOS hosts
+- `linux-x86_64`: used only for Linux amd64 / x86_64 hosts
+- `windows-x86_64`: used only for Windows x86_64 hosts that pass the app’s Windows 11 compatibility check
+
+The app owns compatibility rules such as the Windows 11 requirement. The manifest only maps supported platform keys to Board-hosted URLs.
+
+## Fallback Strategy
+
+The maintained precedence for the later acquisition flow is:
+
+1. freshly fetched remote manifest
+2. cached last-known-good manifest
+3. bundled fallback manifest from the app build
+
+This issue implements the bundled fallback and the maintained remote URL target. Cached manifest behavior lands in the later bootstrap/download work.
+
+## Emergency Update Procedure
+
+If Board changes a `bdb` URL or withdraws a build:
+
+1. update [`config/bdb-sources.json`](../config/bdb-sources.json)
+2. merge the change to `main` so the repo-hosted raw JSON updates
+3. keep or remove the matching platform key deliberately rather than silently redirecting unsupported users
+4. update the related docs and issue thread if the support matrix itself changed
+
+## Current Board References
+
+As of April 23, 2026, the Board Developer Portal advertises these `bdb` downloads:
+
+- [macOS (Universal)](https://dev.board.fun/downloads/bdb/macos-universal/bdb)
+- [Linux (amd64)](https://dev.board.fun/downloads/bdb/linux/bdb)
+- [Windows (Windows 11)](https://dev.board.fun/downloads/bdb/windows/bdb.exe)

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -99,6 +99,7 @@ name = "be-home-for-desktop"
 version = "0.1.0"
 dependencies = [
  "serde",
+ "serde_json",
  "tauri",
  "tauri-build",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -14,5 +14,5 @@ tauri-build = { version = "2", features = [] }
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 tauri = { version = "2", features = [] }
-

--- a/src-tauri/src/bdb.rs
+++ b/src-tauri/src/bdb.rs
@@ -67,7 +67,6 @@ struct DetectedPlatform {
     operating_system: BdbOperatingSystem,
     architecture: BdbArchitecture,
     windows_build: Option<u32>,
-    probe_error: Option<String>,
 }
 
 /// Describes the current machine's compatibility with the maintained `bdb` support matrix.
@@ -178,10 +177,9 @@ fn build_guidance_for_unsupported_platform(
         BdbUnsupportedReason::UnsupportedOperatingSystemVersion => {
             "Board currently advertises its Windows bdb build for Windows 11. This machine did not pass the Windows 11 compatibility check.".into()
         }
-        BdbUnsupportedReason::PlatformProbeFailed => detected
-            .probe_error
-            .clone()
-            .unwrap_or_else(|| "The app could not confirm this machine's supported platform details.".into()),
+        BdbUnsupportedReason::PlatformProbeFailed => {
+            "BE Home could not confirm whether this Windows PC matches Board's current bdb support. Try again, and if this keeps happening, make sure Windows is fully up to date.".into()
+        }
         BdbUnsupportedReason::MissingManifestEntry => {
             "The maintained bdb source manifest is missing the Board-hosted URL for this supported platform key.".into()
         }
@@ -237,35 +235,27 @@ fn detect_current_platform() -> DetectedPlatform {
     };
 
     #[cfg(target_os = "windows")]
-    let (windows_build, probe_error) = match detect_windows_build_number() {
-        Ok(build) => (Some(build), None),
-        Err(error) => (None, Some(error)),
-    };
+    let windows_build = detect_windows_build_number();
 
     #[cfg(not(target_os = "windows"))]
-    let (windows_build, probe_error) = (None, None);
+    let windows_build = None;
 
     DetectedPlatform {
         operating_system,
         architecture,
         windows_build,
-        probe_error,
     }
 }
 
 #[cfg(target_os = "windows")]
-fn detect_windows_build_number() -> Result<u32, String> {
+fn detect_windows_build_number() -> Option<u32> {
     let output = Command::new("cmd")
         .args(["/C", "ver"])
         .output()
-        .map_err(|error| format!("The app could not run `cmd /C ver` to confirm whether this machine is Windows 11: {error}"))?;
+        .ok()?;
 
     let version_text = String::from_utf8_lossy(&output.stdout);
-    parse_windows_build_number(&version_text).ok_or_else(|| {
-        format!(
-            "The app could not parse the Windows version output needed for Board's Windows 11-only bdb support check: {version_text}"
-        )
-    })
+    parse_windows_build_number(&version_text)
 }
 
 fn parse_windows_build_number(version_text: &str) -> Option<u32> {
@@ -319,7 +309,6 @@ mod tests {
                 operating_system: BdbOperatingSystem::Macos,
                 architecture: BdbArchitecture::Aarch64,
                 windows_build: None,
-                probe_error: None,
             },
         );
 
@@ -340,7 +329,6 @@ mod tests {
                 operating_system: BdbOperatingSystem::Linux,
                 architecture: BdbArchitecture::Arm,
                 windows_build: None,
-                probe_error: None,
             },
         );
 
@@ -361,7 +349,6 @@ mod tests {
                 operating_system: BdbOperatingSystem::Windows,
                 architecture: BdbArchitecture::X86_64,
                 windows_build: Some(26100),
-                probe_error: None,
             },
         );
 
@@ -382,7 +369,6 @@ mod tests {
                 operating_system: BdbOperatingSystem::Windows,
                 architecture: BdbArchitecture::X86_64,
                 windows_build: Some(19045),
-                probe_error: None,
             },
         );
 
@@ -395,7 +381,7 @@ mod tests {
     }
 
     #[test]
-    fn windows_probe_failures_are_explicit() {
+    fn windows_probe_failures_use_player_friendly_guidance() {
         let manifest = bundled_manifest();
         let plan = resolve_bdb_source_plan_for_platform(
             &manifest,
@@ -403,7 +389,6 @@ mod tests {
                 operating_system: BdbOperatingSystem::Windows,
                 architecture: BdbArchitecture::X86_64,
                 windows_build: None,
-                probe_error: Some("version probe failed".into()),
             },
         );
 
@@ -412,7 +397,10 @@ mod tests {
             Some(BdbUnsupportedReason::PlatformProbeFailed),
             plan.support.reason
         );
-        assert_eq!("version probe failed", plan.support.guidance);
+        assert_eq!(
+            "BE Home could not confirm whether this Windows PC matches Board's current bdb support. Try again, and if this keeps happening, make sure Windows is fully up to date.",
+            plan.support.guidance
+        );
     }
 
     #[test]

--- a/src-tauri/src/bdb.rs
+++ b/src-tauri/src/bdb.rs
@@ -1,0 +1,425 @@
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+#[cfg(target_os = "windows")]
+use std::process::Command;
+
+const REMOTE_BDB_SOURCE_MANIFEST_URL: &str =
+    "https://raw.githubusercontent.com/board-enthusiasts/be-home-for-desktop/main/config/bdb-sources.json";
+const BUNDLED_BDB_SOURCE_MANIFEST_JSON: &str = include_str!("../../config/bdb-sources.json");
+const LINUX_X86_64_PLATFORM_KEY: &str = "linux-x86_64";
+const MACOS_UNIVERSAL_PLATFORM_KEY: &str = "macos-universal";
+const WINDOWS_X86_64_PLATFORM_KEY: &str = "windows-x86_64";
+const WINDOWS_11_MINIMUM_BUILD: u32 = 22000;
+
+/// Describes the supported source-map status for the current machine.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) enum BdbSupportStatus {
+    Supported,
+    Unsupported,
+}
+
+/// Explains why the current machine could not be matched to a supported `bdb` source.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) enum BdbUnsupportedReason {
+    UnsupportedOperatingSystem,
+    UnsupportedArchitecture,
+    UnsupportedOperatingSystemVersion,
+    PlatformProbeFailed,
+    MissingManifestEntry,
+}
+
+/// Describes the normalized operating system being evaluated.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) enum BdbOperatingSystem {
+    Windows,
+    Macos,
+    Linux,
+    Unknown,
+}
+
+/// Describes the normalized CPU architecture being evaluated.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+pub(crate) enum BdbArchitecture {
+    #[serde(rename = "x86_64")]
+    X86_64,
+    #[serde(rename = "aarch64")]
+    Aarch64,
+    #[serde(rename = "x86")]
+    X86,
+    #[serde(rename = "arm")]
+    Arm,
+    #[serde(rename = "unknown")]
+    Unknown,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct BdbSourceManifest {
+    schema_version: u32,
+    platforms: BTreeMap<String, String>,
+}
+
+#[derive(Clone, Debug)]
+struct DetectedPlatform {
+    operating_system: BdbOperatingSystem,
+    architecture: BdbArchitecture,
+    windows_build: Option<u32>,
+    probe_error: Option<String>,
+}
+
+/// Describes the current machine's compatibility with the maintained `bdb` support matrix.
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct BdbPlatformSupport {
+    status: BdbSupportStatus,
+    operating_system: BdbOperatingSystem,
+    architecture: BdbArchitecture,
+    windows_build: Option<u32>,
+    platform_key: Option<String>,
+    reason: Option<BdbUnsupportedReason>,
+    guidance: String,
+}
+
+/// Describes the Board-hosted `bdb` source chosen for the current machine.
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct BdbDownloadSource {
+    platform_key: String,
+    download_url: String,
+}
+
+/// Describes the maintained source-resolution plan for `bdb` on the current machine.
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct BdbSourcePlan {
+    manifest_source: String,
+    remote_manifest_url: String,
+    manifest_schema_version: u32,
+    support: BdbPlatformSupport,
+    source: Option<BdbDownloadSource>,
+}
+
+/// Resolve the bundled `bdb` source plan for the current machine.
+pub(crate) fn resolve_current_bdb_source_plan() -> BdbSourcePlan {
+    let manifest = bundled_manifest();
+    resolve_bdb_source_plan_for_platform(&manifest, detect_current_platform())
+}
+
+fn resolve_bdb_source_plan_for_platform(
+    manifest: &BdbSourceManifest,
+    detected: DetectedPlatform,
+) -> BdbSourcePlan {
+    let support = match resolve_supported_platform_key(&detected) {
+        Ok(platform_key) => match manifest.platforms.get(platform_key) {
+            Some(_) => BdbPlatformSupport {
+                status: BdbSupportStatus::Supported,
+                operating_system: detected.operating_system,
+                architecture: detected.architecture,
+                windows_build: detected.windows_build,
+                platform_key: Some(platform_key.to_string()),
+                reason: None,
+                guidance: "This machine matches a Board-published bdb target.".into(),
+            },
+            None => BdbPlatformSupport {
+                status: BdbSupportStatus::Unsupported,
+                operating_system: detected.operating_system,
+                architecture: detected.architecture,
+                windows_build: detected.windows_build,
+                platform_key: Some(platform_key.to_string()),
+                reason: Some(BdbUnsupportedReason::MissingManifestEntry),
+                guidance: "This machine matched a supported platform key, but the maintained bdb manifest is missing its Board-hosted download URL.".into(),
+            },
+        },
+        Err(reason) => BdbPlatformSupport {
+            status: BdbSupportStatus::Unsupported,
+            operating_system: detected.operating_system,
+            architecture: detected.architecture,
+            windows_build: detected.windows_build,
+            platform_key: None,
+            reason: Some(reason),
+            guidance: build_guidance_for_unsupported_platform(&detected, reason),
+        },
+    };
+
+    let source = support
+        .platform_key
+        .as_ref()
+        .and_then(|platform_key| manifest.platforms.get(platform_key).map(|download_url| {
+            BdbDownloadSource {
+                platform_key: platform_key.clone(),
+                download_url: download_url.clone(),
+            }
+        }));
+
+    BdbSourcePlan {
+        manifest_source: "bundled".into(),
+        remote_manifest_url: REMOTE_BDB_SOURCE_MANIFEST_URL.into(),
+        manifest_schema_version: manifest.schema_version,
+        support,
+        source,
+    }
+}
+
+fn build_guidance_for_unsupported_platform(
+    detected: &DetectedPlatform,
+    reason: BdbUnsupportedReason,
+) -> String {
+    match reason {
+        BdbUnsupportedReason::UnsupportedOperatingSystem => {
+            "Board currently publishes bdb only for macOS, Linux amd64, and Windows 11 x86_64.".into()
+        }
+        BdbUnsupportedReason::UnsupportedArchitecture => format!(
+            "Board currently publishes bdb only for macOS universal, Linux x86_64, and Windows 11 x86_64. This machine reported architecture {:?}.",
+            detected.architecture
+        ),
+        BdbUnsupportedReason::UnsupportedOperatingSystemVersion => {
+            "Board currently advertises its Windows bdb build for Windows 11. This machine did not pass the Windows 11 compatibility check.".into()
+        }
+        BdbUnsupportedReason::PlatformProbeFailed => detected
+            .probe_error
+            .clone()
+            .unwrap_or_else(|| "The app could not confirm this machine's supported platform details.".into()),
+        BdbUnsupportedReason::MissingManifestEntry => {
+            "The maintained bdb source manifest is missing the Board-hosted URL for this supported platform key.".into()
+        }
+    }
+}
+
+fn resolve_supported_platform_key(
+    detected: &DetectedPlatform,
+) -> Result<&'static str, BdbUnsupportedReason> {
+    match detected.operating_system {
+        BdbOperatingSystem::Macos => match detected.architecture {
+            BdbArchitecture::X86_64 | BdbArchitecture::Aarch64 => Ok(MACOS_UNIVERSAL_PLATFORM_KEY),
+            _ => Err(BdbUnsupportedReason::UnsupportedArchitecture),
+        },
+        BdbOperatingSystem::Linux => match detected.architecture {
+            BdbArchitecture::X86_64 => Ok(LINUX_X86_64_PLATFORM_KEY),
+            _ => Err(BdbUnsupportedReason::UnsupportedArchitecture),
+        },
+        BdbOperatingSystem::Windows => match detected.architecture {
+            BdbArchitecture::X86_64 => match detected.windows_build {
+                Some(build) if build >= WINDOWS_11_MINIMUM_BUILD => Ok(WINDOWS_X86_64_PLATFORM_KEY),
+                Some(_) => Err(BdbUnsupportedReason::UnsupportedOperatingSystemVersion),
+                None => Err(BdbUnsupportedReason::PlatformProbeFailed),
+            },
+            _ => Err(BdbUnsupportedReason::UnsupportedArchitecture),
+        },
+        BdbOperatingSystem::Unknown => Err(BdbUnsupportedReason::UnsupportedOperatingSystem),
+    }
+}
+
+fn bundled_manifest() -> BdbSourceManifest {
+    serde_json::from_str(BUNDLED_BDB_SOURCE_MANIFEST_JSON)
+        .expect("bundled bdb source manifest should deserialize")
+}
+
+fn detect_current_platform() -> DetectedPlatform {
+    let operating_system = if cfg!(target_os = "windows") {
+        BdbOperatingSystem::Windows
+    } else if cfg!(target_os = "macos") {
+        BdbOperatingSystem::Macos
+    } else if cfg!(target_os = "linux") {
+        BdbOperatingSystem::Linux
+    } else {
+        BdbOperatingSystem::Unknown
+    };
+
+    let architecture = match std::env::consts::ARCH {
+        "x86_64" => BdbArchitecture::X86_64,
+        "aarch64" => BdbArchitecture::Aarch64,
+        "x86" | "i686" => BdbArchitecture::X86,
+        "arm" | "armv7" => BdbArchitecture::Arm,
+        _ => BdbArchitecture::Unknown,
+    };
+
+    #[cfg(target_os = "windows")]
+    let (windows_build, probe_error) = match detect_windows_build_number() {
+        Ok(build) => (Some(build), None),
+        Err(error) => (None, Some(error)),
+    };
+
+    #[cfg(not(target_os = "windows"))]
+    let (windows_build, probe_error) = (None, None);
+
+    DetectedPlatform {
+        operating_system,
+        architecture,
+        windows_build,
+        probe_error,
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn detect_windows_build_number() -> Result<u32, String> {
+    let output = Command::new("cmd")
+        .args(["/C", "ver"])
+        .output()
+        .map_err(|error| format!("The app could not run `cmd /C ver` to confirm whether this machine is Windows 11: {error}"))?;
+
+    let version_text = String::from_utf8_lossy(&output.stdout);
+    parse_windows_build_number(&version_text).ok_or_else(|| {
+        format!(
+            "The app could not parse the Windows version output needed for Board's Windows 11-only bdb support check: {version_text}"
+        )
+    })
+}
+
+fn parse_windows_build_number(version_text: &str) -> Option<u32> {
+    let numbers = version_text
+        .split(|character: char| !character.is_ascii_digit())
+        .filter(|segment| !segment.is_empty())
+        .filter_map(|segment| segment.parse::<u32>().ok())
+        .collect::<Vec<_>>();
+
+    if numbers.len() >= 3 {
+        numbers.get(2).copied()
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        bundled_manifest, parse_windows_build_number, resolve_bdb_source_plan_for_platform,
+        BdbArchitecture, BdbOperatingSystem, BdbSupportStatus, BdbUnsupportedReason,
+        DetectedPlatform, LINUX_X86_64_PLATFORM_KEY, MACOS_UNIVERSAL_PLATFORM_KEY,
+        WINDOWS_X86_64_PLATFORM_KEY,
+    };
+
+    #[test]
+    fn bundled_manifest_tracks_current_board_download_urls() {
+        let manifest = bundled_manifest();
+
+        assert_eq!(1, manifest.schema_version);
+        assert_eq!(
+            Some(&"https://dev.board.fun/downloads/bdb/macos-universal/bdb".to_string()),
+            manifest.platforms.get(MACOS_UNIVERSAL_PLATFORM_KEY)
+        );
+        assert_eq!(
+            Some(&"https://dev.board.fun/downloads/bdb/linux/bdb".to_string()),
+            manifest.platforms.get(LINUX_X86_64_PLATFORM_KEY)
+        );
+        assert_eq!(
+            Some(&"https://dev.board.fun/downloads/bdb/windows/bdb.exe".to_string()),
+            manifest.platforms.get(WINDOWS_X86_64_PLATFORM_KEY)
+        );
+    }
+
+    #[test]
+    fn macos_apple_silicon_maps_to_universal_download() {
+        let manifest = bundled_manifest();
+        let plan = resolve_bdb_source_plan_for_platform(
+            &manifest,
+            DetectedPlatform {
+                operating_system: BdbOperatingSystem::Macos,
+                architecture: BdbArchitecture::Aarch64,
+                windows_build: None,
+                probe_error: None,
+            },
+        );
+
+        assert_eq!(BdbSupportStatus::Supported, plan.support.status);
+        assert_eq!(Some(MACOS_UNIVERSAL_PLATFORM_KEY), plan.support.platform_key.as_deref());
+        assert_eq!(
+            Some("https://dev.board.fun/downloads/bdb/macos-universal/bdb"),
+            plan.source.as_ref().map(|source| source.download_url.as_str())
+        );
+    }
+
+    #[test]
+    fn linux_arm_is_reported_as_unsupported_architecture() {
+        let manifest = bundled_manifest();
+        let plan = resolve_bdb_source_plan_for_platform(
+            &manifest,
+            DetectedPlatform {
+                operating_system: BdbOperatingSystem::Linux,
+                architecture: BdbArchitecture::Arm,
+                windows_build: None,
+                probe_error: None,
+            },
+        );
+
+        assert_eq!(BdbSupportStatus::Unsupported, plan.support.status);
+        assert_eq!(
+            Some(BdbUnsupportedReason::UnsupportedArchitecture),
+            plan.support.reason
+        );
+        assert!(plan.source.is_none());
+    }
+
+    #[test]
+    fn windows_11_x86_64_maps_to_board_windows_download() {
+        let manifest = bundled_manifest();
+        let plan = resolve_bdb_source_plan_for_platform(
+            &manifest,
+            DetectedPlatform {
+                operating_system: BdbOperatingSystem::Windows,
+                architecture: BdbArchitecture::X86_64,
+                windows_build: Some(26100),
+                probe_error: None,
+            },
+        );
+
+        assert_eq!(BdbSupportStatus::Supported, plan.support.status);
+        assert_eq!(Some(WINDOWS_X86_64_PLATFORM_KEY), plan.support.platform_key.as_deref());
+        assert_eq!(
+            Some("https://dev.board.fun/downloads/bdb/windows/bdb.exe"),
+            plan.source.as_ref().map(|source| source.download_url.as_str())
+        );
+    }
+
+    #[test]
+    fn windows_10_is_rejected_by_the_windows_11_requirement() {
+        let manifest = bundled_manifest();
+        let plan = resolve_bdb_source_plan_for_platform(
+            &manifest,
+            DetectedPlatform {
+                operating_system: BdbOperatingSystem::Windows,
+                architecture: BdbArchitecture::X86_64,
+                windows_build: Some(19045),
+                probe_error: None,
+            },
+        );
+
+        assert_eq!(BdbSupportStatus::Unsupported, plan.support.status);
+        assert_eq!(
+            Some(BdbUnsupportedReason::UnsupportedOperatingSystemVersion),
+            plan.support.reason
+        );
+        assert!(plan.source.is_none());
+    }
+
+    #[test]
+    fn windows_probe_failures_are_explicit() {
+        let manifest = bundled_manifest();
+        let plan = resolve_bdb_source_plan_for_platform(
+            &manifest,
+            DetectedPlatform {
+                operating_system: BdbOperatingSystem::Windows,
+                architecture: BdbArchitecture::X86_64,
+                windows_build: None,
+                probe_error: Some("version probe failed".into()),
+            },
+        );
+
+        assert_eq!(BdbSupportStatus::Unsupported, plan.support.status);
+        assert_eq!(
+            Some(BdbUnsupportedReason::PlatformProbeFailed),
+            plan.support.reason
+        );
+        assert_eq!("version probe failed", plan.support.guidance);
+    }
+
+    #[test]
+    fn windows_build_parser_extracts_the_build_number() {
+        let build_number =
+            parse_windows_build_number("Microsoft Windows [Version 10.0.26100.1]");
+
+        assert_eq!(Some(26100), build_number);
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,5 @@
+mod bdb;
+
 use serde::Serialize;
 
 #[derive(Clone, Serialize)]
@@ -180,11 +182,19 @@ fn load_shell_state() -> DesktopShellState {
     shell_state()
 }
 
+#[tauri::command]
+fn load_bdb_source_plan() -> bdb::BdbSourcePlan {
+    bdb::resolve_current_bdb_source_plan()
+}
+
 /// Starts the Tauri desktop host for BE Home for Desktop.
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
-        .invoke_handler(tauri::generate_handler![load_shell_state])
+        .invoke_handler(tauri::generate_handler![
+            load_shell_state,
+            load_bdb_source_plan
+        ])
         .run(tauri::generate_context!())
         .expect("error while running BE Home for Desktop");
 }
@@ -255,5 +265,18 @@ mod tests {
             let normalized = entry.to_lowercase();
             banned_terms.iter().all(|term| !normalized.contains(term))
         }));
+    }
+
+    #[test]
+    fn bdb_source_plan_uses_the_bundled_manifest_contract() {
+        let plan = super::load_bdb_source_plan();
+        let serialized = serde_json::to_value(plan).expect("bdb source plan should serialize");
+
+        assert_eq!(Some("bundled"), serialized.get("manifestSource").and_then(|value| value.as_str()));
+        assert_eq!(Some(1), serialized.get("manifestSchemaVersion").and_then(|value| value.as_u64()));
+        assert!(serialized
+            .get("remoteManifestUrl")
+            .and_then(|value| value.as_str())
+            .is_some_and(|value| value.contains("raw.githubusercontent.com/board-enthusiasts/be-home-for-desktop/main/config/bdb-sources.json")));
     }
 }

--- a/src/desktop/client.ts
+++ b/src/desktop/client.ts
@@ -1,9 +1,16 @@
 import { invoke } from "@tauri-apps/api/core";
-import type { DesktopShellState } from "./types";
+import type { BdbSourcePlan, DesktopShellState } from "./types";
 
 /**
  * Loads the current desktop shell state from the Rust host.
  */
 export function loadDesktopShellState(): Promise<DesktopShellState> {
   return invoke<DesktopShellState>("load_shell_state");
+}
+
+/**
+ * Loads the maintained `bdb` source-resolution plan for the current machine.
+ */
+export function loadBdbSourcePlan(): Promise<BdbSourcePlan> {
+  return invoke<BdbSourcePlan>("load_bdb_source_plan");
 }

--- a/src/desktop/types.ts
+++ b/src/desktop/types.ts
@@ -41,3 +41,60 @@ export interface DesktopShellState {
   helpBullets: string[];
   sections: ShellSection[];
 }
+
+/**
+ * Describes whether the current machine matches a supported Board `bdb` target.
+ */
+export type BdbSupportStatus = "supported" | "unsupported";
+
+/**
+ * Explains why the current machine could not be matched to a supported `bdb` source.
+ */
+export type BdbUnsupportedReason =
+  | "unsupportedOperatingSystem"
+  | "unsupportedArchitecture"
+  | "unsupportedOperatingSystemVersion"
+  | "platformProbeFailed"
+  | "missingManifestEntry";
+
+/**
+ * Describes the normalized operating system being evaluated for `bdb`.
+ */
+export type BdbOperatingSystem = "windows" | "macos" | "linux" | "unknown";
+
+/**
+ * Describes the normalized CPU architecture being evaluated for `bdb`.
+ */
+export type BdbArchitecture = "x86_64" | "aarch64" | "x86" | "arm" | "unknown";
+
+/**
+ * Describes the current machine's compatibility with the maintained `bdb` support matrix.
+ */
+export interface BdbPlatformSupport {
+  status: BdbSupportStatus;
+  operatingSystem: BdbOperatingSystem;
+  architecture: BdbArchitecture;
+  windowsBuild: number | null;
+  platformKey: string | null;
+  reason: BdbUnsupportedReason | null;
+  guidance: string;
+}
+
+/**
+ * Describes the Board-hosted `bdb` source chosen for the current machine.
+ */
+export interface BdbDownloadSource {
+  platformKey: string;
+  downloadUrl: string;
+}
+
+/**
+ * Describes the maintained source-resolution plan for `bdb` on the current machine.
+ */
+export interface BdbSourcePlan {
+  manifestSource: string;
+  remoteManifestUrl: string;
+  manifestSchemaVersion: number;
+  support: BdbPlatformSupport;
+  source: BdbDownloadSource | null;
+}


### PR DESCRIPTION
## Summary
- add the maintained repo-hosted `bdb` source manifest with the current Board download URLs
- add a typed host-side source-resolution module with strict platform compatibility mapping
- surface explicit unsupported-system outcomes for unsupported OS, architecture, and Windows version cases
- document the manifest schema, remote hosting target, and planned fallback order

## Testing
- `npm run build`
- `npm run test`

Refs #7

Note: this PR is intentionally based on `feature/desktop-5-ci-baseline` because the `bdb` foundation work depends on the earlier scaffold, workflow-doc, and CI branches already being active.