### PR TITLE
Implement managed storage defaults and overrides

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,5 +7,6 @@ This directory is reserved for maintained developer-facing documentation for `be
 - [`local-development.md`](local-development.md): supported repo-local setup, dev, build, and test workflow
 - [`continuous-integration.md`](continuous-integration.md): current desktop pull-request validation scope and known release gaps
 - [`bdb-source-manifest.md`](bdb-source-manifest.md): maintained `bdb` source map schema, hosting target, and fallback policy
+- [`managed-storage.md`](managed-storage.md): default app-owned storage paths and persisted override model
 
 Use [`planning/`](../planning/README.md) for active MVP planning and delivery breakdowns.

--- a/docs/managed-storage.md
+++ b/docs/managed-storage.md
@@ -1,0 +1,36 @@
+# Managed Storage
+
+This repository separates app-managed storage into two independent locations:
+
+- `bdb` tool storage
+- managed APK library storage
+
+## Default Locations
+
+The maintained defaults are:
+
+- Windows: `%LocalAppData%/Board Enthusiasts/BE Home for Desktop/tools` and `%LocalAppData%/Board Enthusiasts/BE Home for Desktop/apk-library`
+- macOS: `~/Library/Application Support/Board Enthusiasts/BE Home for Desktop/tools` and `~/Library/Application Support/Board Enthusiasts/BE Home for Desktop/apk-library`
+- Linux: `~/.local/share/Board Enthusiasts/BE Home for Desktop/tools` and `~/.local/share/Board Enthusiasts/BE Home for Desktop/apk-library`
+
+## Persisted Overrides
+
+When a player changes either location, the app persists absolute-path overrides in an app-owned settings file instead of relying on command-line flags or ad hoc path parsing.
+
+Current settings file location:
+
+- Windows: `%LocalAppData%/Board Enthusiasts/BE Home for Desktop/settings/managed-storage.json`
+- macOS: `~/Library/Application Support/Board Enthusiasts/BE Home for Desktop/settings/managed-storage.json`
+- Linux: `~/.local/share/Board Enthusiasts/BE Home for Desktop/settings/managed-storage.json`
+
+## Current Contract
+
+The host-side storage settings contract exposes:
+
+- the current OS
+- the settings file path
+- the default path for each storage area
+- the optional persisted override for each storage area
+- the effective path the app should use right now
+
+This keeps later setup, settings, download, and library flows aligned on one shared source of truth.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -102,6 +102,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tempfile",
 ]
 
 [[package]]
@@ -722,6 +723,16 @@ dependencies = [
  "serde",
  "serde_core",
  "typeid",
+]
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1739,6 +1750,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2707,6 +2724,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.11.1",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3491,6 +3521,19 @@ dependencies = [
  "dunce",
  "embed-resource",
  "toml 0.9.12+spec-1.1.0",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -16,3 +16,6 @@ tauri-build = { version = "2", features = [] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tauri = { version = "2", features = [] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
 mod bdb;
+mod storage;
 
 use serde::Serialize;
 
@@ -187,13 +188,27 @@ fn load_bdb_source_plan() -> bdb::BdbSourcePlan {
     bdb::resolve_current_bdb_source_plan()
 }
 
+#[tauri::command]
+fn load_managed_storage_settings() -> Result<storage::ManagedStorageSettings, String> {
+    storage::load_managed_storage_settings()
+}
+
+#[tauri::command]
+fn save_managed_storage_settings(
+    overrides: storage::ManagedStorageOverridesInput,
+) -> Result<storage::ManagedStorageSettings, String> {
+    storage::save_managed_storage_settings(overrides)
+}
+
 /// Starts the Tauri desktop host for BE Home for Desktop.
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
         .invoke_handler(tauri::generate_handler![
             load_shell_state,
-            load_bdb_source_plan
+            load_bdb_source_plan,
+            load_managed_storage_settings,
+            save_managed_storage_settings
         ])
         .run(tauri::generate_context!())
         .expect("error while running BE Home for Desktop");
@@ -278,5 +293,22 @@ mod tests {
             .get("remoteManifestUrl")
             .and_then(|value| value.as_str())
             .is_some_and(|value| value.contains("raw.githubusercontent.com/board-enthusiasts/be-home-for-desktop/main/config/bdb-sources.json")));
+    }
+
+    #[test]
+    fn managed_storage_settings_serialize_with_distinct_tool_and_library_locations() {
+        let settings = super::load_managed_storage_settings().expect("managed storage should load");
+        let serialized =
+            serde_json::to_value(settings).expect("managed storage settings should serialize");
+
+        assert!(serialized.get("settingsFilePath").is_some());
+        assert!(serialized
+            .get("bdbTools")
+            .and_then(|value| value.get("effectivePath"))
+            .is_some());
+        assert!(serialized
+            .get("apkLibrary")
+            .and_then(|value| value.get("effectivePath"))
+            .is_some());
     }
 }

--- a/src-tauri/src/storage.rs
+++ b/src-tauri/src/storage.rs
@@ -97,25 +97,24 @@ fn build_managed_storage_settings(
 ) -> ManagedStorageSettings {
     let default_bdb_tools_path = context.app_data_root.join(TOOLS_DIRECTORY);
     let default_apk_library_path = context.app_data_root.join(APK_LIBRARY_DIRECTORY);
+    let bdb_tools_override = normalize_loaded_override(persisted.bdb_tools_override.as_deref());
+    let apk_library_override = normalize_loaded_override(persisted.apk_library_override.as_deref());
 
     ManagedStorageSettings {
         operating_system: context.operating_system,
         settings_file_path: path_to_string(&context.settings_file_path),
-        bdb_tools: build_location(default_bdb_tools_path, persisted.bdb_tools_override.as_deref()),
-        apk_library: build_location(
-            default_apk_library_path,
-            persisted.apk_library_override.as_deref(),
-        ),
+        bdb_tools: build_location(default_bdb_tools_path, bdb_tools_override),
+        apk_library: build_location(default_apk_library_path, apk_library_override),
     }
 }
 
-fn build_location(default_path: PathBuf, override_path: Option<&str>) -> ManagedStorageLocation {
+fn build_location(default_path: PathBuf, override_path: Option<String>) -> ManagedStorageLocation {
     let default_path_string = path_to_string(&default_path);
     match override_path {
         Some(override_path) => ManagedStorageLocation {
             default_path: default_path_string,
-            override_path: Some(override_path.to_string()),
-            effective_path: override_path.to_string(),
+            override_path: Some(override_path.clone()),
+            effective_path: override_path,
             source: ManagedStoragePathSource::Override,
         },
         None => ManagedStorageLocation {
@@ -125,6 +124,10 @@ fn build_location(default_path: PathBuf, override_path: Option<&str>) -> Managed
             source: ManagedStoragePathSource::Default,
         },
     }
+}
+
+fn normalize_loaded_override(value: Option<&str>) -> Option<String> {
+    normalize_override(value.map(str::to_owned)).ok().flatten()
 }
 
 fn current_storage_context() -> Result<ManagedStorageContext, String> {
@@ -180,8 +183,7 @@ fn require_environment_path(
     environment: &BTreeMap<OsString, OsString>,
     key: &str,
 ) -> Result<PathBuf, String> {
-    environment
-        .get(&OsString::from(key))
+    lookup_environment_value(environment, key)
         .map(PathBuf::from)
         .filter(|path| !path.as_os_str().is_empty())
         .ok_or_else(|| {
@@ -189,6 +191,24 @@ fn require_environment_path(
                 "The desktop app could not resolve its managed storage defaults because the `{key}` environment variable was unavailable."
             )
         })
+}
+
+fn lookup_environment_value(
+    environment: &BTreeMap<OsString, OsString>,
+    key: &str,
+) -> Option<OsString> {
+    #[cfg(target_os = "windows")]
+    {
+        environment
+            .iter()
+            .find(|(candidate, _)| candidate.to_string_lossy().eq_ignore_ascii_case(key))
+            .map(|(_, value)| value.clone())
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        environment.get(&OsString::from(key)).cloned()
+    }
 }
 
 fn load_persisted_overrides(
@@ -271,12 +291,57 @@ mod tests {
     use std::ffi::OsString;
     use std::path::PathBuf;
 
+    fn sample_tools_override_path() -> String {
+        if cfg!(target_os = "windows") {
+            r"C:\temp\be\tools".into()
+        } else {
+            "/tmp/be/tools".into()
+        }
+    }
+
+    fn sample_apk_library_override_path() -> String {
+        if cfg!(target_os = "windows") {
+            r"C:\temp\be\apk-library".into()
+        } else {
+            "/tmp/be/apk-library".into()
+        }
+    }
+
     #[cfg(target_os = "windows")]
     #[test]
     fn windows_defaults_use_local_app_data() {
         let mut environment = BTreeMap::new();
         environment.insert(
             OsString::from("LOCALAPPDATA"),
+            OsString::from(r"C:\Users\matt\AppData\Local"),
+        );
+
+        let context = current_storage_context_from_environment(&environment)
+            .expect("windows context should resolve");
+
+        assert_eq!(StorageOperatingSystem::Windows, context.operating_system);
+        assert_eq!(
+            PathBuf::from(r"C:\Users\matt\AppData\Local")
+                .join("Board Enthusiasts")
+                .join("BE Home for Desktop")
+                .join("tools"),
+            PathBuf::from(
+                build_managed_storage_settings(
+                    &context,
+                    &PersistedManagedStorageOverrides::default(),
+                )
+                .bdb_tools
+                .effective_path
+            )
+        );
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn windows_defaults_allow_case_insensitive_local_app_data_keys() {
+        let mut environment = BTreeMap::new();
+        environment.insert(
+            OsString::from("LocalAppData"),
             OsString::from(r"C:\Users\matt\AppData\Local"),
         );
 
@@ -375,8 +440,8 @@ mod tests {
                 .join("managed-storage.json"),
         };
         let overrides = PersistedManagedStorageOverrides {
-            bdb_tools_override: Some("/tmp/be/tools".into()),
-            apk_library_override: Some("/tmp/be/apk-library".into()),
+            bdb_tools_override: Some(sample_tools_override_path()),
+            apk_library_override: Some(sample_apk_library_override_path()),
         };
 
         save_persisted_overrides(&context.settings_file_path, &overrides)
@@ -385,12 +450,47 @@ mod tests {
             .expect("settings file should load");
         let settings = build_managed_storage_settings(&context, &loaded);
 
-        assert_eq!(Some("/tmp/be/tools"), settings.bdb_tools.override_path.as_deref());
-        assert_eq!("/tmp/be/tools", settings.bdb_tools.effective_path);
         assert_eq!(
-            Some("/tmp/be/apk-library"),
+            Some(sample_tools_override_path().as_str()),
+            settings.bdb_tools.override_path.as_deref()
+        );
+        assert_eq!(sample_tools_override_path(), settings.bdb_tools.effective_path);
+        assert_eq!(
+            Some(sample_apk_library_override_path().as_str()),
             settings.apk_library.override_path.as_deref()
         );
-        assert_eq!("/tmp/be/apk-library", settings.apk_library.effective_path);
+        assert_eq!(
+            sample_apk_library_override_path(),
+            settings.apk_library.effective_path
+        );
+    }
+
+    #[test]
+    fn invalid_loaded_overrides_fall_back_to_defaults() {
+        let temp_directory = tempfile::tempdir().expect("temporary directory should exist");
+        let context = ManagedStorageContext {
+            operating_system: StorageOperatingSystem::Linux,
+            app_data_root: temp_directory.path().join("app-data"),
+            settings_file_path: temp_directory
+                .path()
+                .join("settings")
+                .join("managed-storage.json"),
+        };
+        let persisted = PersistedManagedStorageOverrides {
+            bdb_tools_override: Some("relative/tools".into()),
+            apk_library_override: Some(sample_apk_library_override_path()),
+        };
+
+        let settings = build_managed_storage_settings(&context, &persisted);
+
+        assert_eq!(None, settings.bdb_tools.override_path);
+        assert_eq!(
+            context.app_data_root.join("tools"),
+            PathBuf::from(settings.bdb_tools.effective_path)
+        );
+        assert_eq!(
+            Some(sample_apk_library_override_path().as_str()),
+            settings.apk_library.override_path.as_deref()
+        );
     }
 }

--- a/src-tauri/src/storage.rs
+++ b/src-tauri/src/storage.rs
@@ -1,0 +1,396 @@
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::ffi::OsString;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const APP_VENDOR_DIRECTORY: &str = "Board Enthusiasts";
+const APP_PRODUCT_DIRECTORY: &str = "BE Home for Desktop";
+const APK_LIBRARY_DIRECTORY: &str = "apk-library";
+const SETTINGS_DIRECTORY: &str = "settings";
+const STORAGE_SETTINGS_FILE_NAME: &str = "managed-storage.json";
+const TOOLS_DIRECTORY: &str = "tools";
+
+/// Describes the normalized operating system used for managed-storage defaults.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) enum StorageOperatingSystem {
+    Windows,
+    Macos,
+    Linux,
+}
+
+/// Describes whether a managed storage location is using the default path or an override.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) enum ManagedStoragePathSource {
+    Default,
+    Override,
+}
+
+/// Describes one managed storage location and how its current path was chosen.
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ManagedStorageLocation {
+    default_path: String,
+    override_path: Option<String>,
+    effective_path: String,
+    source: ManagedStoragePathSource,
+}
+
+/// Describes the current managed storage configuration for the desktop app.
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ManagedStorageSettings {
+    operating_system: StorageOperatingSystem,
+    settings_file_path: String,
+    bdb_tools: ManagedStorageLocation,
+    apk_library: ManagedStorageLocation,
+}
+
+/// Represents the persisted override payload accepted by the desktop host.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ManagedStorageOverridesInput {
+    bdb_tools_override: Option<String>,
+    apk_library_override: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct PersistedManagedStorageOverrides {
+    bdb_tools_override: Option<String>,
+    apk_library_override: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+struct ManagedStorageContext {
+    operating_system: StorageOperatingSystem,
+    app_data_root: PathBuf,
+    settings_file_path: PathBuf,
+}
+
+/// Load the current managed storage settings for the desktop app.
+pub(crate) fn load_managed_storage_settings() -> Result<ManagedStorageSettings, String> {
+    let context = current_storage_context()?;
+    let persisted = load_persisted_overrides(&context.settings_file_path)?;
+    Ok(build_managed_storage_settings(&context, &persisted))
+}
+
+/// Save managed storage overrides and return the updated effective settings.
+pub(crate) fn save_managed_storage_settings(
+    input: ManagedStorageOverridesInput,
+) -> Result<ManagedStorageSettings, String> {
+    let context = current_storage_context()?;
+    let persisted = PersistedManagedStorageOverrides {
+        bdb_tools_override: normalize_override(input.bdb_tools_override)?,
+        apk_library_override: normalize_override(input.apk_library_override)?,
+    };
+
+    save_persisted_overrides(&context.settings_file_path, &persisted)?;
+    Ok(build_managed_storage_settings(&context, &persisted))
+}
+
+fn build_managed_storage_settings(
+    context: &ManagedStorageContext,
+    persisted: &PersistedManagedStorageOverrides,
+) -> ManagedStorageSettings {
+    let default_bdb_tools_path = context.app_data_root.join(TOOLS_DIRECTORY);
+    let default_apk_library_path = context.app_data_root.join(APK_LIBRARY_DIRECTORY);
+
+    ManagedStorageSettings {
+        operating_system: context.operating_system,
+        settings_file_path: path_to_string(&context.settings_file_path),
+        bdb_tools: build_location(default_bdb_tools_path, persisted.bdb_tools_override.as_deref()),
+        apk_library: build_location(
+            default_apk_library_path,
+            persisted.apk_library_override.as_deref(),
+        ),
+    }
+}
+
+fn build_location(default_path: PathBuf, override_path: Option<&str>) -> ManagedStorageLocation {
+    let default_path_string = path_to_string(&default_path);
+    match override_path {
+        Some(override_path) => ManagedStorageLocation {
+            default_path: default_path_string,
+            override_path: Some(override_path.to_string()),
+            effective_path: override_path.to_string(),
+            source: ManagedStoragePathSource::Override,
+        },
+        None => ManagedStorageLocation {
+            default_path: default_path_string.clone(),
+            override_path: None,
+            effective_path: default_path_string,
+            source: ManagedStoragePathSource::Default,
+        },
+    }
+}
+
+fn current_storage_context() -> Result<ManagedStorageContext, String> {
+    let environment = std::env::vars_os().collect::<BTreeMap<_, _>>();
+    current_storage_context_from_environment(&environment)
+}
+
+fn current_storage_context_from_environment(
+    environment: &BTreeMap<OsString, OsString>,
+) -> Result<ManagedStorageContext, String> {
+    if cfg!(target_os = "windows") {
+        let local_app_data = require_environment_path(environment, "LOCALAPPDATA")?;
+        return Ok(ManagedStorageContext {
+            operating_system: StorageOperatingSystem::Windows,
+            app_data_root: local_app_data
+                .join(APP_VENDOR_DIRECTORY)
+                .join(APP_PRODUCT_DIRECTORY),
+            settings_file_path: local_app_data
+                .join(APP_VENDOR_DIRECTORY)
+                .join(APP_PRODUCT_DIRECTORY)
+                .join(SETTINGS_DIRECTORY)
+                .join(STORAGE_SETTINGS_FILE_NAME),
+        });
+    }
+
+    let home_directory = require_environment_path(environment, "HOME")?;
+    if cfg!(target_os = "macos") {
+        let root = home_directory
+            .join("Library")
+            .join("Application Support")
+            .join(APP_VENDOR_DIRECTORY)
+            .join(APP_PRODUCT_DIRECTORY);
+        return Ok(ManagedStorageContext {
+            operating_system: StorageOperatingSystem::Macos,
+            settings_file_path: root.join(SETTINGS_DIRECTORY).join(STORAGE_SETTINGS_FILE_NAME),
+            app_data_root: root,
+        });
+    }
+
+    let root = home_directory
+        .join(".local")
+        .join("share")
+        .join(APP_VENDOR_DIRECTORY)
+        .join(APP_PRODUCT_DIRECTORY);
+    Ok(ManagedStorageContext {
+        operating_system: StorageOperatingSystem::Linux,
+        settings_file_path: root.join(SETTINGS_DIRECTORY).join(STORAGE_SETTINGS_FILE_NAME),
+        app_data_root: root,
+    })
+}
+
+fn require_environment_path(
+    environment: &BTreeMap<OsString, OsString>,
+    key: &str,
+) -> Result<PathBuf, String> {
+    environment
+        .get(&OsString::from(key))
+        .map(PathBuf::from)
+        .filter(|path| !path.as_os_str().is_empty())
+        .ok_or_else(|| {
+            format!(
+                "The desktop app could not resolve its managed storage defaults because the `{key}` environment variable was unavailable."
+            )
+        })
+}
+
+fn load_persisted_overrides(
+    settings_file_path: &Path,
+) -> Result<PersistedManagedStorageOverrides, String> {
+    if !settings_file_path.exists() {
+        return Ok(PersistedManagedStorageOverrides::default());
+    }
+
+    let content = fs::read_to_string(settings_file_path).map_err(|error| {
+        format!(
+            "The desktop app could not read its managed storage settings file at `{}`: {error}",
+            settings_file_path.display()
+        )
+    })?;
+
+    serde_json::from_str(&content).map_err(|error| {
+        format!(
+            "The desktop app could not parse its managed storage settings file at `{}`: {error}",
+            settings_file_path.display()
+        )
+    })
+}
+
+fn save_persisted_overrides(
+    settings_file_path: &Path,
+    overrides: &PersistedManagedStorageOverrides,
+) -> Result<(), String> {
+    if let Some(parent) = settings_file_path.parent() {
+        fs::create_dir_all(parent).map_err(|error| {
+            format!(
+                "The desktop app could not create the managed storage settings directory at `{}`: {error}",
+                parent.display()
+            )
+        })?;
+    }
+
+    let content = serde_json::to_string_pretty(overrides)
+        .expect("managed storage overrides should serialize");
+    fs::write(settings_file_path, content).map_err(|error| {
+        format!(
+            "The desktop app could not save its managed storage settings file at `{}`: {error}",
+            settings_file_path.display()
+        )
+    })
+}
+
+fn normalize_override(value: Option<String>) -> Result<Option<String>, String> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+
+    let path = PathBuf::from(trimmed);
+    if !path.is_absolute() {
+        return Err(format!(
+            "Managed storage overrides must use absolute paths. `{trimmed}` is not absolute."
+        ));
+    }
+
+    Ok(Some(path_to_string(&path)))
+}
+
+fn path_to_string(path: &Path) -> String {
+    path.to_string_lossy().into_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        build_managed_storage_settings, current_storage_context_from_environment,
+        load_persisted_overrides, normalize_override, save_persisted_overrides,
+        ManagedStorageContext, PersistedManagedStorageOverrides, StorageOperatingSystem,
+    };
+    use std::collections::BTreeMap;
+    use std::ffi::OsString;
+    use std::path::PathBuf;
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn windows_defaults_use_local_app_data() {
+        let mut environment = BTreeMap::new();
+        environment.insert(
+            OsString::from("LOCALAPPDATA"),
+            OsString::from(r"C:\Users\matt\AppData\Local"),
+        );
+
+        let context = current_storage_context_from_environment(&environment)
+            .expect("windows context should resolve");
+
+        assert_eq!(StorageOperatingSystem::Windows, context.operating_system);
+        assert_eq!(
+            PathBuf::from(r"C:\Users\matt\AppData\Local")
+                .join("Board Enthusiasts")
+                .join("BE Home for Desktop")
+                .join("tools"),
+            PathBuf::from(
+                build_managed_storage_settings(
+                    &context,
+                    &PersistedManagedStorageOverrides::default(),
+                )
+                .bdb_tools
+                .effective_path
+            )
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_defaults_use_application_support() {
+        let mut environment = BTreeMap::new();
+        environment.insert(OsString::from("HOME"), OsString::from("/Users/matt"));
+
+        let context = current_storage_context_from_environment(&environment)
+            .expect("macos context should resolve");
+
+        assert_eq!(StorageOperatingSystem::Macos, context.operating_system);
+        assert_eq!(
+            PathBuf::from("/Users/matt")
+                .join("Library")
+                .join("Application Support")
+                .join("Board Enthusiasts")
+                .join("BE Home for Desktop")
+                .join("apk-library"),
+            PathBuf::from(
+                build_managed_storage_settings(
+                    &context,
+                    &PersistedManagedStorageOverrides::default(),
+                )
+                .apk_library
+                .effective_path
+            )
+        );
+    }
+
+    #[cfg(not(any(target_os = "windows", target_os = "macos")))]
+    #[test]
+    fn linux_defaults_use_local_share() {
+        let mut environment = BTreeMap::new();
+        environment.insert(OsString::from("HOME"), OsString::from("/home/matt"));
+
+        let context = current_storage_context_from_environment(&environment)
+            .expect("linux context should resolve");
+
+        assert_eq!(StorageOperatingSystem::Linux, context.operating_system);
+        assert_eq!(
+            PathBuf::from("/home/matt")
+                .join(".local")
+                .join("share")
+                .join("Board Enthusiasts")
+                .join("BE Home for Desktop")
+                .join("tools"),
+            PathBuf::from(
+                build_managed_storage_settings(
+                    &context,
+                    &PersistedManagedStorageOverrides::default(),
+                )
+                .bdb_tools
+                .effective_path
+            )
+        );
+    }
+
+    #[test]
+    fn override_paths_must_be_absolute() {
+        let result = normalize_override(Some("relative/path".into()));
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn round_tripped_overrides_preserve_effective_paths() {
+        let temp_directory = tempfile::tempdir().expect("temporary directory should exist");
+        let context = ManagedStorageContext {
+            operating_system: StorageOperatingSystem::Linux,
+            app_data_root: temp_directory.path().join("app-data"),
+            settings_file_path: temp_directory
+                .path()
+                .join("settings")
+                .join("managed-storage.json"),
+        };
+        let overrides = PersistedManagedStorageOverrides {
+            bdb_tools_override: Some("/tmp/be/tools".into()),
+            apk_library_override: Some("/tmp/be/apk-library".into()),
+        };
+
+        save_persisted_overrides(&context.settings_file_path, &overrides)
+            .expect("settings file should save");
+        let loaded = load_persisted_overrides(&context.settings_file_path)
+            .expect("settings file should load");
+        let settings = build_managed_storage_settings(&context, &loaded);
+
+        assert_eq!(Some("/tmp/be/tools"), settings.bdb_tools.override_path.as_deref());
+        assert_eq!("/tmp/be/tools", settings.bdb_tools.effective_path);
+        assert_eq!(
+            Some("/tmp/be/apk-library"),
+            settings.apk_library.override_path.as_deref()
+        );
+        assert_eq!("/tmp/be/apk-library", settings.apk_library.effective_path);
+    }
+}

--- a/src/desktop/client.ts
+++ b/src/desktop/client.ts
@@ -1,5 +1,10 @@
 import { invoke } from "@tauri-apps/api/core";
-import type { BdbSourcePlan, DesktopShellState } from "./types";
+import type {
+  BdbSourcePlan,
+  DesktopShellState,
+  ManagedStorageOverridesInput,
+  ManagedStorageSettings,
+} from "./types";
 
 /**
  * Loads the current desktop shell state from the Rust host.
@@ -13,4 +18,22 @@ export function loadDesktopShellState(): Promise<DesktopShellState> {
  */
 export function loadBdbSourcePlan(): Promise<BdbSourcePlan> {
   return invoke<BdbSourcePlan>("load_bdb_source_plan");
+}
+
+/**
+ * Loads the current managed storage settings from the desktop host.
+ */
+export function loadManagedStorageSettings(): Promise<ManagedStorageSettings> {
+  return invoke<ManagedStorageSettings>("load_managed_storage_settings");
+}
+
+/**
+ * Saves managed storage overrides and returns the updated effective settings.
+ */
+export function saveManagedStorageSettings(
+  overrides: ManagedStorageOverridesInput,
+): Promise<ManagedStorageSettings> {
+  return invoke<ManagedStorageSettings>("save_managed_storage_settings", {
+    overrides,
+  });
 }

--- a/src/desktop/types.ts
+++ b/src/desktop/types.ts
@@ -98,3 +98,41 @@ export interface BdbSourcePlan {
   support: BdbPlatformSupport;
   source: BdbDownloadSource | null;
 }
+
+/**
+ * Describes whether a managed storage location is using the default path or an override.
+ */
+export type ManagedStoragePathSource = "default" | "override";
+
+/**
+ * Describes one managed storage location and how its current path was chosen.
+ */
+export interface ManagedStorageLocation {
+  defaultPath: string;
+  overridePath: string | null;
+  effectivePath: string;
+  source: ManagedStoragePathSource;
+}
+
+/**
+ * Describes the normalized operating system used for managed-storage defaults.
+ */
+export type StorageOperatingSystem = "windows" | "macos" | "linux";
+
+/**
+ * Describes the current managed storage configuration for the desktop app.
+ */
+export interface ManagedStorageSettings {
+  operatingSystem: StorageOperatingSystem;
+  settingsFilePath: string;
+  bdbTools: ManagedStorageLocation;
+  apkLibrary: ManagedStorageLocation;
+}
+
+/**
+ * Represents the persisted override payload accepted by the desktop host.
+ */
+export interface ManagedStorageOverridesInput {
+  bdbToolsOverride: string | null;
+  apkLibraryOverride: string | null;
+}


### PR DESCRIPTION
## Summary
- add the managed storage settings contract for `bdb` tools and the local APK library
- persist absolute-path overrides in an app-owned settings file with platform-specific defaults
- document the managed storage model for later setup and install flows

## Testing
- npm run build
- npm run test