### PR TITLE
Implement bdb download and validation service

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ This directory is reserved for maintained developer-facing documentation for `be
 - [`local-development.md`](local-development.md): supported repo-local setup, dev, build, and test workflow
 - [`continuous-integration.md`](continuous-integration.md): current desktop pull-request validation scope and known release gaps
 - [`bdb-source-manifest.md`](bdb-source-manifest.md): maintained `bdb` source map schema, hosting target, and fallback policy
+- [`bdb-tool-lifecycle.md`](bdb-tool-lifecycle.md): managed `bdb` download, repair, and runnable-validation contract
 - [`managed-storage.md`](managed-storage.md): default app-owned storage paths and persisted override model
 
 Use [`planning/`](../planning/README.md) for active MVP planning and delivery breakdowns.

--- a/docs/bdb-source-manifest.md
+++ b/docs/bdb-source-manifest.md
@@ -45,7 +45,15 @@ The maintained precedence for the later acquisition flow is:
 2. cached last-known-good manifest
 3. bundled fallback manifest from the app build
 
-This issue implements the bundled fallback and the maintained remote URL target. Cached manifest behavior lands in the later bootstrap/download work.
+The desktop host now implements this full precedence order at runtime. When the remote manifest refresh succeeds, the app saves that JSON as the last-known-good cached manifest for later offline or outage fallback.
+
+## Cache Location
+
+The cached manifest is stored in the app-owned cache directory beside the rest of the desktop utility state:
+
+- Windows: `%LocalAppData%/Board Enthusiasts/BE Home for Desktop/cache/bdb-source-manifest.json`
+- macOS: `~/Library/Application Support/Board Enthusiasts/BE Home for Desktop/cache/bdb-source-manifest.json`
+- Linux: `~/.local/share/Board Enthusiasts/BE Home for Desktop/cache/bdb-source-manifest.json`
 
 ## Emergency Update Procedure
 

--- a/docs/bdb-tool-lifecycle.md
+++ b/docs/bdb-tool-lifecycle.md
@@ -1,0 +1,53 @@
+# `bdb` Tool Lifecycle
+
+The desktop host is responsible for the full local `bdb` bootstrap flow. The renderer consumes typed state and result objects instead of parsing file-system or process details itself.
+
+## Managed Executable Path
+
+The host always stores the managed executable inside the configured `bdb` tools directory:
+
+- Windows: `<managed tools path>/bdb.exe`
+- macOS and Linux: `<managed tools path>/bdb`
+
+The managed tools directory itself comes from the persisted storage contract described in [`managed-storage.md`](managed-storage.md).
+
+## Runtime Flow
+
+When the app inspects or acquires `bdb`, it follows this order:
+
+1. resolve the current Board-hosted source plan using remote, cached, then bundled manifest precedence
+2. resolve the current managed `bdb` storage directory
+3. look for the expected `bdb` executable in that directory
+4. if the file exists, run `bdb help` to confirm the binary can open without requiring a Board device
+5. if download or repair is requested, fetch the Board-hosted binary, replace the managed copy, and validate it again
+
+## State Model
+
+The host exposes four player-facing tool states:
+
+- `unsupported`: Board does not publish a maintained `bdb` target for this computer
+- `missing`: no managed `bdb` executable is present yet
+- `downloaded`: a managed `bdb` file exists, but BE Home could not confirm that the OS would let it open
+- `runnable`: the managed `bdb` executable opened successfully during `bdb help` validation
+
+The validation contract also captures whether the last check was `unsupported`, `missing`, `blocked`, or `runnable`, along with the command BE Home attempted.
+
+## Repair Behavior
+
+Repair does not require players to browse hidden folders or delete files manually. The host:
+
+- downloads a fresh Board-hosted binary
+- writes it into the managed tools directory
+- replaces the existing managed copy if one is already present
+- re-runs runnable validation immediately
+
+## Failure Normalization
+
+The host translates common failure categories into player-friendly guidance:
+
+- unsupported-system outcomes point back to Board's current platform matrix
+- download failures explain that Board's host or the player's connection was unavailable
+- storage failures explain that the managed tools folder could not be written
+- blocked-executable failures explain that the file exists but the computer would not let BE Home open it yet
+
+No repo asset, cached manifest, or release artifact redistributes `bdb`. The binary is only downloaded from Board-hosted URLs at runtime.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -98,6 +98,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 name = "be-home-for-desktop"
 version = "0.1.0"
 dependencies = [
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tauri",
@@ -310,6 +311,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -847,6 +854,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -1047,8 +1055,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1058,9 +1068,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1342,6 +1354,22 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1775,6 +1803,12 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mac"
@@ -2498,6 +2532,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2544,6 +2633,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2564,6 +2663,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2579,6 +2688,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -2676,6 +2794,46 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
@@ -2709,6 +2867,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2737,10 +2909,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -2948,6 +3161,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -3189,6 +3414,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "swift-rs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3339,7 +3570,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "serde_repr",
@@ -3639,6 +3870,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3650,6 +3896,16 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -3934,6 +4190,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4176,6 +4438,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web_atoms"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4229,6 +4501,15 @@ dependencies = [
  "pkg-config",
  "soup3-sys",
  "system-deps",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -4459,6 +4740,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4954,6 +5244,12 @@ dependencies = [
  "syn 2.0.117",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -13,6 +13,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
+reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tauri = { version = "2", features = [] }

--- a/src-tauri/src/bdb.rs
+++ b/src-tauri/src/bdb.rs
@@ -1,7 +1,12 @@
+use crate::storage;
+use reqwest::blocking::Client;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
 #[cfg(target_os = "windows")]
 use std::process::Command;
+use std::time::Duration;
 
 const REMOTE_BDB_SOURCE_MANIFEST_URL: &str =
     "https://raw.githubusercontent.com/board-enthusiasts/be-home-for-desktop/main/config/bdb-sources.json";
@@ -10,6 +15,9 @@ const LINUX_X86_64_PLATFORM_KEY: &str = "linux-x86_64";
 const MACOS_UNIVERSAL_PLATFORM_KEY: &str = "macos-universal";
 const WINDOWS_X86_64_PLATFORM_KEY: &str = "windows-x86_64";
 const WINDOWS_11_MINIMUM_BUILD: u32 = 22000;
+const MANIFEST_CACHE_DIRECTORY: &str = "cache";
+const MANIFEST_CACHE_FILE_NAME: &str = "bdb-source-manifest.json";
+const REMOTE_MANIFEST_TIMEOUT_SECONDS: u64 = 10;
 
 /// Describes the supported source-map status for the current machine.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
@@ -63,6 +71,13 @@ struct BdbSourceManifest {
 }
 
 #[derive(Clone, Debug)]
+struct LoadedManifest {
+    manifest: BdbSourceManifest,
+    source: &'static str,
+    cache_path: Option<PathBuf>,
+}
+
+#[derive(Clone, Debug)]
 struct DetectedPlatform {
     operating_system: BdbOperatingSystem,
     architecture: BdbArchitecture,
@@ -74,46 +89,65 @@ struct DetectedPlatform {
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct BdbPlatformSupport {
-    status: BdbSupportStatus,
-    operating_system: BdbOperatingSystem,
-    architecture: BdbArchitecture,
-    windows_build: Option<u32>,
-    platform_key: Option<String>,
-    reason: Option<BdbUnsupportedReason>,
-    guidance: String,
+    pub(crate) status: BdbSupportStatus,
+    pub(crate) operating_system: BdbOperatingSystem,
+    pub(crate) architecture: BdbArchitecture,
+    pub(crate) windows_build: Option<u32>,
+    pub(crate) platform_key: Option<String>,
+    pub(crate) reason: Option<BdbUnsupportedReason>,
+    pub(crate) guidance: String,
 }
 
 /// Describes the Board-hosted `bdb` source chosen for the current machine.
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct BdbDownloadSource {
-    platform_key: String,
-    download_url: String,
+    pub(crate) platform_key: String,
+    pub(crate) download_url: String,
 }
 
 /// Describes the maintained source-resolution plan for `bdb` on the current machine.
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct BdbSourcePlan {
-    manifest_source: String,
-    remote_manifest_url: String,
-    manifest_schema_version: u32,
-    support: BdbPlatformSupport,
-    source: Option<BdbDownloadSource>,
+    pub(crate) manifest_source: String,
+    pub(crate) remote_manifest_url: String,
+    pub(crate) manifest_cache_path: Option<String>,
+    pub(crate) manifest_schema_version: u32,
+    pub(crate) support: BdbPlatformSupport,
+    pub(crate) source: Option<BdbDownloadSource>,
 }
 
-/// Resolve the bundled `bdb` source plan for the current machine.
+/// Resolve the maintained `bdb` source plan for the current machine.
 pub(crate) fn resolve_current_bdb_source_plan() -> BdbSourcePlan {
-    let manifest = bundled_manifest();
-    resolve_bdb_source_plan_for_platform(&manifest, detect_current_platform())
+    #[cfg(test)]
+    let allow_remote_manifest_refresh = false;
+    #[cfg(not(test))]
+    let allow_remote_manifest_refresh = true;
+
+    let detected = detect_current_platform();
+    let cache_path = resolve_manifest_cache_path();
+    let manifest = load_manifest_with_fallbacks(
+        cache_path.as_deref(),
+        allow_remote_manifest_refresh,
+        fetch_remote_manifest_text,
+    );
+    resolve_bdb_source_plan_for_platform(&manifest, detected)
+}
+
+fn resolve_manifest_cache_path() -> Option<PathBuf> {
+    storage::resolve_app_data_root().ok().map(|root| {
+        root.join(MANIFEST_CACHE_DIRECTORY)
+            .join(MANIFEST_CACHE_FILE_NAME)
+    })
 }
 
 fn resolve_bdb_source_plan_for_platform(
-    manifest: &BdbSourceManifest,
+    loaded_manifest: &LoadedManifest,
     detected: DetectedPlatform,
 ) -> BdbSourcePlan {
     let support = match resolve_supported_platform_key(&detected) {
-        Ok(platform_key) => match manifest.platforms.get(platform_key) {
+        Ok(platform_key) => match loaded_manifest.manifest.platforms.get(platform_key) {
             Some(_) => BdbPlatformSupport {
                 status: BdbSupportStatus::Supported,
                 operating_system: detected.operating_system,
@@ -144,20 +178,22 @@ fn resolve_bdb_source_plan_for_platform(
         },
     };
 
-    let source = support
-        .platform_key
-        .as_ref()
-        .and_then(|platform_key| manifest.platforms.get(platform_key).map(|download_url| {
-            BdbDownloadSource {
+    let source = support.platform_key.as_ref().and_then(|platform_key| {
+        loaded_manifest
+            .manifest
+            .platforms
+            .get(platform_key)
+            .map(|download_url| BdbDownloadSource {
                 platform_key: platform_key.clone(),
                 download_url: download_url.clone(),
-            }
-        }));
+            })
+    });
 
     BdbSourcePlan {
-        manifest_source: "bundled".into(),
+        manifest_source: loaded_manifest.source.into(),
         remote_manifest_url: REMOTE_BDB_SOURCE_MANIFEST_URL.into(),
-        manifest_schema_version: manifest.schema_version,
+        manifest_cache_path: loaded_manifest.cache_path.as_deref().map(path_to_string),
+        manifest_schema_version: loaded_manifest.manifest.schema_version,
         support,
         source,
     }
@@ -169,7 +205,8 @@ fn build_guidance_for_unsupported_platform(
 ) -> String {
     match reason {
         BdbUnsupportedReason::UnsupportedOperatingSystem => {
-            "Board currently publishes bdb only for macOS, Linux amd64, and Windows 11 x86_64.".into()
+            "Board currently publishes bdb only for macOS, Linux amd64, and Windows 11 x86_64."
+                .into()
         }
         BdbUnsupportedReason::UnsupportedArchitecture => format!(
             "Board currently publishes bdb only for macOS universal, Linux x86_64, and Windows 11 x86_64. This machine reported architecture {:?}.",
@@ -178,10 +215,9 @@ fn build_guidance_for_unsupported_platform(
         BdbUnsupportedReason::UnsupportedOperatingSystemVersion => {
             "Board currently advertises its Windows bdb build for Windows 11. This machine did not pass the Windows 11 compatibility check.".into()
         }
-        BdbUnsupportedReason::PlatformProbeFailed => detected
-            .probe_error
-            .clone()
-            .unwrap_or_else(|| "The app could not confirm this machine's supported platform details.".into()),
+        BdbUnsupportedReason::PlatformProbeFailed => detected.probe_error.clone().unwrap_or_else(
+            || "The app could not confirm this machine's supported platform details.".into(),
+        ),
         BdbUnsupportedReason::MissingManifestEntry => {
             "The maintained bdb source manifest is missing the Board-hosted URL for this supported platform key.".into()
         }
@@ -212,8 +248,111 @@ fn resolve_supported_platform_key(
     }
 }
 
+fn load_manifest_with_fallbacks<F>(
+    cache_path: Option<&Path>,
+    allow_remote_manifest_refresh: bool,
+    fetch_remote_manifest: F,
+) -> LoadedManifest
+where
+    F: Fn(&str) -> Result<String, String>,
+{
+    if allow_remote_manifest_refresh {
+        if let Ok(remote_text) = fetch_remote_manifest(REMOTE_BDB_SOURCE_MANIFEST_URL) {
+            if let Ok(manifest) = parse_manifest(&remote_text) {
+                if let Some(cache_path) = cache_path {
+                    let _ = save_cached_manifest(cache_path, &remote_text);
+                }
+
+                return LoadedManifest {
+                    manifest,
+                    source: "remote",
+                    cache_path: cache_path.map(|path| path.to_path_buf()),
+                };
+            }
+        }
+    }
+
+    if let Some(cache_path) = cache_path {
+        if let Ok(manifest) = load_cached_manifest(cache_path) {
+            return LoadedManifest {
+                manifest,
+                source: "cached",
+                cache_path: Some(cache_path.to_path_buf()),
+            };
+        }
+    }
+
+    LoadedManifest {
+        manifest: bundled_manifest(),
+        source: "bundled",
+        cache_path: cache_path.map(|path| path.to_path_buf()),
+    }
+}
+
+fn fetch_remote_manifest_text(url: &str) -> Result<String, String> {
+    let client = Client::builder()
+        .timeout(Duration::from_secs(REMOTE_MANIFEST_TIMEOUT_SECONDS))
+        .build()
+        .map_err(|error| format!("The app could not prepare its bdb manifest client: {error}"))?;
+    let response = client
+        .get(url)
+        .send()
+        .map_err(|error| format!("The app could not refresh the remote bdb manifest: {error}"))?;
+    let status = response.status();
+    if !status.is_success() {
+        return Err(format!(
+            "The remote bdb manifest responded with HTTP status {status}."
+        ));
+    }
+
+    response
+        .text()
+        .map_err(|error| format!("The app could not read the remote bdb manifest body: {error}"))
+}
+
+fn load_cached_manifest(cache_path: &Path) -> Result<BdbSourceManifest, String> {
+    let content = fs::read_to_string(cache_path).map_err(|error| {
+        format!(
+            "The app could not read the cached bdb manifest at `{}`: {error}",
+            cache_path.display()
+        )
+    })?;
+    parse_manifest(&content)
+}
+
+fn save_cached_manifest(cache_path: &Path, manifest_text: &str) -> Result<(), String> {
+    if let Some(parent) = cache_path.parent() {
+        fs::create_dir_all(parent).map_err(|error| {
+            format!(
+                "The app could not create the cached bdb manifest directory at `{}`: {error}",
+                parent.display()
+            )
+        })?;
+    }
+
+    fs::write(cache_path, manifest_text).map_err(|error| {
+        format!(
+            "The app could not save the cached bdb manifest at `{}`: {error}",
+            cache_path.display()
+        )
+    })
+}
+
+fn parse_manifest(manifest_text: &str) -> Result<BdbSourceManifest, String> {
+    let manifest: BdbSourceManifest = serde_json::from_str(manifest_text)
+        .map_err(|error| format!("The bdb manifest JSON was invalid: {error}"))?;
+    if manifest.schema_version != 1 {
+        return Err(format!(
+            "The bdb manifest used unsupported schema version {}.",
+            manifest.schema_version
+        ));
+    }
+
+    Ok(manifest)
+}
+
 fn bundled_manifest() -> BdbSourceManifest {
-    serde_json::from_str(BUNDLED_BDB_SOURCE_MANIFEST_JSON)
+    parse_manifest(BUNDLED_BDB_SOURCE_MANIFEST_JSON)
         .expect("bundled bdb source manifest should deserialize")
 }
 
@@ -282,14 +421,19 @@ fn parse_windows_build_number(version_text: &str) -> Option<u32> {
     }
 }
 
+fn path_to_string(path: &Path) -> String {
+    path.to_string_lossy().into_owned()
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        bundled_manifest, parse_windows_build_number, resolve_bdb_source_plan_for_platform,
-        BdbArchitecture, BdbOperatingSystem, BdbSupportStatus, BdbUnsupportedReason,
-        DetectedPlatform, LINUX_X86_64_PLATFORM_KEY, MACOS_UNIVERSAL_PLATFORM_KEY,
-        WINDOWS_X86_64_PLATFORM_KEY,
+        bundled_manifest, load_manifest_with_fallbacks, parse_manifest, parse_windows_build_number,
+        resolve_bdb_source_plan_for_platform, BdbArchitecture, BdbOperatingSystem,
+        BdbSupportStatus, BdbUnsupportedReason, DetectedPlatform, LoadedManifest,
+        LINUX_X86_64_PLATFORM_KEY, MACOS_UNIVERSAL_PLATFORM_KEY, WINDOWS_X86_64_PLATFORM_KEY,
     };
+    use std::fs;
 
     #[test]
     fn bundled_manifest_tracks_current_board_download_urls() {
@@ -311,10 +455,93 @@ mod tests {
     }
 
     #[test]
+    fn remote_manifest_is_preferred_and_cached_when_it_is_valid() {
+        let temp_directory = tempfile::tempdir().expect("temporary directory should exist");
+        let cache_path = temp_directory
+            .path()
+            .join("cache")
+            .join("bdb-source-manifest.json");
+
+        let loaded = load_manifest_with_fallbacks(Some(&cache_path), true, |_| {
+            Ok(
+                r#"{"schemaVersion":1,"platforms":{"linux-x86_64":"https://example.com/linux/bdb"}}"#
+                    .into(),
+            )
+        });
+
+        assert_eq!("remote", loaded.source);
+        assert_eq!(
+            Some(&"https://example.com/linux/bdb".to_string()),
+            loaded.manifest.platforms.get(LINUX_X86_64_PLATFORM_KEY)
+        );
+        assert!(fs::read_to_string(cache_path)
+            .expect("cache file should be written")
+            .contains("example.com/linux/bdb"));
+    }
+
+    #[test]
+    fn cached_manifest_is_used_when_the_remote_refresh_is_invalid() {
+        let temp_directory = tempfile::tempdir().expect("temporary directory should exist");
+        let cache_path = temp_directory
+            .path()
+            .join("cache")
+            .join("bdb-source-manifest.json");
+        fs::create_dir_all(
+            cache_path
+                .parent()
+                .expect("cache directory should have parent"),
+        )
+        .expect("cache directory should exist");
+        fs::write(
+            &cache_path,
+            r#"{"schemaVersion":1,"platforms":{"linux-x86_64":"https://cached.example/bdb"}}"#,
+        )
+        .expect("cache manifest should be written");
+
+        let loaded =
+            load_manifest_with_fallbacks(Some(&cache_path), true, |_| Ok("{ invalid json".into()));
+
+        assert_eq!("cached", loaded.source);
+        assert_eq!(
+            Some(&"https://cached.example/bdb".to_string()),
+            loaded.manifest.platforms.get(LINUX_X86_64_PLATFORM_KEY)
+        );
+    }
+
+    #[test]
+    fn bundled_manifest_is_used_when_remote_and_cache_are_unavailable() {
+        let temp_directory = tempfile::tempdir().expect("temporary directory should exist");
+        let cache_path = temp_directory
+            .path()
+            .join("cache")
+            .join("bdb-source-manifest.json");
+
+        let loaded =
+            load_manifest_with_fallbacks(Some(&cache_path), true, |_| Err("offline".into()));
+
+        assert_eq!("bundled", loaded.source);
+        assert_eq!(
+            Some(&"https://dev.board.fun/downloads/bdb/linux/bdb".to_string()),
+            loaded.manifest.platforms.get(LINUX_X86_64_PLATFORM_KEY)
+        );
+    }
+
+    #[test]
+    fn manifest_parser_rejects_unknown_schema_versions() {
+        let result = parse_manifest(r#"{"schemaVersion":2,"platforms":{}}"#);
+
+        assert!(result.is_err());
+    }
+
+    #[test]
     fn macos_apple_silicon_maps_to_universal_download() {
-        let manifest = bundled_manifest();
+        let loaded_manifest = LoadedManifest {
+            manifest: bundled_manifest(),
+            source: "bundled",
+            cache_path: None,
+        };
         let plan = resolve_bdb_source_plan_for_platform(
-            &manifest,
+            &loaded_manifest,
             DetectedPlatform {
                 operating_system: BdbOperatingSystem::Macos,
                 architecture: BdbArchitecture::Aarch64,
@@ -324,18 +551,27 @@ mod tests {
         );
 
         assert_eq!(BdbSupportStatus::Supported, plan.support.status);
-        assert_eq!(Some(MACOS_UNIVERSAL_PLATFORM_KEY), plan.support.platform_key.as_deref());
+        assert_eq!(
+            Some(MACOS_UNIVERSAL_PLATFORM_KEY),
+            plan.support.platform_key.as_deref()
+        );
         assert_eq!(
             Some("https://dev.board.fun/downloads/bdb/macos-universal/bdb"),
-            plan.source.as_ref().map(|source| source.download_url.as_str())
+            plan.source
+                .as_ref()
+                .map(|source| source.download_url.as_str())
         );
     }
 
     #[test]
     fn linux_arm_is_reported_as_unsupported_architecture() {
-        let manifest = bundled_manifest();
+        let loaded_manifest = LoadedManifest {
+            manifest: bundled_manifest(),
+            source: "bundled",
+            cache_path: None,
+        };
         let plan = resolve_bdb_source_plan_for_platform(
-            &manifest,
+            &loaded_manifest,
             DetectedPlatform {
                 operating_system: BdbOperatingSystem::Linux,
                 architecture: BdbArchitecture::Arm,
@@ -354,9 +590,13 @@ mod tests {
 
     #[test]
     fn windows_11_x86_64_maps_to_board_windows_download() {
-        let manifest = bundled_manifest();
+        let loaded_manifest = LoadedManifest {
+            manifest: bundled_manifest(),
+            source: "bundled",
+            cache_path: None,
+        };
         let plan = resolve_bdb_source_plan_for_platform(
-            &manifest,
+            &loaded_manifest,
             DetectedPlatform {
                 operating_system: BdbOperatingSystem::Windows,
                 architecture: BdbArchitecture::X86_64,
@@ -366,18 +606,27 @@ mod tests {
         );
 
         assert_eq!(BdbSupportStatus::Supported, plan.support.status);
-        assert_eq!(Some(WINDOWS_X86_64_PLATFORM_KEY), plan.support.platform_key.as_deref());
+        assert_eq!(
+            Some(WINDOWS_X86_64_PLATFORM_KEY),
+            plan.support.platform_key.as_deref()
+        );
         assert_eq!(
             Some("https://dev.board.fun/downloads/bdb/windows/bdb.exe"),
-            plan.source.as_ref().map(|source| source.download_url.as_str())
+            plan.source
+                .as_ref()
+                .map(|source| source.download_url.as_str())
         );
     }
 
     #[test]
     fn windows_10_is_rejected_by_the_windows_11_requirement() {
-        let manifest = bundled_manifest();
+        let loaded_manifest = LoadedManifest {
+            manifest: bundled_manifest(),
+            source: "bundled",
+            cache_path: None,
+        };
         let plan = resolve_bdb_source_plan_for_platform(
-            &manifest,
+            &loaded_manifest,
             DetectedPlatform {
                 operating_system: BdbOperatingSystem::Windows,
                 architecture: BdbArchitecture::X86_64,
@@ -396,9 +645,13 @@ mod tests {
 
     #[test]
     fn windows_probe_failures_are_explicit() {
-        let manifest = bundled_manifest();
+        let loaded_manifest = LoadedManifest {
+            manifest: bundled_manifest(),
+            source: "bundled",
+            cache_path: None,
+        };
         let plan = resolve_bdb_source_plan_for_platform(
-            &manifest,
+            &loaded_manifest,
             DetectedPlatform {
                 operating_system: BdbOperatingSystem::Windows,
                 architecture: BdbArchitecture::X86_64,
@@ -417,8 +670,7 @@ mod tests {
 
     #[test]
     fn windows_build_parser_extracts_the_build_number() {
-        let build_number =
-            parse_windows_build_number("Microsoft Windows [Version 10.0.26100.1]");
+        let build_number = parse_windows_build_number("Microsoft Windows [Version 10.0.26100.1]");
 
         assert_eq!(Some(26100), build_number);
     }

--- a/src-tauri/src/bdb_tool.rs
+++ b/src-tauri/src/bdb_tool.rs
@@ -1,0 +1,768 @@
+use crate::{bdb, storage};
+use reqwest::blocking::Client;
+use serde::Serialize;
+use std::fs;
+use std::io;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::Duration;
+
+const BDB_HELP_ARGUMENT: &str = "help";
+const BDB_DOWNLOAD_TIMEOUT_SECONDS: u64 = 30;
+
+/// Describes the local `bdb` readiness state the renderer can consume.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) enum BdbToolStatus {
+    Unsupported,
+    Missing,
+    Downloaded,
+    Runnable,
+}
+
+/// Describes the result of the no-device-required runnable validation command.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) enum BdbRunnableStatus {
+    Unsupported,
+    Missing,
+    Blocked,
+    Runnable,
+}
+
+/// Describes the latest runnable-validation result for the stored `bdb` binary.
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct BdbRunnableValidation {
+    pub(crate) status: BdbRunnableStatus,
+    pub(crate) command: String,
+    pub(crate) exit_code: Option<i32>,
+    pub(crate) summary: String,
+    pub(crate) detail: Option<String>,
+}
+
+/// Describes the managed `bdb` tool state for the current machine.
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct BdbToolState {
+    pub(crate) status: BdbToolStatus,
+    pub(crate) summary: String,
+    pub(crate) guidance: String,
+    pub(crate) executable_path: String,
+    pub(crate) executable_exists: bool,
+    pub(crate) storage: storage::ManagedStorageLocation,
+    pub(crate) source_plan: bdb::BdbSourcePlan,
+    pub(crate) validation: BdbRunnableValidation,
+}
+
+/// Describes the outcome of an acquire or repair attempt for `bdb`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) enum BdbAcquisitionOutcome {
+    Unsupported,
+    AlreadyReady,
+    Downloaded,
+    Repaired,
+    Failed,
+}
+
+/// Describes the acquire or repair result returned to the renderer.
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct BdbAcquisitionResult {
+    pub(crate) outcome: BdbAcquisitionOutcome,
+    pub(crate) summary: String,
+    pub(crate) guidance: String,
+    pub(crate) tool_state: BdbToolState,
+}
+
+#[derive(Clone, Debug)]
+struct UserFacingError {
+    summary: String,
+    guidance: String,
+}
+
+#[derive(Clone, Debug)]
+struct ProcessRunOutput {
+    exit_code: Option<i32>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ProcessRunFailureKind {
+    PermissionDenied,
+    NotFound,
+    Other,
+}
+
+#[derive(Clone, Debug)]
+struct ProcessRunFailure {
+    kind: ProcessRunFailureKind,
+    detail: String,
+}
+
+trait BinaryDownloader {
+    fn download(&self, url: &str) -> Result<Vec<u8>, UserFacingError>;
+}
+
+trait ProcessRunner {
+    fn run(
+        &self,
+        executable_path: &Path,
+        args: &[&str],
+    ) -> Result<ProcessRunOutput, ProcessRunFailure>;
+}
+
+struct ReqwestBinaryDownloader {
+    client: Client,
+}
+
+impl ReqwestBinaryDownloader {
+    fn new() -> Result<Self, String> {
+        let client = Client::builder()
+            .timeout(Duration::from_secs(BDB_DOWNLOAD_TIMEOUT_SECONDS))
+            .build()
+            .map_err(|error| {
+                format!("The desktop app could not prepare its bdb download client: {error}")
+            })?;
+        Ok(Self { client })
+    }
+}
+
+impl BinaryDownloader for ReqwestBinaryDownloader {
+    fn download(&self, url: &str) -> Result<Vec<u8>, UserFacingError> {
+        let response = self.client.get(url).send().map_err(|error| {
+            if error.is_timeout() {
+                return UserFacingError {
+                    summary: "BE Home could not finish reaching Board's bdb download in time."
+                        .into(),
+                    guidance:
+                        "Check your internet connection, then try the download again.".into(),
+                };
+            }
+
+            if error.is_connect() {
+                return UserFacingError {
+                    summary: "BE Home could not reach Board's bdb download right now.".into(),
+                    guidance:
+                        "Check your internet connection, then try the download again.".into(),
+                };
+            }
+
+            UserFacingError {
+                summary: "BE Home could not download bdb from Board right now.".into(),
+                guidance:
+                    "Wait a moment and try again. If the problem keeps happening, Board's download host may be unavailable."
+                        .into(),
+            }
+        })?;
+        let status = response.status();
+        if !status.is_success() {
+            return Err(UserFacingError {
+                summary: "Board's download host did not accept the bdb request.".into(),
+                guidance: format!(
+                    "Board responded with HTTP status {status}. Try again in a little while."
+                ),
+            });
+        }
+
+        response
+            .bytes()
+            .map(|bytes| bytes.to_vec())
+            .map_err(|_| UserFacingError {
+                summary: "BE Home could not finish reading Board's bdb download.".into(),
+                guidance: "Try the download again in a moment.".into(),
+            })
+    }
+}
+
+struct CommandProcessRunner;
+
+impl ProcessRunner for CommandProcessRunner {
+    fn run(
+        &self,
+        executable_path: &Path,
+        args: &[&str],
+    ) -> Result<ProcessRunOutput, ProcessRunFailure> {
+        let output = Command::new(executable_path)
+            .args(args)
+            .output()
+            .map_err(classify_process_failure)?;
+
+        Ok(ProcessRunOutput {
+            exit_code: output.status.code(),
+        })
+    }
+}
+
+/// Load the current `bdb` tool state for the local machine.
+pub(crate) fn load_current_bdb_tool_state() -> Result<BdbToolState, String> {
+    let source_plan = bdb::resolve_current_bdb_source_plan();
+    let storage_settings = storage::load_managed_storage_settings()?;
+    Ok(inspect_bdb_tool_state_with_plan_and_runner(
+        source_plan,
+        storage_settings,
+        &CommandProcessRunner,
+    ))
+}
+
+/// Download or repair `bdb`, then return the updated state.
+pub(crate) fn acquire_current_bdb_tool(repair: bool) -> Result<BdbAcquisitionResult, String> {
+    let source_plan = bdb::resolve_current_bdb_source_plan();
+    let storage_settings = storage::load_managed_storage_settings()?;
+    let downloader = ReqwestBinaryDownloader::new()?;
+    Ok(acquire_bdb_tool_with_dependencies(
+        source_plan,
+        storage_settings,
+        &downloader,
+        &CommandProcessRunner,
+        repair,
+    ))
+}
+
+fn inspect_bdb_tool_state_with_plan_and_runner<P: ProcessRunner>(
+    source_plan: bdb::BdbSourcePlan,
+    storage_settings: storage::ManagedStorageSettings,
+    runner: &P,
+) -> BdbToolState {
+    let storage_location = storage_settings.bdb_tools.clone();
+    let executable_path = resolve_bdb_executable_path(&storage_location);
+    let executable_exists = executable_path.exists();
+    let validation_command = build_validation_command(&executable_path);
+
+    if source_plan.support.status == bdb::BdbSupportStatus::Unsupported {
+        return BdbToolState {
+            status: BdbToolStatus::Unsupported,
+            summary: "This computer is outside Board's current bdb support matrix.".into(),
+            guidance: source_plan.support.guidance.clone(),
+            executable_path: path_to_string(&executable_path),
+            executable_exists,
+            storage: storage_location,
+            source_plan,
+            validation: BdbRunnableValidation {
+                status: BdbRunnableStatus::Unsupported,
+                command: validation_command,
+                exit_code: None,
+                summary: "BE Home skipped the bdb runnable check because Board does not publish a supported download for this computer.".into(),
+                detail: None,
+            },
+        };
+    }
+
+    if !executable_exists {
+        return BdbToolState {
+            status: BdbToolStatus::Missing,
+            summary: "BE Home has not downloaded bdb into the managed tools folder yet.".into(),
+            guidance: "Continue setup and BE Home will download Board's bdb into its managed tools folder for you.".into(),
+            executable_path: path_to_string(&executable_path),
+            executable_exists: false,
+            storage: storage_location,
+            source_plan,
+            validation: BdbRunnableValidation {
+                status: BdbRunnableStatus::Missing,
+                command: validation_command,
+                exit_code: None,
+                summary: "No managed bdb executable is present yet.".into(),
+                detail: None,
+            },
+        };
+    }
+
+    let validation = validate_runnable(&executable_path, runner);
+    let (status, summary, guidance) = match validation.status {
+        BdbRunnableStatus::Runnable => (
+            BdbToolStatus::Runnable,
+            "Board's install tool is ready to use.".into(),
+            "BE Home confirmed that bdb can open from its managed tools folder.".into(),
+        ),
+        BdbRunnableStatus::Blocked => (
+            BdbToolStatus::Downloaded,
+            "BE Home found bdb, but this computer did not let it open yet.".into(),
+            "Choose repair to download a fresh copy, or move the managed tools folder to a location you control.".into(),
+        ),
+        BdbRunnableStatus::Missing => (
+            BdbToolStatus::Missing,
+            "BE Home has not downloaded bdb into the managed tools folder yet.".into(),
+            "Continue setup and BE Home will download Board's bdb into its managed tools folder for you.".into(),
+        ),
+        BdbRunnableStatus::Unsupported => (
+            BdbToolStatus::Unsupported,
+            "This computer is outside Board's current bdb support matrix.".into(),
+            source_plan.support.guidance.clone(),
+        ),
+    };
+
+    BdbToolState {
+        status,
+        summary,
+        guidance,
+        executable_path: path_to_string(&executable_path),
+        executable_exists,
+        storage: storage_location,
+        source_plan,
+        validation,
+    }
+}
+
+fn acquire_bdb_tool_with_dependencies<D: BinaryDownloader, P: ProcessRunner>(
+    source_plan: bdb::BdbSourcePlan,
+    storage_settings: storage::ManagedStorageSettings,
+    downloader: &D,
+    runner: &P,
+    repair: bool,
+) -> BdbAcquisitionResult {
+    let initial_state = inspect_bdb_tool_state_with_plan_and_runner(
+        source_plan.clone(),
+        storage_settings.clone(),
+        runner,
+    );
+
+    if initial_state.status == BdbToolStatus::Unsupported {
+        return BdbAcquisitionResult {
+            outcome: BdbAcquisitionOutcome::Unsupported,
+            summary: initial_state.summary.clone(),
+            guidance: initial_state.guidance.clone(),
+            tool_state: initial_state,
+        };
+    }
+
+    if initial_state.status == BdbToolStatus::Runnable && !repair {
+        return BdbAcquisitionResult {
+            outcome: BdbAcquisitionOutcome::AlreadyReady,
+            summary: "Board's install tool was already ready.".into(),
+            guidance: "No new download was needed.".into(),
+            tool_state: initial_state,
+        };
+    }
+
+    let Some(source) = source_plan.source.as_ref() else {
+        return BdbAcquisitionResult {
+            outcome: BdbAcquisitionOutcome::Unsupported,
+            summary: initial_state.summary.clone(),
+            guidance: initial_state.guidance.clone(),
+            tool_state: initial_state,
+        };
+    };
+
+    let download_result =
+        download_and_store_bdb(&initial_state.storage, &source.download_url, downloader);
+    let updated_state =
+        inspect_bdb_tool_state_with_plan_and_runner(source_plan, storage_settings, runner);
+
+    match download_result {
+        Ok(()) if updated_state.status == BdbToolStatus::Runnable => {
+            let outcome = if initial_state.executable_exists {
+                BdbAcquisitionOutcome::Repaired
+            } else {
+                BdbAcquisitionOutcome::Downloaded
+            };
+            let summary = if outcome == BdbAcquisitionOutcome::Repaired {
+                "BE Home repaired the managed bdb install.".into()
+            } else {
+                "BE Home downloaded Board's bdb into the managed tools folder.".into()
+            };
+
+            BdbAcquisitionResult {
+                outcome,
+                summary,
+                guidance: "The managed bdb binary is now runnable.".into(),
+                tool_state: updated_state,
+            }
+        }
+        Ok(()) => BdbAcquisitionResult {
+            outcome: BdbAcquisitionOutcome::Failed,
+            summary: "BE Home downloaded bdb, but this computer still did not let it open.".into(),
+            guidance: updated_state.guidance.clone(),
+            tool_state: updated_state,
+        },
+        Err(error) => BdbAcquisitionResult {
+            outcome: BdbAcquisitionOutcome::Failed,
+            summary: error.summary,
+            guidance: error.guidance,
+            tool_state: updated_state,
+        },
+    }
+}
+
+fn download_and_store_bdb<D: BinaryDownloader>(
+    storage_location: &storage::ManagedStorageLocation,
+    download_url: &str,
+    downloader: &D,
+) -> Result<(), UserFacingError> {
+    let executable_path = resolve_bdb_executable_path(storage_location);
+    let tools_directory = executable_path
+        .parent()
+        .expect("bdb executable path should have a parent")
+        .to_path_buf();
+    let temp_path = tools_directory.join(format!("{}.download", bdb_executable_file_name()));
+
+    let bytes = downloader.download(download_url)?;
+
+    fs::create_dir_all(&tools_directory)
+        .map_err(|error| storage_write_error(&tools_directory, &error))?;
+    let _ = fs::remove_file(&temp_path);
+
+    fs::write(&temp_path, bytes).map_err(|error| storage_write_error(&temp_path, &error))?;
+
+    #[cfg(unix)]
+    {
+        let mut permissions = fs::metadata(&temp_path)
+            .map_err(|error| storage_write_error(&temp_path, &error))?
+            .permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&temp_path, permissions)
+            .map_err(|error| storage_write_error(&temp_path, &error))?;
+    }
+
+    if executable_path.exists() {
+        fs::remove_file(&executable_path)
+            .map_err(|error| storage_write_error(&executable_path, &error))?;
+    }
+
+    fs::rename(&temp_path, &executable_path)
+        .map_err(|error| storage_write_error(&executable_path, &error))?;
+    Ok(())
+}
+
+fn validate_runnable<P: ProcessRunner>(
+    executable_path: &Path,
+    runner: &P,
+) -> BdbRunnableValidation {
+    let command = build_validation_command(executable_path);
+
+    match runner.run(executable_path, &[BDB_HELP_ARGUMENT]) {
+        Ok(output) => BdbRunnableValidation {
+            status: BdbRunnableStatus::Runnable,
+            command,
+            exit_code: output.exit_code,
+            summary: "BE Home could open bdb from its managed tools folder.".into(),
+            detail: output.exit_code.and_then(|code| {
+                if code == 0 {
+                    None
+                } else {
+                    Some(format!(
+                        "bdb opened successfully and then exited with code {code}."
+                    ))
+                }
+            }),
+        },
+        Err(failure) => match failure.kind {
+            ProcessRunFailureKind::PermissionDenied => BdbRunnableValidation {
+                status: BdbRunnableStatus::Blocked,
+                command,
+                exit_code: None,
+                summary: "This computer would not let BE Home open the stored bdb binary.".into(),
+                detail: Some(failure.detail),
+            },
+            ProcessRunFailureKind::NotFound => BdbRunnableValidation {
+                status: BdbRunnableStatus::Missing,
+                command,
+                exit_code: None,
+                summary:
+                    "The managed bdb file was no longer present when BE Home tried to open it."
+                        .into(),
+                detail: Some(failure.detail),
+            },
+            ProcessRunFailureKind::Other => BdbRunnableValidation {
+                status: BdbRunnableStatus::Blocked,
+                command,
+                exit_code: None,
+                summary: "BE Home could not confirm that the stored bdb binary is runnable.".into(),
+                detail: Some(failure.detail),
+            },
+        },
+    }
+}
+
+fn classify_process_failure(error: io::Error) -> ProcessRunFailure {
+    let detail = error.to_string();
+    let kind = match error.kind() {
+        io::ErrorKind::PermissionDenied => ProcessRunFailureKind::PermissionDenied,
+        io::ErrorKind::NotFound => ProcessRunFailureKind::NotFound,
+        _ => ProcessRunFailureKind::Other,
+    };
+
+    ProcessRunFailure { kind, detail }
+}
+
+fn storage_write_error(path: &Path, error: &io::Error) -> UserFacingError {
+    if error.kind() == io::ErrorKind::PermissionDenied {
+        return UserFacingError {
+            summary: "BE Home could not save bdb in its managed tools folder.".into(),
+            guidance:
+                "Choose a different tools folder in settings or close anything that may be locking the file."
+                    .into(),
+        };
+    }
+
+    UserFacingError {
+        summary: "BE Home could not finish saving bdb in its managed tools folder.".into(),
+        guidance: format!(
+            "Check that `{}` is still available, then try again.",
+            path.display()
+        ),
+    }
+}
+
+fn resolve_bdb_executable_path(storage_location: &storage::ManagedStorageLocation) -> PathBuf {
+    PathBuf::from(&storage_location.effective_path).join(bdb_executable_file_name())
+}
+
+fn build_validation_command(executable_path: &Path) -> String {
+    format!("{} {}", executable_path.display(), BDB_HELP_ARGUMENT)
+}
+
+fn bdb_executable_file_name() -> &'static str {
+    if cfg!(target_os = "windows") {
+        "bdb.exe"
+    } else {
+        "bdb"
+    }
+}
+
+fn path_to_string(path: &Path) -> String {
+    path.to_string_lossy().into_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        acquire_bdb_tool_with_dependencies, inspect_bdb_tool_state_with_plan_and_runner,
+        BdbAcquisitionOutcome, BdbRunnableStatus, BdbToolStatus, BinaryDownloader,
+        ProcessRunFailure, ProcessRunFailureKind, ProcessRunOutput, ProcessRunner, UserFacingError,
+    };
+    use crate::{
+        bdb::{
+            BdbArchitecture, BdbDownloadSource, BdbOperatingSystem, BdbPlatformSupport,
+            BdbSourcePlan, BdbSupportStatus,
+        },
+        storage::{
+            ManagedStorageLocation, ManagedStoragePathSource, ManagedStorageSettings,
+            StorageOperatingSystem,
+        },
+    };
+    use std::fs;
+    use std::path::{Path, PathBuf};
+
+    struct StaticDownloader {
+        response: Result<Vec<u8>, UserFacingError>,
+    }
+
+    impl BinaryDownloader for StaticDownloader {
+        fn download(&self, _url: &str) -> Result<Vec<u8>, UserFacingError> {
+            self.response.clone()
+        }
+    }
+
+    struct ContentAwareRunner;
+
+    impl ProcessRunner for ContentAwareRunner {
+        fn run(
+            &self,
+            executable_path: &Path,
+            _args: &[&str],
+        ) -> Result<ProcessRunOutput, ProcessRunFailure> {
+            let content = fs::read_to_string(executable_path).unwrap_or_default();
+            match content.as_str() {
+                "fresh-bdb" => Ok(ProcessRunOutput { exit_code: Some(0) }),
+                "odd-but-runnable" => Ok(ProcessRunOutput { exit_code: Some(1) }),
+                "blocked-bdb" => Err(ProcessRunFailure {
+                    kind: ProcessRunFailureKind::PermissionDenied,
+                    detail: "The operating system denied access to the file.".into(),
+                }),
+                _ => Err(ProcessRunFailure {
+                    kind: ProcessRunFailureKind::Other,
+                    detail: "The stored file did not behave like bdb.".into(),
+                }),
+            }
+        }
+    }
+
+    #[test]
+    fn missing_tool_state_is_reported_before_any_download() {
+        let temp_directory = tempfile::tempdir().expect("temporary directory should exist");
+
+        let state = inspect_bdb_tool_state_with_plan_and_runner(
+            supported_source_plan(),
+            managed_storage_settings(temp_directory.path()),
+            &ContentAwareRunner,
+        );
+
+        assert_eq!(BdbToolStatus::Missing, state.status);
+        assert_eq!(BdbRunnableStatus::Missing, state.validation.status);
+    }
+
+    #[test]
+    fn successful_download_reports_a_runnable_tool() {
+        let temp_directory = tempfile::tempdir().expect("temporary directory should exist");
+        let settings = managed_storage_settings(temp_directory.path());
+
+        let result = acquire_bdb_tool_with_dependencies(
+            supported_source_plan(),
+            settings.clone(),
+            &StaticDownloader {
+                response: Ok(b"fresh-bdb".to_vec()),
+            },
+            &ContentAwareRunner,
+            false,
+        );
+
+        assert_eq!(BdbAcquisitionOutcome::Downloaded, result.outcome);
+        assert_eq!(BdbToolStatus::Runnable, result.tool_state.status);
+        assert_eq!(
+            "fresh-bdb",
+            fs::read_to_string(resolve_expected_executable_path(&settings))
+                .expect("downloaded binary should be written")
+        );
+    }
+
+    #[test]
+    fn repair_replaces_a_blocked_binary_without_manual_cleanup() {
+        let temp_directory = tempfile::tempdir().expect("temporary directory should exist");
+        let settings = managed_storage_settings(temp_directory.path());
+        let executable_path = resolve_expected_executable_path(&settings);
+        fs::create_dir_all(
+            executable_path
+                .parent()
+                .expect("executable should have parent"),
+        )
+        .expect("tools directory should exist");
+        fs::write(&executable_path, "blocked-bdb").expect("blocked binary should exist");
+
+        let result = acquire_bdb_tool_with_dependencies(
+            supported_source_plan(),
+            settings.clone(),
+            &StaticDownloader {
+                response: Ok(b"fresh-bdb".to_vec()),
+            },
+            &ContentAwareRunner,
+            false,
+        );
+
+        assert_eq!(BdbAcquisitionOutcome::Repaired, result.outcome);
+        assert_eq!(BdbToolStatus::Runnable, result.tool_state.status);
+        assert_eq!(
+            "fresh-bdb",
+            fs::read_to_string(resolve_expected_executable_path(&settings))
+                .expect("repaired binary should replace the blocked copy")
+        );
+    }
+
+    #[test]
+    fn blocked_binary_after_download_is_reported_as_downloaded_but_not_runnable() {
+        let temp_directory = tempfile::tempdir().expect("temporary directory should exist");
+        let settings = managed_storage_settings(temp_directory.path());
+
+        let result = acquire_bdb_tool_with_dependencies(
+            supported_source_plan(),
+            settings,
+            &StaticDownloader {
+                response: Ok(b"blocked-bdb".to_vec()),
+            },
+            &ContentAwareRunner,
+            false,
+        );
+
+        assert_eq!(BdbAcquisitionOutcome::Failed, result.outcome);
+        assert_eq!(BdbToolStatus::Downloaded, result.tool_state.status);
+        assert_eq!(
+            BdbRunnableStatus::Blocked,
+            result.tool_state.validation.status
+        );
+    }
+
+    #[test]
+    fn unsupported_plan_surfaces_actionable_guidance() {
+        let temp_directory = tempfile::tempdir().expect("temporary directory should exist");
+        let state = inspect_bdb_tool_state_with_plan_and_runner(
+            unsupported_source_plan(),
+            managed_storage_settings(temp_directory.path()),
+            &ContentAwareRunner,
+        );
+
+        assert_eq!(BdbToolStatus::Unsupported, state.status);
+        assert!(state
+            .guidance
+            .contains("Board currently publishes bdb only"));
+    }
+
+    fn supported_source_plan() -> BdbSourcePlan {
+        BdbSourcePlan {
+            manifest_source: "bundled".into(),
+            remote_manifest_url: "https://example.com/bdb-sources.json".into(),
+            manifest_cache_path: None,
+            manifest_schema_version: 1,
+            support: BdbPlatformSupport {
+                status: BdbSupportStatus::Supported,
+                operating_system: BdbOperatingSystem::Linux,
+                architecture: BdbArchitecture::X86_64,
+                windows_build: None,
+                platform_key: Some("linux-x86_64".into()),
+                reason: None,
+                guidance: "This machine matches a Board-published bdb target.".into(),
+            },
+            source: Some(BdbDownloadSource {
+                platform_key: "linux-x86_64".into(),
+                download_url: "https://example.com/bdb".into(),
+            }),
+        }
+    }
+
+    fn unsupported_source_plan() -> BdbSourcePlan {
+        BdbSourcePlan {
+            manifest_source: "bundled".into(),
+            remote_manifest_url: "https://example.com/bdb-sources.json".into(),
+            manifest_cache_path: None,
+            manifest_schema_version: 1,
+            support: BdbPlatformSupport {
+                status: BdbSupportStatus::Unsupported,
+                operating_system: BdbOperatingSystem::Linux,
+                architecture: BdbArchitecture::Arm,
+                windows_build: None,
+                platform_key: None,
+                reason: None,
+                guidance:
+                    "Board currently publishes bdb only for macOS, Linux amd64, and Windows 11 x86_64."
+                        .into(),
+            },
+            source: None,
+        }
+    }
+
+    fn managed_storage_settings(root: &Path) -> ManagedStorageSettings {
+        let tools_path = root.join("tools");
+        let apk_library_path = root.join("apk-library");
+
+        ManagedStorageSettings {
+            operating_system: StorageOperatingSystem::Linux,
+            settings_file_path: root
+                .join("settings")
+                .join("managed-storage.json")
+                .to_string_lossy()
+                .into_owned(),
+            bdb_tools: ManagedStorageLocation {
+                default_path: tools_path.to_string_lossy().into_owned(),
+                override_path: None,
+                effective_path: tools_path.to_string_lossy().into_owned(),
+                source: ManagedStoragePathSource::Default,
+            },
+            apk_library: ManagedStorageLocation {
+                default_path: apk_library_path.to_string_lossy().into_owned(),
+                override_path: None,
+                effective_path: apk_library_path.to_string_lossy().into_owned(),
+                source: ManagedStoragePathSource::Default,
+            },
+        }
+    }
+
+    fn resolve_expected_executable_path(settings: &ManagedStorageSettings) -> PathBuf {
+        let file_name = if cfg!(target_os = "windows") {
+            "bdb.exe"
+        } else {
+            "bdb"
+        };
+
+        PathBuf::from(&settings.bdb_tools.effective_path).join(file_name)
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
 mod bdb;
+mod bdb_tool;
 mod storage;
 
 use serde::Serialize;
@@ -189,6 +190,16 @@ fn load_bdb_source_plan() -> bdb::BdbSourcePlan {
 }
 
 #[tauri::command]
+fn load_bdb_tool_state() -> Result<bdb_tool::BdbToolState, String> {
+    bdb_tool::load_current_bdb_tool_state()
+}
+
+#[tauri::command]
+fn acquire_bdb_tool(repair: bool) -> Result<bdb_tool::BdbAcquisitionResult, String> {
+    bdb_tool::acquire_current_bdb_tool(repair)
+}
+
+#[tauri::command]
 fn load_managed_storage_settings() -> Result<storage::ManagedStorageSettings, String> {
     storage::load_managed_storage_settings()
 }
@@ -207,6 +218,8 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             load_shell_state,
             load_bdb_source_plan,
+            load_bdb_tool_state,
+            acquire_bdb_tool,
             load_managed_storage_settings,
             save_managed_storage_settings
         ])
@@ -287,8 +300,16 @@ mod tests {
         let plan = super::load_bdb_source_plan();
         let serialized = serde_json::to_value(plan).expect("bdb source plan should serialize");
 
-        assert_eq!(Some("bundled"), serialized.get("manifestSource").and_then(|value| value.as_str()));
-        assert_eq!(Some(1), serialized.get("manifestSchemaVersion").and_then(|value| value.as_u64()));
+        assert!(serialized
+            .get("manifestSource")
+            .and_then(|value| value.as_str())
+            .is_some_and(|value| matches!(value, "bundled" | "cached" | "remote")));
+        assert_eq!(
+            Some(1),
+            serialized
+                .get("manifestSchemaVersion")
+                .and_then(|value| value.as_u64())
+        );
         assert!(serialized
             .get("remoteManifestUrl")
             .and_then(|value| value.as_str())
@@ -309,6 +330,20 @@ mod tests {
         assert!(serialized
             .get("apkLibrary")
             .and_then(|value| value.get("effectivePath"))
+            .is_some());
+    }
+
+    #[test]
+    fn bdb_tool_state_serializes_the_host_side_status_contract() {
+        let state = super::load_bdb_tool_state().expect("bdb tool state should load");
+        let serialized = serde_json::to_value(state).expect("bdb tool state should serialize");
+
+        assert!(serialized.get("status").is_some());
+        assert!(serialized.get("storage").is_some());
+        assert!(serialized.get("sourcePlan").is_some());
+        assert!(serialized
+            .get("validation")
+            .and_then(|value| value.get("status"))
             .is_some());
     }
 }

--- a/src-tauri/src/storage.rs
+++ b/src-tauri/src/storage.rs
@@ -32,20 +32,20 @@ pub(crate) enum ManagedStoragePathSource {
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct ManagedStorageLocation {
-    default_path: String,
-    override_path: Option<String>,
-    effective_path: String,
-    source: ManagedStoragePathSource,
+    pub(crate) default_path: String,
+    pub(crate) override_path: Option<String>,
+    pub(crate) effective_path: String,
+    pub(crate) source: ManagedStoragePathSource,
 }
 
 /// Describes the current managed storage configuration for the desktop app.
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct ManagedStorageSettings {
-    operating_system: StorageOperatingSystem,
-    settings_file_path: String,
-    bdb_tools: ManagedStorageLocation,
-    apk_library: ManagedStorageLocation,
+    pub(crate) operating_system: StorageOperatingSystem,
+    pub(crate) settings_file_path: String,
+    pub(crate) bdb_tools: ManagedStorageLocation,
+    pub(crate) apk_library: ManagedStorageLocation,
 }
 
 /// Represents the persisted override payload accepted by the desktop host.
@@ -77,6 +77,11 @@ pub(crate) fn load_managed_storage_settings() -> Result<ManagedStorageSettings, 
     Ok(build_managed_storage_settings(&context, &persisted))
 }
 
+/// Resolve the app-owned root directory used for desktop settings, tools, and cached files.
+pub(crate) fn resolve_app_data_root() -> Result<PathBuf, String> {
+    Ok(current_storage_context()?.app_data_root)
+}
+
 /// Save managed storage overrides and return the updated effective settings.
 pub(crate) fn save_managed_storage_settings(
     input: ManagedStorageOverridesInput,
@@ -101,7 +106,10 @@ fn build_managed_storage_settings(
     ManagedStorageSettings {
         operating_system: context.operating_system,
         settings_file_path: path_to_string(&context.settings_file_path),
-        bdb_tools: build_location(default_bdb_tools_path, persisted.bdb_tools_override.as_deref()),
+        bdb_tools: build_location(
+            default_bdb_tools_path,
+            persisted.bdb_tools_override.as_deref(),
+        ),
         apk_library: build_location(
             default_apk_library_path,
             persisted.apk_library_override.as_deref(),
@@ -159,7 +167,9 @@ fn current_storage_context_from_environment(
             .join(APP_PRODUCT_DIRECTORY);
         return Ok(ManagedStorageContext {
             operating_system: StorageOperatingSystem::Macos,
-            settings_file_path: root.join(SETTINGS_DIRECTORY).join(STORAGE_SETTINGS_FILE_NAME),
+            settings_file_path: root
+                .join(SETTINGS_DIRECTORY)
+                .join(STORAGE_SETTINGS_FILE_NAME),
             app_data_root: root,
         });
     }
@@ -171,7 +181,9 @@ fn current_storage_context_from_environment(
         .join(APP_PRODUCT_DIRECTORY);
     Ok(ManagedStorageContext {
         operating_system: StorageOperatingSystem::Linux,
-        settings_file_path: root.join(SETTINGS_DIRECTORY).join(STORAGE_SETTINGS_FILE_NAME),
+        settings_file_path: root
+            .join(SETTINGS_DIRECTORY)
+            .join(STORAGE_SETTINGS_FILE_NAME),
         app_data_root: root,
     })
 }
@@ -385,7 +397,10 @@ mod tests {
             .expect("settings file should load");
         let settings = build_managed_storage_settings(&context, &loaded);
 
-        assert_eq!(Some("/tmp/be/tools"), settings.bdb_tools.override_path.as_deref());
+        assert_eq!(
+            Some("/tmp/be/tools"),
+            settings.bdb_tools.override_path.as_deref()
+        );
         assert_eq!("/tmp/be/tools", settings.bdb_tools.effective_path);
         assert_eq!(
             Some("/tmp/be/apk-library"),

--- a/src/desktop/client.ts
+++ b/src/desktop/client.ts
@@ -1,6 +1,8 @@
 import { invoke } from "@tauri-apps/api/core";
 import type {
+  BdbAcquisitionResult,
   BdbSourcePlan,
+  BdbToolState,
   DesktopShellState,
   ManagedStorageOverridesInput,
   ManagedStorageSettings,
@@ -18,6 +20,20 @@ export function loadDesktopShellState(): Promise<DesktopShellState> {
  */
 export function loadBdbSourcePlan(): Promise<BdbSourcePlan> {
   return invoke<BdbSourcePlan>("load_bdb_source_plan");
+}
+
+/**
+ * Loads the current managed `bdb` tool state from the desktop host.
+ */
+export function loadBdbToolState(): Promise<BdbToolState> {
+  return invoke<BdbToolState>("load_bdb_tool_state");
+}
+
+/**
+ * Downloads or repairs the managed `bdb` binary, then returns the updated state.
+ */
+export function acquireBdbTool(repair = false): Promise<BdbAcquisitionResult> {
+  return invoke<BdbAcquisitionResult>("acquire_bdb_tool", { repair });
 }
 
 /**

--- a/src/desktop/types.ts
+++ b/src/desktop/types.ts
@@ -94,9 +94,65 @@ export interface BdbDownloadSource {
 export interface BdbSourcePlan {
   manifestSource: string;
   remoteManifestUrl: string;
+  manifestCachePath: string | null;
   manifestSchemaVersion: number;
   support: BdbPlatformSupport;
   source: BdbDownloadSource | null;
+}
+
+/**
+ * Describes the local readiness state for the managed `bdb` binary.
+ */
+export type BdbToolStatus = "unsupported" | "missing" | "downloaded" | "runnable";
+
+/**
+ * Describes the runnable validation result for the managed `bdb` binary.
+ */
+export type BdbRunnableStatus = "unsupported" | "missing" | "blocked" | "runnable";
+
+/**
+ * Describes the latest no-device-required validation result for the managed `bdb` binary.
+ */
+export interface BdbRunnableValidation {
+  status: BdbRunnableStatus;
+  command: string;
+  exitCode: number | null;
+  summary: string;
+  detail: string | null;
+}
+
+/**
+ * Describes the current managed `bdb` tool state.
+ */
+export interface BdbToolState {
+  status: BdbToolStatus;
+  summary: string;
+  guidance: string;
+  executablePath: string;
+  executableExists: boolean;
+  storage: ManagedStorageLocation;
+  sourcePlan: BdbSourcePlan;
+  validation: BdbRunnableValidation;
+}
+
+/**
+ * Describes the outcome of an acquire or repair attempt for `bdb`.
+ */
+export type BdbAcquisitionOutcome =
+  | "unsupported"
+  | "alreadyReady"
+  | "downloaded"
+  | "repaired"
+  | "failed";
+
+/**
+ * Describes the result returned after BE Home attempts to acquire or repair `bdb`.
+ */
+export interface BdbAcquisitionResult {
+  outcome: BdbAcquisitionOutcome;
+  summary: string;
+  guidance: string;
+  toolState: BdbToolState;
 }
 
 /**


### PR DESCRIPTION
## Summary
- add remote/cached/bundled `bdb` source-manifest fallback in the desktop host
- implement managed `bdb` download, repair, and runnable validation with player-friendly status contracts
- document the runtime `bdb` lifecycle and expose the new host DTOs to the renderer

## Testing
- npm run build
- npm run test