### PR TITLE
Add the desktop setup gate and first-run flow

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,187 +1,11 @@
 mod bdb;
 mod bdb_tool;
+mod setup;
 mod storage;
 
-use serde::Serialize;
-
-#[derive(Clone, Serialize)]
-#[serde(rename_all = "camelCase")]
-struct DesktopShellState {
-    app_name: String,
-    version: String,
-    platform_label: String,
-    intro_eyebrow: String,
-    intro_summary: String,
-    highlights: Vec<ShellBadge>,
-    getting_started_title: String,
-    getting_started_steps: Vec<String>,
-    help_title: String,
-    help_summary: String,
-    help_bullets: Vec<String>,
-    sections: Vec<ShellSection>,
-}
-
-#[derive(Clone, Serialize)]
-#[serde(rename_all = "camelCase")]
-struct ShellSection {
-    id: String,
-    eyebrow: String,
-    title: String,
-    summary: String,
-    tone: String,
-    badges: Vec<ShellBadge>,
-    bullets: Vec<String>,
-}
-
-#[derive(Clone, Serialize)]
-#[serde(rename_all = "camelCase")]
-struct ShellBadge {
-    label: String,
-    value: String,
-}
-
-fn shell_state() -> DesktopShellState {
-    DesktopShellState {
-        app_name: "BE Home for Desktop".into(),
-        version: env!("CARGO_PKG_VERSION").into(),
-        platform_label: current_platform_label().into(),
-        intro_eyebrow: "Board installs made easier".into(),
-        intro_summary: "Keep your Board install tool ready, choose an APK from your computer, and keep favorite installs close for later.".into(),
-        highlights: vec![
-            ShellBadge {
-                label: "Works with".into(),
-                value: "USB + APK".into(),
-            },
-            ShellBadge {
-                label: "Manual choice".into(),
-                value: "Always welcome".into(),
-            },
-            ShellBadge {
-                label: "BE account".into(),
-                value: "Optional".into(),
-            },
-        ],
-        getting_started_title: "Keep your next install close and familiar.".into(),
-        getting_started_steps: vec![
-            "Connect your Board with USB when you are ready to install.".into(),
-            "Choose a game or app APK from Downloads or another folder you already trust.".into(),
-            "Keep favorite APKs together so reinstalling later takes fewer steps.".into(),
-        ],
-        help_title: "Built for real player routines".into(),
-        help_summary: "BE Home keeps the most important install steps in one place so getting back to play feels less scattered.".into(),
-        help_bullets: vec![
-            "If you already know which download you want, you can still pick the APK yourself.".into(),
-            "Once the Board install tool is ready, local checks and library browsing can stay useful without a network connection.".into(),
-            "Your BE account can help with matching later, but it should never be the only way to finish a local install.".into(),
-        ],
-        sections: vec![
-            ShellSection {
-                id: "bdb-setup".into(),
-                eyebrow: "Keep setup simple".into(),
-                title: "Stay ready for the Board install tool".into(),
-                summary: "BE Home keeps the required Board install tool easy to find so getting back to a game or app takes less guesswork.".into(),
-                tone: "sunrise".into(),
-                badges: vec![
-                    ShellBadge {
-                        label: "Needed once".into(),
-                        value: "Set up bdb".into(),
-                    },
-                    ShellBadge {
-                        label: "Stored for you".into(),
-                        value: "App space".into(),
-                    },
-                ],
-                bullets: vec![
-                    "Keep the Board install tool nearby so you do not have to chase it down each time you want to install.".into(),
-                    "Save it in a familiar app-owned location with room for a player-friendly override.".into(),
-                    "Check it early so repair guidance is ready before you start an install.".into(),
-                ],
-            },
-            ShellSection {
-                id: "device-status".into(),
-                eyebrow: "Know before you install".into(),
-                title: "Check your Board connection at a glance".into(),
-                summary: "See when your Board is ready, then move into install, reinstall, or launch steps with more confidence.".into(),
-                tone: "ocean".into(),
-                badges: vec![
-                    ShellBadge {
-                        label: "Connection".into(),
-                        value: "USB".into(),
-                    },
-                    ShellBadge {
-                        label: "Updates".into(),
-                        value: "Clear guidance".into(),
-                    },
-                ],
-                bullets: vec![
-                    "Check whether your Board is connected without sending you into terminal troubleshooting.".into(),
-                    "Keep install, uninstall, and launch steps tied to easy-to-follow readiness messages.".into(),
-                    "Refresh the device picture while the app stays open so you do not have to keep starting over.".into(),
-                ],
-            },
-            ShellSection {
-                id: "apk-library".into(),
-                eyebrow: "Choose what to install".into(),
-                title: "Find downloads from familiar folders or your saved library".into(),
-                summary: "Keep Board-ready APKs together, browse what you already downloaded, and pick an APK yourself whenever that is fastest.".into(),
-                tone: "forest".into(),
-                badges: vec![
-                    ShellBadge {
-                        label: "Manual choice".into(),
-                        value: "Always welcome".into(),
-                    },
-                    ShellBadge {
-                        label: "Saved library".into(),
-                        value: "Ready for later".into(),
-                    },
-                ],
-                bullets: vec![
-                    "Start with familiar folders such as Downloads and let players add more when they want to.".into(),
-                    "Keep a local library for titles you return to often or want ready for reinstall.".into(),
-                    "Pick any APK yourself when that is the fastest way to move forward.".into(),
-                ],
-            },
-            ShellSection {
-                id: "account-enhancements".into(),
-                eyebrow: "Optional extras".into(),
-                title: "Bring your BE library with you when it helps".into(),
-                summary: "Sign in for quicker library and wishlist matching, or stay local-only when you just want to install from your own computer.".into(),
-                tone: "slate".into(),
-                badges: vec![
-                    ShellBadge {
-                        label: "Sign-in".into(),
-                        value: "Optional".into(),
-                    },
-                    ShellBadge {
-                        label: "Local flow".into(),
-                        value: "Works on its own".into(),
-                    },
-                ],
-                bullets: vec![
-                    "Bring in your BE wishlist and library only when they save time.".into(),
-                    "Keep local device checks and installs useful even if you never sign in.".into(),
-                    "Let account features feel like a convenience, not a requirement.".into(),
-                ],
-            },
-        ],
-    }
-}
-
-fn current_platform_label() -> &'static str {
-    if cfg!(target_os = "windows") {
-        "Windows"
-    } else if cfg!(target_os = "macos") {
-        "macOS"
-    } else if cfg!(target_os = "linux") {
-        "Linux"
-    } else {
-        "Unsupported desktop platform"
-    }
-}
-
 #[tauri::command]
-fn load_shell_state() -> DesktopShellState {
-    shell_state()
+fn load_setup_gate_state() -> Result<setup::SetupGateState, String> {
+    setup::load_setup_gate_state()
 }
 
 #[tauri::command]
@@ -216,7 +40,7 @@ fn save_managed_storage_settings(
 pub fn run() {
     tauri::Builder::default()
         .invoke_handler(tauri::generate_handler![
-            load_shell_state,
+            load_setup_gate_state,
             load_bdb_source_plan,
             load_bdb_tool_state,
             acquire_bdb_tool,
@@ -229,70 +53,18 @@ pub fn run() {
 
 #[cfg(test)]
 mod tests {
-    use super::shell_state;
-
     #[test]
-    fn shell_state_describes_player_install_workflow() {
-        let state = shell_state();
+    fn setup_gate_state_serializes_the_bootstrap_contract() {
+        let state =
+            super::load_setup_gate_state().expect("setup gate state should load successfully");
+        let serialized =
+            serde_json::to_value(state).expect("setup gate state should serialize successfully");
 
-        assert_eq!(state.app_name, "BE Home for Desktop");
-        assert_eq!(state.sections.len(), 4);
-        assert_eq!(state.getting_started_steps.len(), 3);
-        assert_eq!(state.help_bullets.len(), 3);
-        assert!(state.sections.iter().any(|section| section
-            .bullets
-            .iter()
-            .any(|bullet| bullet.contains("Pick any APK yourself"))));
-    }
-
-    #[test]
-    fn shell_state_avoids_internal_placeholder_language() {
-        let state = shell_state();
-        let banned_terms = [
-            "scaffold",
-            "placeholder",
-            "planned",
-            "next wave",
-            "foundation shell",
-        ];
-        let mut copy = vec![
-            state.app_name.clone(),
-            state.intro_eyebrow.clone(),
-            state.intro_summary.clone(),
-            state.getting_started_title.clone(),
-            state.help_title.clone(),
-            state.help_summary.clone(),
-        ];
-
-        assert!(!state.platform_label.is_empty());
-
-        for highlight in state.highlights {
-            copy.push(highlight.label);
-            copy.push(highlight.value);
-        }
-        for item in state.getting_started_steps {
-            copy.push(item);
-        }
-        for item in state.help_bullets {
-            copy.push(item);
-        }
-        for section in state.sections {
-            copy.push(section.eyebrow);
-            copy.push(section.title);
-            copy.push(section.summary);
-            for badge in section.badges {
-                copy.push(badge.label);
-                copy.push(badge.value);
-            }
-            for bullet in section.bullets {
-                copy.push(bullet);
-            }
-        }
-
-        assert!(copy.iter().all(|entry| {
-            let normalized = entry.to_lowercase();
-            banned_terms.iter().all(|term| !normalized.contains(term))
-        }));
+        assert!(serialized.get("status").is_some());
+        assert!(serialized.get("requiredStep").is_some());
+        assert!(serialized.get("toolState").is_some());
+        assert!(serialized.get("storage").is_some());
+        assert!(serialized.get("defaultScanFolders").is_some());
     }
 
     #[test]

--- a/src-tauri/src/setup.rs
+++ b/src-tauri/src/setup.rs
@@ -1,0 +1,323 @@
+use crate::{bdb_tool, storage};
+use serde::Serialize;
+use std::collections::BTreeMap;
+use std::ffi::OsString;
+use std::path::PathBuf;
+
+const APP_NAME: &str = "BE Home for Desktop";
+const DOWNLOADS_DIRECTORY_NAME: &str = "Downloads";
+
+/// Describes whether the app must keep the player inside setup before opening the workspace.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) enum SetupGateStatus {
+    RequiresSetup,
+    Ready,
+    Unsupported,
+}
+
+/// Describes the setup step that should be active based on current host state.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) enum SetupRequiredStep {
+    SystemCheck,
+    ToolSetup,
+    Workspace,
+}
+
+/// Describes the stable setup-gate contract returned by the desktop host.
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct SetupGateState {
+    pub(crate) app_name: String,
+    pub(crate) version: String,
+    pub(crate) platform_label: String,
+    pub(crate) status: SetupGateStatus,
+    pub(crate) required_step: SetupRequiredStep,
+    pub(crate) summary: String,
+    pub(crate) guidance: String,
+    pub(crate) tool_state: bdb_tool::BdbToolState,
+    pub(crate) storage: storage::ManagedStorageSettings,
+    pub(crate) default_scan_folders: Vec<String>,
+}
+
+/// Load the current setup-gate state used to decide whether the app can open the workspace.
+pub(crate) fn load_setup_gate_state() -> Result<SetupGateState, String> {
+    let storage = storage::load_managed_storage_settings()?;
+    let tool_state = bdb_tool::load_current_bdb_tool_state()?;
+
+    Ok(build_setup_gate_state(
+        tool_state,
+        storage,
+        resolve_default_scan_folders(),
+    ))
+}
+
+fn build_setup_gate_state(
+    tool_state: bdb_tool::BdbToolState,
+    storage: storage::ManagedStorageSettings,
+    default_scan_folders: Vec<String>,
+) -> SetupGateState {
+    let (status, required_step, summary, guidance) = match tool_state.status {
+        bdb_tool::BdbToolStatus::Unsupported => (
+            SetupGateStatus::Unsupported,
+            SetupRequiredStep::SystemCheck,
+            "This computer cannot complete the Board install-tool setup yet.".into(),
+            tool_state.guidance.clone(),
+        ),
+        bdb_tool::BdbToolStatus::Runnable => (
+            SetupGateStatus::Ready,
+            SetupRequiredStep::Workspace,
+            "Board's install tool is ready, so BE Home can open your desktop workspace."
+                .into(),
+            "You can come back to repair the install tool later if anything changes.".into(),
+        ),
+        bdb_tool::BdbToolStatus::Missing => (
+            SetupGateStatus::RequiresSetup,
+            SetupRequiredStep::ToolSetup,
+            "BE Home still needs to download Board's install tool before the workspace can open."
+                .into(),
+            tool_state.guidance.clone(),
+        ),
+        bdb_tool::BdbToolStatus::Downloaded => (
+            SetupGateStatus::RequiresSetup,
+            SetupRequiredStep::ToolSetup,
+            "BE Home found Board's install tool, but it still needs attention before installs can start."
+                .into(),
+            tool_state.guidance.clone(),
+        ),
+    };
+
+    SetupGateState {
+        app_name: APP_NAME.into(),
+        version: env!("CARGO_PKG_VERSION").into(),
+        platform_label: current_platform_label().into(),
+        status,
+        required_step,
+        summary,
+        guidance,
+        tool_state,
+        storage,
+        default_scan_folders,
+    }
+}
+
+fn resolve_default_scan_folders() -> Vec<String> {
+    resolve_default_scan_folders_from_environment(&std::env::vars_os().collect::<BTreeMap<_, _>>())
+}
+
+fn resolve_default_scan_folders_from_environment(
+    environment: &BTreeMap<OsString, OsString>,
+) -> Vec<String> {
+    let mut folders = Vec::new();
+    if let Some(home_directory) = resolve_home_directory(environment) {
+        folders.push(
+            home_directory
+                .join(DOWNLOADS_DIRECTORY_NAME)
+                .to_string_lossy()
+                .into_owned(),
+        );
+    }
+
+    folders
+}
+
+fn resolve_home_directory(environment: &BTreeMap<OsString, OsString>) -> Option<PathBuf> {
+    #[cfg(target_os = "windows")]
+    {
+        lookup_environment_value(environment, "USERPROFILE")
+            .or_else(|| {
+                let drive = lookup_environment_value(environment, "HOMEDRIVE")?;
+                let path = lookup_environment_value(environment, "HOMEPATH")?;
+                Some(format!("{}{}", drive.to_string_lossy(), path.to_string_lossy()).into())
+            })
+            .map(PathBuf::from)
+            .filter(|path| !path.as_os_str().is_empty())
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        lookup_environment_value(environment, "HOME")
+            .map(PathBuf::from)
+            .filter(|path| !path.as_os_str().is_empty())
+    }
+}
+
+fn lookup_environment_value(
+    environment: &BTreeMap<OsString, OsString>,
+    key: &str,
+) -> Option<OsString> {
+    #[cfg(target_os = "windows")]
+    {
+        environment
+            .iter()
+            .find(|(candidate, _)| candidate.to_string_lossy().eq_ignore_ascii_case(key))
+            .map(|(_, value)| value.clone())
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        environment.get(&OsString::from(key)).cloned()
+    }
+}
+
+fn current_platform_label() -> &'static str {
+    if cfg!(target_os = "windows") {
+        "Windows"
+    } else if cfg!(target_os = "macos") {
+        "macOS"
+    } else if cfg!(target_os = "linux") {
+        "Linux"
+    } else {
+        "Unsupported desktop platform"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        build_setup_gate_state, resolve_default_scan_folders_from_environment, SetupGateStatus,
+        SetupRequiredStep,
+    };
+    use crate::{
+        bdb::{
+            BdbArchitecture, BdbDownloadSource, BdbOperatingSystem, BdbPlatformSupport,
+            BdbSourcePlan, BdbSupportStatus,
+        },
+        bdb_tool::{BdbRunnableStatus, BdbRunnableValidation, BdbToolState, BdbToolStatus},
+        storage::{
+            ManagedStorageLocation, ManagedStoragePathSource, ManagedStorageSettings,
+            StorageOperatingSystem,
+        },
+    };
+    use std::collections::BTreeMap;
+    use std::ffi::OsString;
+
+    #[test]
+    fn missing_tool_requires_setup_download_step() {
+        let state = build_setup_gate_state(
+            sample_tool_state(BdbToolStatus::Missing, BdbRunnableStatus::Missing),
+            sample_storage_settings(),
+            vec!["/tmp/Downloads".into()],
+        );
+
+        assert_eq!(SetupGateStatus::RequiresSetup, state.status);
+        assert_eq!(SetupRequiredStep::ToolSetup, state.required_step);
+    }
+
+    #[test]
+    fn runnable_tool_opens_the_workspace() {
+        let state = build_setup_gate_state(
+            sample_tool_state(BdbToolStatus::Runnable, BdbRunnableStatus::Runnable),
+            sample_storage_settings(),
+            vec!["/tmp/Downloads".into()],
+        );
+
+        assert_eq!(SetupGateStatus::Ready, state.status);
+        assert_eq!(SetupRequiredStep::Workspace, state.required_step);
+    }
+
+    #[test]
+    fn unsupported_host_stays_in_system_check() {
+        let state = build_setup_gate_state(
+            sample_tool_state(BdbToolStatus::Unsupported, BdbRunnableStatus::Unsupported),
+            sample_storage_settings(),
+            Vec::new(),
+        );
+
+        assert_eq!(SetupGateStatus::Unsupported, state.status);
+        assert_eq!(SetupRequiredStep::SystemCheck, state.required_step);
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn windows_scan_folder_defaults_use_user_profile() {
+        let mut environment = BTreeMap::new();
+        environment.insert(
+            OsString::from("USERPROFILE"),
+            OsString::from(r"C:\Users\matt"),
+        );
+
+        let folders = resolve_default_scan_folders_from_environment(&environment);
+
+        assert_eq!(vec![r"C:\Users\matt\Downloads".to_string()], folders);
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn unix_scan_folder_defaults_use_home_downloads() {
+        let mut environment = BTreeMap::new();
+        environment.insert(OsString::from("HOME"), OsString::from("/home/matt"));
+
+        let folders = resolve_default_scan_folders_from_environment(&environment);
+
+        assert_eq!(vec!["/home/matt/Downloads".to_string()], folders);
+    }
+
+    fn sample_tool_state(
+        status: BdbToolStatus,
+        runnable_status: BdbRunnableStatus,
+    ) -> BdbToolState {
+        BdbToolState {
+            status,
+            summary: "sample summary".into(),
+            guidance: "sample guidance".into(),
+            executable_path: "/tmp/bdb".into(),
+            executable_exists: matches!(
+                status,
+                BdbToolStatus::Downloaded | BdbToolStatus::Runnable
+            ),
+            storage: ManagedStorageLocation {
+                default_path: "/tmp/tools".into(),
+                override_path: None,
+                effective_path: "/tmp/tools".into(),
+                source: ManagedStoragePathSource::Default,
+            },
+            source_plan: BdbSourcePlan {
+                manifest_source: "bundled".into(),
+                remote_manifest_url: "https://example.com/bdb-sources.json".into(),
+                manifest_cache_path: None,
+                manifest_schema_version: 1,
+                support: BdbPlatformSupport {
+                    status: BdbSupportStatus::Supported,
+                    operating_system: BdbOperatingSystem::Linux,
+                    architecture: BdbArchitecture::X86_64,
+                    windows_build: None,
+                    platform_key: Some("linux-x86_64".into()),
+                    reason: None,
+                    guidance: "This machine matches a Board-published bdb target.".into(),
+                },
+                source: Some(BdbDownloadSource {
+                    platform_key: "linux-x86_64".into(),
+                    download_url: "https://example.com/bdb".into(),
+                }),
+            },
+            validation: BdbRunnableValidation {
+                status: runnable_status,
+                command: "/tmp/bdb help".into(),
+                exit_code: Some(0),
+                summary: "validation summary".into(),
+                detail: None,
+            },
+        }
+    }
+
+    fn sample_storage_settings() -> ManagedStorageSettings {
+        ManagedStorageSettings {
+            operating_system: StorageOperatingSystem::Linux,
+            settings_file_path: "/tmp/settings/managed-storage.json".into(),
+            bdb_tools: ManagedStorageLocation {
+                default_path: "/tmp/tools".into(),
+                override_path: None,
+                effective_path: "/tmp/tools".into(),
+                source: ManagedStoragePathSource::Default,
+            },
+            apk_library: ManagedStorageLocation {
+                default_path: "/tmp/apk-library".into(),
+                override_path: None,
+                effective_path: "/tmp/apk-library".into(),
+                source: ManagedStoragePathSource::Default,
+            },
+        }
+    }
+}

--- a/src/App.css
+++ b/src/App.css
@@ -3,7 +3,7 @@
 }
 
 .desktop-grid {
-  max-width: 90rem;
+  max-width: 92rem;
   margin: 0 auto;
 }
 
@@ -11,23 +11,23 @@
   margin-top: clamp(1rem, 4vw, 3rem);
 }
 
-.desktop-hero {
+.desktop-banner {
   overflow: hidden;
 }
 
-.desktop-hero::after {
+.desktop-banner::after {
   content: "";
   position: absolute;
-  inset: auto -8rem -8rem auto;
+  inset: auto -6rem -8rem auto;
   width: 18rem;
   height: 18rem;
   border-radius: 999px;
   background:
-    radial-gradient(circle, rgba(77, 117, 244, 0.24) 0%, rgba(77, 117, 244, 0.12) 34%, transparent 72%);
+    radial-gradient(circle, rgba(77, 117, 244, 0.24) 0%, rgba(77, 117, 244, 0.12) 38%, transparent 72%);
   pointer-events: none;
 }
 
-.desktop-hero-copy {
+.desktop-banner-copy {
   display: grid;
   gap: 1rem;
 }
@@ -38,14 +38,10 @@
   color: rgba(220, 247, 234, 0.78);
 }
 
-.desktop-highlight-row,
-.desktop-badge-row {
+.desktop-highlight-row {
   display: flex;
   flex-wrap: wrap;
   gap: 0.75rem;
-}
-
-.desktop-highlight-row {
   margin-top: 1.25rem;
 }
 
@@ -79,23 +75,229 @@
   color: #f7fff8;
 }
 
-.desktop-info-grid,
-.desktop-section-grid {
+.desktop-setup-layout,
+.desktop-workspace-layout {
+  display: grid;
+  grid-template-columns: minmax(17rem, 23rem) minmax(0, 1fr);
+  gap: 1.5rem;
+}
+
+.desktop-stepper,
+.desktop-nav-panel,
+.desktop-setup-panel,
+.desktop-workspace-panel {
+  height: 100%;
+}
+
+.desktop-step-list {
+  display: grid;
+  gap: 1rem;
+  margin: 1.5rem 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.desktop-step-card {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 0.9rem;
+  align-items: start;
+  padding: 1rem;
+  border-radius: 1.25rem;
+  border: 1px solid rgba(118, 255, 170, 0.14);
+  background: rgba(18, 17, 23, 0.55);
+}
+
+.desktop-step-card--active {
+  border-color: rgba(118, 255, 170, 0.38);
+  box-shadow: 0 0 22px rgba(118, 255, 170, 0.08);
+}
+
+.desktop-step-card--complete {
+  border-color: rgba(77, 117, 244, 0.3);
+}
+
+.desktop-step-number {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  border: 1px solid rgba(118, 255, 170, 0.24);
+  background: rgba(64, 198, 141, 0.12);
+  font-size: 0.88rem;
+  font-weight: 700;
+  color: #f7fff8;
+}
+
+.desktop-step-copy {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.desktop-step-copy h3,
+.desktop-inline-card h3,
+.desktop-inline-message h3 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 700;
+  color: #ffffff;
+}
+
+.desktop-step-copy p,
+.desktop-inline-card p,
+.desktop-inline-message p,
+.desktop-detail-row dd,
+.desktop-nav-summary {
+  margin: 0;
+  color: rgb(203 213 225 / 1);
+  line-height: 1.7;
+}
+
+.desktop-setup-panel,
+.desktop-workspace-main {
   display: grid;
   gap: 1.5rem;
 }
 
-.desktop-info-grid {
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+.desktop-detail-grid {
+  display: grid;
+  gap: 0.85rem;
+  margin: 1.5rem 0 0;
 }
 
-.desktop-section-grid {
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+.desktop-detail-row {
+  display: grid;
+  gap: 0.25rem;
+  padding: 0.9rem 1rem;
+  border-radius: 1rem;
+  background: rgba(18, 17, 23, 0.55);
+  border: 1px solid rgba(118, 255, 170, 0.12);
 }
 
-.desktop-panel,
-.desktop-section {
-  height: 100%;
+.desktop-detail-row dt {
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(220, 247, 234, 0.68);
+}
+
+.desktop-inline-card,
+.desktop-inline-message {
+  display: grid;
+  gap: 0.5rem;
+  margin-top: 1.5rem;
+  padding: 1rem 1.1rem;
+  border-radius: 1.25rem;
+  border: 1px solid rgba(118, 255, 170, 0.18);
+  background:
+    radial-gradient(circle at 0% 0%, rgba(96, 255, 164, 0.08), transparent 26%),
+    rgba(18, 17, 23, 0.72);
+}
+
+.desktop-inline-message--warning {
+  border-color: rgba(243, 177, 58, 0.28);
+  background:
+    radial-gradient(circle at 0% 0%, rgba(243, 177, 58, 0.1), transparent 26%),
+    rgba(18, 17, 23, 0.72);
+}
+
+.desktop-action-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.85rem;
+  margin-top: 1.5rem;
+}
+
+.primary-button,
+.secondary-button,
+.tertiary-button,
+.desktop-nav-button {
+  border: none;
+  cursor: pointer;
+  transition:
+    transform 140ms ease,
+    box-shadow 140ms ease,
+    border-color 140ms ease,
+    background-color 140ms ease;
+  font: inherit;
+}
+
+.primary-button,
+.secondary-button,
+.tertiary-button {
+  min-height: 3rem;
+  padding: 0.8rem 1.15rem;
+  border-radius: 999px;
+  font-weight: 700;
+}
+
+.primary-button {
+  background: linear-gradient(135deg, #69f0a3, #41c68d);
+  color: #111116;
+  box-shadow: 0 0 22px rgba(118, 255, 170, 0.16);
+}
+
+.secondary-button {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(118, 255, 170, 0.24);
+  color: #f7fff8;
+}
+
+.tertiary-button {
+  background: transparent;
+  border: 1px solid rgba(196, 205, 255, 0.2);
+  color: rgba(220, 247, 234, 0.78);
+}
+
+.primary-button:hover,
+.secondary-button:hover,
+.tertiary-button:hover,
+.desktop-nav-button:hover {
+  transform: translateY(-1px);
+}
+
+.primary-button:disabled,
+.secondary-button:disabled,
+.tertiary-button:disabled,
+.desktop-nav-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.62;
+  transform: none;
+  box-shadow: none;
+}
+
+.desktop-nav-list {
+  display: grid;
+  gap: 0.85rem;
+  margin-top: 1.5rem;
+}
+
+.desktop-nav-button {
+  display: grid;
+  gap: 0.18rem;
+  text-align: left;
+  padding: 0.95rem 1rem;
+  border-radius: 1.1rem;
+  border: 1px solid rgba(118, 255, 170, 0.14);
+  background: rgba(18, 17, 23, 0.55);
+}
+
+.desktop-nav-button--active {
+  border-color: rgba(118, 255, 170, 0.36);
+  box-shadow: 0 0 22px rgba(118, 255, 170, 0.08);
+}
+
+.desktop-nav-label {
+  font-size: 0.98rem;
+  font-weight: 700;
+  color: #ffffff;
+}
+
+.desktop-workspace-main {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
 .desktop-list {
@@ -108,48 +310,15 @@
   margin-top: 0.8rem;
 }
 
-.desktop-list--ordered li::marker {
-  color: rgb(220 247 234 / 0.88);
-  font-weight: 700;
-}
-
-.desktop-section--sunrise {
-  border-color: rgba(243, 177, 58, 0.28);
-  box-shadow:
-    inset 0 1px 0 rgba(235, 255, 244, 0.04),
-    0 0 0 1px rgba(243, 177, 58, 0.08),
-    0 0 18px rgba(243, 177, 58, 0.12),
-    0 18px 52px rgba(8, 8, 12, 0.34);
-}
-
-.desktop-section--forest {
-  border-color: rgba(118, 255, 170, 0.3);
-}
-
-.desktop-section--ocean {
-  border-color: rgba(77, 117, 244, 0.28);
-  box-shadow:
-    inset 0 1px 0 rgba(235, 255, 244, 0.04),
-    0 0 0 1px rgba(77, 117, 244, 0.08),
-    0 0 18px rgba(77, 117, 244, 0.14),
-    0 18px 52px rgba(8, 8, 12, 0.34);
-}
-
-.desktop-section--slate {
-  border-color: rgba(196, 205, 255, 0.22);
-  box-shadow:
-    inset 0 1px 0 rgba(235, 255, 244, 0.04),
-    0 0 0 1px rgba(196, 205, 255, 0.05),
-    0 0 18px rgba(196, 205, 255, 0.08),
-    0 18px 52px rgba(8, 8, 12, 0.34);
+@media (max-width: 1080px) {
+  .desktop-setup-layout,
+  .desktop-workspace-layout,
+  .desktop-workspace-main {
+    grid-template-columns: 1fr;
+  }
 }
 
 @media (max-width: 960px) {
-  .desktop-info-grid,
-  .desktop-section-grid {
-    grid-template-columns: 1fr;
-  }
-
   .desktop-shell {
     padding: 1rem;
   }
@@ -157,5 +326,15 @@
   .desktop-highlight {
     width: 100%;
     justify-content: space-between;
+  }
+
+  .desktop-action-row {
+    flex-direction: column;
+  }
+
+  .primary-button,
+  .secondary-button,
+  .tertiary-button {
+    width: 100%;
   }
 }

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,8 +1,8 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { invoke } from "@tauri-apps/api/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import App from "./App";
-import type { DesktopShellState } from "./desktop/types";
+import type { SetupGateState } from "./desktop/types";
 
 vi.mock("@tauri-apps/api/core", () => ({
   invoke: vi.fn(),
@@ -10,44 +10,95 @@ vi.mock("@tauri-apps/api/core", () => ({
 
 const invokeMock = vi.mocked(invoke);
 
-const shellStateFixture: DesktopShellState = {
+const missingToolFixture: SetupGateState = {
   appName: "BE Home for Desktop",
   version: "0.1.0",
   platformLabel: "Windows",
-  introEyebrow: "Board installs made easier",
-  introSummary:
-    "Keep your Board install tool ready, choose an APK from your computer, and keep favorite installs close for later.",
-  highlights: [
-    {
-      label: "Manual choice",
-      value: "Always welcome",
+  status: "requiresSetup",
+  requiredStep: "toolSetup",
+  summary: "BE Home still needs to download Board's install tool before the workspace can open.",
+  guidance: "Continue setup and BE Home will download Board's bdb into its managed tools folder for you.",
+  toolState: {
+    status: "missing",
+    summary: "BE Home has not downloaded bdb into the managed tools folder yet.",
+    guidance:
+      "Continue setup and BE Home will download Board's bdb into its managed tools folder for you.",
+    executablePath: "C:\\Users\\Matt\\AppData\\Local\\Board Enthusiasts\\BE Home for Desktop\\tools\\bdb.exe",
+    executableExists: false,
+    storage: {
+      defaultPath: "C:\\Users\\Matt\\AppData\\Local\\Board Enthusiasts\\BE Home for Desktop\\tools",
+      overridePath: null,
+      effectivePath: "C:\\Users\\Matt\\AppData\\Local\\Board Enthusiasts\\BE Home for Desktop\\tools",
+      source: "default",
     },
-  ],
-  gettingStartedTitle: "Keep your next install close and familiar.",
-  gettingStartedSteps: [
-    "Connect your Board with USB when you are ready to install.",
-    "Choose a game or app APK from a folder you already trust.",
-  ],
-  helpTitle: "Built for real player routines",
-  helpSummary: "BE Home keeps the most important install steps in one place so getting back to play feels less scattered.",
-  helpBullets: ["Your BE account stays optional."],
-  sections: [
-    {
-      id: "apk-library",
-      eyebrow: "Choose what to install",
-      title: "Find downloads from familiar folders or your saved library",
-      summary:
-        "Keep Board-ready APKs together, browse what you already downloaded, and pick an APK yourself whenever that is fastest.",
-      tone: "forest",
-      badges: [
-        {
-          label: "Manual choice",
-          value: "Always welcome",
-        },
-      ],
-      bullets: ["Pick any APK yourself when that is the fastest way to move forward."],
+    sourcePlan: {
+      manifestSource: "bundled",
+      remoteManifestUrl: "https://example.com/bdb-sources.json",
+      manifestCachePath: null,
+      manifestSchemaVersion: 1,
+      support: {
+        status: "supported",
+        operatingSystem: "windows",
+        architecture: "x86_64",
+        windowsBuild: 26100,
+        platformKey: "windows-x86_64",
+        reason: null,
+        guidance: "This machine matches a Board-published bdb target.",
+      },
+      source: {
+        platformKey: "windows-x86_64",
+        downloadUrl: "https://example.com/bdb.exe",
+      },
     },
-  ],
+    validation: {
+      status: "missing",
+      command: "bdb help",
+      exitCode: null,
+      summary: "No managed bdb executable is present yet.",
+      detail: null,
+    },
+  },
+  storage: {
+    operatingSystem: "windows",
+    settingsFilePath:
+      "C:\\Users\\Matt\\AppData\\Local\\Board Enthusiasts\\BE Home for Desktop\\settings\\managed-storage.json",
+    bdbTools: {
+      defaultPath: "C:\\Users\\Matt\\AppData\\Local\\Board Enthusiasts\\BE Home for Desktop\\tools",
+      overridePath: null,
+      effectivePath: "C:\\Users\\Matt\\AppData\\Local\\Board Enthusiasts\\BE Home for Desktop\\tools",
+      source: "default",
+    },
+    apkLibrary: {
+      defaultPath:
+        "C:\\Users\\Matt\\AppData\\Local\\Board Enthusiasts\\BE Home for Desktop\\apk-library",
+      overridePath: null,
+      effectivePath:
+        "C:\\Users\\Matt\\AppData\\Local\\Board Enthusiasts\\BE Home for Desktop\\apk-library",
+      source: "default",
+    },
+  },
+  defaultScanFolders: ["C:\\Users\\Matt\\Downloads"],
+};
+
+const runnableFixture: SetupGateState = {
+  ...missingToolFixture,
+  status: "ready",
+  requiredStep: "workspace",
+  summary: "Board's install tool is ready, so BE Home can open your desktop workspace.",
+  guidance: "You can come back to repair the install tool later if anything changes.",
+  toolState: {
+    ...missingToolFixture.toolState,
+    status: "runnable",
+    summary: "Board's install tool is ready to use.",
+    executableExists: true,
+    validation: {
+      status: "runnable",
+      command: "bdb help",
+      exitCode: 0,
+      summary: "BE Home could open bdb from its managed tools folder.",
+      detail: null,
+    },
+  },
 };
 
 describe("App", () => {
@@ -55,22 +106,66 @@ describe("App", () => {
     invokeMock.mockReset();
   });
 
-  it("renders shell content returned by the Tauri host", async () => {
-    invokeMock.mockResolvedValue(shellStateFixture);
+  it("keeps players inside the setup flow when bdb is missing", async () => {
+    invokeMock.mockImplementation(async (command) => {
+      if (command === "load_setup_gate_state") {
+        return missingToolFixture;
+      }
+
+      throw new Error(`Unexpected command: ${command}`);
+    });
 
     render(<App />);
 
     expect(screen.getByText("Opening BE Home for Desktop")).toBeInTheDocument();
-    expect(
-      await screen.findByText("Find downloads from familiar folders or your saved library"),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("heading", { level: 1, name: "BE Home for Desktop" }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText("Pick any APK yourself when that is the fastest way to move forward."),
-    ).toBeInTheDocument();
-    expect(screen.queryByText(/scaffold/i)).not.toBeInTheDocument();
+    expect(await screen.findByText("Get your install workspace ready")).toBeInTheDocument();
+    expect(screen.getByText("Get Board's install tool ready.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Download bdb" })).toBeInTheDocument();
+  });
+
+  it("opens the workspace when bdb is already runnable", async () => {
+    invokeMock.mockImplementation(async (command) => {
+      if (command === "load_setup_gate_state") {
+        return runnableFixture;
+      }
+
+      throw new Error(`Unexpected command: ${command}`);
+    });
+
+    render(<App />);
+
+    expect(await screen.findByText("Your desktop install space is ready")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Device/ })).toBeInTheDocument();
+    expect(screen.getByText("Board's install tool is already checked.")).toBeInTheDocument();
+  });
+
+  it("shows the review-defaults step after a successful bdb download", async () => {
+    let setupGateReads = 0;
+    invokeMock.mockImplementation(async (command) => {
+      if (command === "load_setup_gate_state") {
+        setupGateReads += 1;
+        return setupGateReads === 1 ? missingToolFixture : runnableFixture;
+      }
+
+      if (command === "acquire_bdb_tool") {
+        return {
+          outcome: "downloaded",
+          summary: "BE Home downloaded Board's bdb into the managed tools folder.",
+          guidance: "The managed bdb binary is now runnable.",
+          toolState: runnableFixture.toolState,
+        };
+      }
+
+      throw new Error(`Unexpected command: ${command}`);
+    });
+
+    render(<App />);
+
+    expect(await screen.findByText("Get your install workspace ready")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Download bdb" }));
+
+    expect(await screen.findByText("Review the local defaults BE Home will start with.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Open workspace" })).toBeInTheDocument();
   });
 
   it("shows a friendly host failure message", async () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,33 +1,169 @@
-import { useEffect, useState } from "react";
-import { loadDesktopShellState } from "./desktop/client";
-import type { DesktopShellState, ShellSection } from "./desktop/types";
+import { useEffect, useMemo, useState } from "react";
+import { acquireBdbTool, loadSetupGateState } from "./desktop/client";
+import type {
+  BdbAcquisitionResult,
+  BdbPlatformSupport,
+  ManagedStorageLocation,
+  SetupGateState,
+} from "./desktop/types";
+
+type SetupViewStep = "systemCheck" | "toolSetup" | "reviewDefaults";
+type WorkspaceSectionId = "device" | "apkLibrary" | "installed" | "settings";
+
+interface WorkspaceSection {
+  id: WorkspaceSectionId;
+  label: string;
+  eyebrow: string;
+  title: string;
+  summary: string;
+  bullets: string[];
+}
+
+const workspaceSections: WorkspaceSection[] = [
+  {
+    id: "device",
+    label: "Device",
+    eyebrow: "Board connection",
+    title: "Keep connection checks in one place",
+    summary:
+      "This area becomes your quick read on whether Board is nearby and ready before you try an install.",
+    bullets: [
+      "Check Board connection before you reach for an APK.",
+      "Keep repair and retry guidance close to the status that needs it.",
+      "Stay in the desktop flow instead of jumping into terminal troubleshooting.",
+    ],
+  },
+  {
+    id: "apkLibrary",
+    label: "APK Library",
+    eyebrow: "Local APKs",
+    title: "Bring trusted downloads together",
+    summary:
+      "Use familiar folders and a managed library so reinstalling later takes fewer steps and less guessing.",
+    bullets: [
+      "Start with Downloads and add more folders when your routine needs them.",
+      "Keep Board-ready APKs available in one stable library location.",
+      "Stay flexible when you want to pick a file yourself.",
+    ],
+  },
+  {
+    id: "installed",
+    label: "Installed on Board",
+    eyebrow: "What is already there",
+    title: "Keep current installs easy to review",
+    summary:
+      "Installed titles will live here so uninstall and launch actions stay close to the packages that are already on Board.",
+    bullets: [
+      "See what is already installed before you repeat work.",
+      "Keep uninstall and launch actions near the inventory they affect.",
+      "Refresh Board state without restarting the app.",
+    ],
+  },
+  {
+    id: "settings",
+    label: "Settings",
+    eyebrow: "Your storage routine",
+    title: "Keep folders and storage understandable",
+    summary:
+      "Settings stay focused on the locations that matter so the app still feels friendly without filesystem jargon.",
+    bullets: [
+      "Keep the managed APK library in a place that feels familiar.",
+      "See where Board's install tool lives without digging through app data manually.",
+      "Adjust the folders you want BE Home to pay attention to.",
+    ],
+  },
+];
 
 function App() {
-  const [shellState, setShellState] = useState<DesktopShellState | null>(null);
+  const [setupGateState, setSetupGateState] = useState<SetupGateState | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [setupViewStep, setSetupViewStep] = useState<SetupViewStep>("systemCheck");
+  const [showReviewDefaults, setShowReviewDefaults] = useState(false);
+  const [toolActionState, setToolActionState] = useState<{
+    loading: boolean;
+    message: string | null;
+    detail: string | null;
+    lastOutcome: BdbAcquisitionResult["outcome"] | null;
+  }>({
+    loading: false,
+    message: null,
+    detail: null,
+    lastOutcome: null,
+  });
+  const [activeWorkspaceSection, setActiveWorkspaceSection] =
+    useState<WorkspaceSectionId>("device");
 
   useEffect(() => {
-    let isCancelled = false;
-
-    async function loadState(): Promise<void> {
-      try {
-        const state = await loadDesktopShellState();
-        if (!isCancelled) {
-          setShellState(state);
-        }
-      } catch {
-        if (!isCancelled) {
-          setErrorMessage("We couldn't reach the desktop host just yet. Try reloading the window or restarting the app.");
-        }
-      }
-    }
-
-    void loadState();
-
-    return () => {
-      isCancelled = true;
-    };
+    void refreshSetupGateState();
   }, []);
+
+  const shouldShowSetup =
+    setupGateState !== null &&
+    (setupGateState.status !== "ready" || showReviewDefaults);
+
+  const activeWorkspaceSectionState = useMemo(
+    () => workspaceSections.find((section) => section.id === activeWorkspaceSection) ?? workspaceSections[0],
+    [activeWorkspaceSection],
+  );
+
+  async function refreshSetupGateState(options?: {
+    showReviewDefaultsOnReady?: boolean;
+  }): Promise<void> {
+    try {
+      const state = await loadSetupGateState();
+      setSetupGateState(state);
+      setErrorMessage(null);
+
+      if (options?.showReviewDefaultsOnReady === true && state.status === "ready") {
+        setShowReviewDefaults(true);
+        setSetupViewStep("reviewDefaults");
+        return;
+      }
+
+      if (state.status === "ready") {
+        setShowReviewDefaults(false);
+        return;
+      }
+
+      setShowReviewDefaults(false);
+      setSetupViewStep(state.requiredStep === "toolSetup" ? "toolSetup" : "systemCheck");
+    } catch {
+      setErrorMessage(
+        "We couldn't reach the desktop host just yet. Try reloading the window or restarting the app.",
+      );
+    }
+  }
+
+  async function handleAcquireBdbTool(repair: boolean): Promise<void> {
+    setToolActionState({
+      loading: true,
+      message: null,
+      detail: null,
+      lastOutcome: null,
+    });
+
+    try {
+      const result = await acquireBdbTool(repair);
+      setToolActionState({
+        loading: false,
+        message: result.summary,
+        detail: result.guidance,
+        lastOutcome: result.outcome,
+      });
+      await refreshSetupGateState({
+        showReviewDefaultsOnReady:
+          result.toolState.status === "runnable" &&
+          (result.outcome === "downloaded" || result.outcome === "repaired"),
+      });
+    } catch {
+      setToolActionState({
+        loading: false,
+        message: "BE Home couldn't finish the bdb setup step.",
+        detail: "Please try again in a moment.",
+        lastOutcome: "failed",
+      });
+    }
+  }
 
   if (errorMessage !== null) {
     return (
@@ -43,14 +179,16 @@ function App() {
     );
   }
 
-  if (shellState === null) {
+  if (setupGateState === null) {
     return (
       <main className="page-shell desktop-shell">
         <section className="page-grid narrow">
           <section className="panel desktop-state-card" aria-live="polite">
             <div className="eyebrow">Opening BE Home for Desktop</div>
-            <h2>Just a moment while we get things ready.</h2>
-            <p className="panel-description">We're opening your Board install workspace and checking the desktop connection.</p>
+            <h2>Just a moment while we check your setup.</h2>
+            <p className="panel-description">
+              We're checking whether Board's install tool is ready and whether your desktop workspace can open.
+            </p>
           </section>
         </section>
       </main>
@@ -60,79 +198,407 @@ function App() {
   return (
     <main className="page-shell desktop-shell">
       <section className="page-grid desktop-grid">
-        <section className="hero-panel compact desktop-hero">
-          <div className="hero-copy desktop-hero-copy">
-            <div className="eyebrow">{shellState.introEyebrow}</div>
-            <h1>{shellState.appName}</h1>
-            <p>{shellState.introSummary}</p>
-            <p className="desktop-platform-note">{shellState.platformLabel} desktop · v{shellState.version}</p>
+        <section className="hero-panel desktop-banner">
+          <div className="hero-copy desktop-banner-copy">
+            <div className="eyebrow">BE Home for Desktop</div>
+            <h1>{shouldShowSetup ? "Get your install workspace ready" : "Your desktop install space is ready"}</h1>
+            <p>{setupGateState.summary}</p>
+            <p className="desktop-platform-note">
+              {setupGateState.platformLabel} desktop · v{setupGateState.version}
+            </p>
           </div>
-          <div className="desktop-highlight-row" aria-label="Key install notes">
-            {shellState.highlights.map((highlight) => (
-              <span className="desktop-highlight" key={`${highlight.label}-${highlight.value}`}>
-                <span className="desktop-highlight-label">{highlight.label}</span>
-                <span className="desktop-highlight-value">{highlight.value}</span>
-              </span>
-            ))}
+          <div className="desktop-highlight-row" aria-label="Setup summary">
+            <StatusChip label="Setup" value={statusLabel(setupGateState.status)} />
+            <StatusChip
+              label="Board tool"
+              value={statusLabel(setupGateState.toolState.status)}
+            />
+            <StatusChip
+              label="Managed tool folder"
+              value={locationSourceLabel(setupGateState.toolState.storage)}
+            />
           </div>
         </section>
 
-        <section className="desktop-info-grid" aria-label="Desktop install overview">
-          <article className="panel desktop-panel">
-            <div className="eyebrow">Getting started</div>
-            <h2>{shellState.gettingStartedTitle}</h2>
-            <ol className="desktop-list desktop-list--ordered">
-              {shellState.gettingStartedSteps.map((item) => (
-                <li key={item}>{item}</li>
-              ))}
-            </ol>
-          </article>
-          <article className="panel desktop-panel">
-            <div className="eyebrow">Good to know</div>
-            <h2>{shellState.helpTitle}</h2>
-            <p className="panel-description">{shellState.helpSummary}</p>
-            <ul className="desktop-list">
-              {shellState.helpBullets.map((item) => (
-                <li key={item}>{item}</li>
-              ))}
-            </ul>
-          </article>
-        </section>
+        {shouldShowSetup ? (
+          <section className="desktop-setup-layout">
+            <aside className="panel desktop-stepper" aria-label="Setup steps">
+              <div className="eyebrow">Required setup</div>
+              <h2>Stay inside setup until Board's tool is ready.</h2>
+              <ol className="desktop-step-list">
+                <SetupStepCard
+                  stepNumber={1}
+                  title="Check this computer"
+                  summary="Confirm that this computer matches Board's current download support."
+                  status={describeSetupStepStatus(setupViewStep, "systemCheck")}
+                />
+                <SetupStepCard
+                  stepNumber={2}
+                  title="Get Board's install tool ready"
+                  summary="Download or repair bdb so BE Home can use it without terminal steps."
+                  status={describeSetupStepStatus(setupViewStep, "toolSetup")}
+                />
+                <SetupStepCard
+                  stepNumber={3}
+                  title="Review your local defaults"
+                  summary="See where BE Home starts with scan folders and managed storage before the workspace opens."
+                  status={describeSetupStepStatus(setupViewStep, "reviewDefaults")}
+                />
+              </ol>
+            </aside>
 
-        <section className="desktop-section-grid" aria-label="What BE Home for Desktop keeps in one place">
-          {shellState.sections.map((section) => (
-            <SectionCard key={section.id} section={section} />
-          ))}
-        </section>
+            <section className="panel desktop-setup-panel" aria-live="polite">
+              {setupViewStep === "systemCheck" ? (
+                <SystemCheckStep
+                  setupGateState={setupGateState}
+                  onContinue={() => setSetupViewStep("toolSetup")}
+                  onRefresh={() => void refreshSetupGateState()}
+                />
+              ) : null}
+
+              {setupViewStep === "toolSetup" ? (
+                <ToolSetupStep
+                  setupGateState={setupGateState}
+                  toolActionState={toolActionState}
+                  onBack={() => setSetupViewStep("systemCheck")}
+                  onDownload={() => void handleAcquireBdbTool(false)}
+                  onRepair={() => void handleAcquireBdbTool(true)}
+                  onRefresh={() => void refreshSetupGateState()}
+                />
+              ) : null}
+
+              {setupViewStep === "reviewDefaults" ? (
+                <ReviewDefaultsStep
+                  setupGateState={setupGateState}
+                  onOpenWorkspace={() => setShowReviewDefaults(false)}
+                  onBack={() => setSetupViewStep("toolSetup")}
+                />
+              ) : null}
+            </section>
+          </section>
+        ) : (
+          <section className="desktop-workspace-layout">
+            <aside className="panel desktop-nav-panel" aria-label="Workspace navigation">
+              <div className="eyebrow">Workspace</div>
+              <h2>Choose the area you want to keep close.</h2>
+              <nav className="desktop-nav-list">
+                {workspaceSections.map((section) => (
+                  <button
+                    className={
+                      section.id === activeWorkspaceSection
+                        ? "desktop-nav-button desktop-nav-button--active"
+                        : "desktop-nav-button"
+                    }
+                    key={section.id}
+                    onClick={() => setActiveWorkspaceSection(section.id)}
+                    type="button"
+                  >
+                    <span className="desktop-nav-label">{section.label}</span>
+                    <span className="desktop-nav-summary">{section.eyebrow}</span>
+                  </button>
+                ))}
+              </nav>
+            </aside>
+
+            <section className="desktop-workspace-main">
+              <article className="panel desktop-workspace-panel">
+                <div className="eyebrow">{activeWorkspaceSectionState.eyebrow}</div>
+                <h2>{activeWorkspaceSectionState.title}</h2>
+                <p className="panel-description">{activeWorkspaceSectionState.summary}</p>
+                <ul className="desktop-list">
+                  {activeWorkspaceSectionState.bullets.map((item) => (
+                    <li key={`${activeWorkspaceSectionState.id}-${item}`}>{item}</li>
+                  ))}
+                </ul>
+              </article>
+
+              <article className="panel desktop-workspace-panel">
+                <div className="eyebrow">Ready now</div>
+                <h2>Board's install tool is already checked.</h2>
+                <p className="panel-description">{setupGateState.toolState.summary}</p>
+                <dl className="desktop-detail-grid">
+                  <DetailRow
+                    label="Managed bdb location"
+                    value={setupGateState.toolState.executablePath}
+                  />
+                  <DetailRow
+                    label="Managed APK library"
+                    value={setupGateState.storage.apkLibrary.effectivePath}
+                  />
+                  <DetailRow
+                    label="Default scan folder"
+                    value={formatScanFolders(setupGateState.defaultScanFolders)}
+                  />
+                </dl>
+              </article>
+            </section>
+          </section>
+        )}
       </section>
     </main>
   );
 }
 
-interface SectionCardProps {
-  section: ShellSection;
+interface SetupStepCardProps {
+  stepNumber: number;
+  title: string;
+  summary: string;
+  status: "complete" | "active" | "upcoming";
 }
 
-function SectionCard({ section }: SectionCardProps) {
+function SetupStepCard({ stepNumber, title, summary, status }: SetupStepCardProps) {
   return (
-    <article className={`panel desktop-section desktop-section--${section.tone}`}>
-      <div className="eyebrow">{section.eyebrow}</div>
-      <h2>{section.title}</h2>
-      <p className="panel-description">{section.summary}</p>
-      <div className="desktop-badge-row" aria-label={`${section.title} highlights`}>
-        {section.badges.map((badge) => (
-          <span className="status-chip" key={`${section.id}-${badge.label}`}>
-            {badge.label}: {badge.value}
-          </span>
-        ))}
+    <li className={`desktop-step-card desktop-step-card--${status}`}>
+      <span className="desktop-step-number">{stepNumber}</span>
+      <div className="desktop-step-copy">
+        <h3>{title}</h3>
+        <p>{summary}</p>
       </div>
-      <ul className="desktop-list">
-        {section.bullets.map((item) => (
-          <li key={`${section.id}-${item}`}>{item}</li>
-        ))}
-      </ul>
+    </li>
+  );
+}
+
+interface SystemCheckStepProps {
+  setupGateState: SetupGateState;
+  onContinue: () => void;
+  onRefresh: () => void;
+}
+
+function SystemCheckStep({ setupGateState, onContinue, onRefresh }: SystemCheckStepProps) {
+  const support = setupGateState.toolState.sourcePlan.support;
+  const isBlocked = setupGateState.status === "unsupported";
+
+  return (
+    <>
+      <div className="eyebrow">Step 1</div>
+      <h2>Check this computer before downloading anything.</h2>
+      <p className="panel-description">{setupGateState.guidance}</p>
+      <dl className="desktop-detail-grid">
+        <DetailRow label="Support status" value={statusLabel(setupGateState.status)} />
+        <DetailRow label="Operating system" value={support.operatingSystem} />
+        <DetailRow label="Architecture" value={support.architecture} />
+        <DetailRow
+          label="Windows build"
+          value={support.windowsBuild === null ? "Not needed on this platform" : String(support.windowsBuild)}
+        />
+      </dl>
+
+      <StatusSummaryCard
+        title="What BE Home found"
+        summary={setupGateState.toolState.summary}
+        guidance={setupGateState.toolState.guidance}
+      />
+
+      <div className="desktop-action-row">
+        <button className="primary-button" disabled={isBlocked} onClick={onContinue} type="button">
+          Continue to bdb setup
+        </button>
+        <button className="secondary-button" onClick={onRefresh} type="button">
+          Refresh checks
+        </button>
+      </div>
+    </>
+  );
+}
+
+interface ToolSetupStepProps {
+  setupGateState: SetupGateState;
+  toolActionState: {
+    loading: boolean;
+    message: string | null;
+    detail: string | null;
+    lastOutcome: BdbAcquisitionResult["outcome"] | null;
+  };
+  onBack: () => void;
+  onDownload: () => void;
+  onRepair: () => void;
+  onRefresh: () => void;
+}
+
+function ToolSetupStep({
+  setupGateState,
+  toolActionState,
+  onBack,
+  onDownload,
+  onRepair,
+  onRefresh,
+}: ToolSetupStepProps) {
+  const isRepair = setupGateState.toolState.executableExists;
+  const primaryActionLabel = isRepair ? "Repair bdb" : "Download bdb";
+
+  return (
+    <>
+      <div className="eyebrow">Step 2</div>
+      <h2>Get Board's install tool ready.</h2>
+      <p className="panel-description">{setupGateState.toolState.guidance}</p>
+      <dl className="desktop-detail-grid">
+        <DetailRow label="Managed tool folder" value={setupGateState.toolState.storage.effectivePath} />
+        <DetailRow label="Executable path" value={setupGateState.toolState.executablePath} />
+        <DetailRow label="Runnable check" value={statusLabel(setupGateState.toolState.validation.status)} />
+      </dl>
+
+      <StatusSummaryCard
+        title="Current tool state"
+        summary={setupGateState.toolState.summary}
+        guidance={setupGateState.toolState.validation.summary}
+      />
+
+      {toolActionState.message !== null ? (
+        <article
+          className={
+            toolActionState.lastOutcome === "failed"
+              ? "desktop-inline-message desktop-inline-message--warning"
+              : "desktop-inline-message"
+          }
+        >
+          <h3>{toolActionState.message}</h3>
+          {toolActionState.detail !== null ? <p>{toolActionState.detail}</p> : null}
+        </article>
+      ) : null}
+
+      <div className="desktop-action-row">
+        <button
+          className="primary-button"
+          disabled={toolActionState.loading}
+          onClick={isRepair ? onRepair : onDownload}
+          type="button"
+        >
+          {toolActionState.loading ? "Working..." : primaryActionLabel}
+        </button>
+        <button className="secondary-button" disabled={toolActionState.loading} onClick={onRefresh} type="button">
+          Refresh checks
+        </button>
+        <button className="tertiary-button" disabled={toolActionState.loading} onClick={onBack} type="button">
+          Back
+        </button>
+      </div>
+    </>
+  );
+}
+
+interface ReviewDefaultsStepProps {
+  setupGateState: SetupGateState;
+  onOpenWorkspace: () => void;
+  onBack: () => void;
+}
+
+function ReviewDefaultsStep({ setupGateState, onOpenWorkspace, onBack }: ReviewDefaultsStepProps) {
+  return (
+    <>
+      <div className="eyebrow">Step 3</div>
+      <h2>Review the local defaults BE Home will start with.</h2>
+      <p className="panel-description">
+        You can change these locations later, but this is the familiar starting point BE Home will use today.
+      </p>
+      <dl className="desktop-detail-grid">
+        <DetailRow label="Managed bdb folder" value={setupGateState.storage.bdbTools.effectivePath} />
+        <DetailRow label="Managed APK library" value={setupGateState.storage.apkLibrary.effectivePath} />
+        <DetailRow label="Default scan folder" value={formatScanFolders(setupGateState.defaultScanFolders)} />
+      </dl>
+      <div className="desktop-action-row">
+        <button className="primary-button" onClick={onOpenWorkspace} type="button">
+          Open workspace
+        </button>
+        <button className="tertiary-button" onClick={onBack} type="button">
+          Back
+        </button>
+      </div>
+    </>
+  );
+}
+
+interface DetailRowProps {
+  label: string;
+  value: string;
+}
+
+function DetailRow({ label, value }: DetailRowProps) {
+  return (
+    <div className="desktop-detail-row">
+      <dt>{label}</dt>
+      <dd>{value}</dd>
+    </div>
+  );
+}
+
+interface StatusSummaryCardProps {
+  title: string;
+  summary: string;
+  guidance: string;
+}
+
+function StatusSummaryCard({ title, summary, guidance }: StatusSummaryCardProps) {
+  return (
+    <article className="desktop-inline-card">
+      <h3>{title}</h3>
+      <p>{summary}</p>
+      <p>{guidance}</p>
     </article>
   );
+}
+
+interface StatusChipProps {
+  label: string;
+  value: string;
+}
+
+function StatusChip({ label, value }: StatusChipProps) {
+  return (
+    <span className="desktop-highlight">
+      <span className="desktop-highlight-label">{label}</span>
+      <span className="desktop-highlight-value">{value}</span>
+    </span>
+  );
+}
+
+function describeSetupStepStatus(
+  currentStep: SetupViewStep,
+  targetStep: SetupViewStep,
+): "complete" | "active" | "upcoming" {
+  const order: SetupViewStep[] = ["systemCheck", "toolSetup", "reviewDefaults"];
+  const currentIndex = order.indexOf(currentStep);
+  const targetIndex = order.indexOf(targetStep);
+
+  if (currentIndex === targetIndex) {
+    return "active";
+  }
+
+  return currentIndex > targetIndex ? "complete" : "upcoming";
+}
+
+function formatScanFolders(scanFolders: string[]): string {
+  return scanFolders.length === 0 ? "Downloads will be added when BE Home can resolve them on this computer." : scanFolders.join(", ");
+}
+
+function statusLabel(value: SetupGateState["status"] | SetupGateState["toolState"]["status"] | SetupGateState["toolState"]["validation"]["status"]): string {
+  switch (value) {
+    case "requiresSetup":
+      return "Needs setup";
+    case "ready":
+      return "Ready";
+    case "unsupported":
+      return "Unsupported";
+    case "missing":
+      return "Missing";
+    case "downloaded":
+      return "Needs repair";
+    case "runnable":
+      return "Runnable";
+    case "blocked":
+      return "Blocked";
+    default:
+      return value;
+  }
+}
+
+function locationSourceLabel(location: ManagedStorageLocation): string {
+  return location.source === "override" ? "Custom location" : "App default";
+}
+
+export function supportStatusSummary(support: BdbPlatformSupport): string {
+  return support.status === "supported"
+    ? "This computer matches one of Board's current install-tool downloads."
+    : support.guidance;
 }
 
 export default App;

--- a/src/desktop/client.ts
+++ b/src/desktop/client.ts
@@ -3,16 +3,16 @@ import type {
   BdbAcquisitionResult,
   BdbSourcePlan,
   BdbToolState,
-  DesktopShellState,
   ManagedStorageOverridesInput,
   ManagedStorageSettings,
+  SetupGateState,
 } from "./types";
 
 /**
- * Loads the current desktop shell state from the Rust host.
+ * Loads the current setup gate state from the Rust host.
  */
-export function loadDesktopShellState(): Promise<DesktopShellState> {
-  return invoke<DesktopShellState>("load_shell_state");
+export function loadSetupGateState(): Promise<SetupGateState> {
+  return invoke<SetupGateState>("load_setup_gate_state");
 }
 
 /**

--- a/src/desktop/types.ts
+++ b/src/desktop/types.ts
@@ -1,45 +1,27 @@
 /**
- * Allowed accent families for a dashboard section card.
+ * Describes whether the app must keep the player inside setup before opening the workspace.
  */
-export type ShellTone = "sunrise" | "forest" | "ocean" | "slate";
+export type SetupGateStatus = "requiresSetup" | "ready" | "unsupported";
 
 /**
- * Describes a small status badge shown inside a dashboard section.
+ * Describes the setup step that should be active based on current host state.
  */
-export interface ShellBadge {
-  label: string;
-  value: string;
-}
+export type SetupRequiredStep = "systemCheck" | "toolSetup" | "workspace";
 
 /**
- * Describes one major workflow area in the desktop shell.
+ * Describes the stable setup-gate contract returned by the desktop host.
  */
-export interface ShellSection {
-  id: string;
-  eyebrow: string;
-  title: string;
-  summary: string;
-  tone: ShellTone;
-  badges: ShellBadge[];
-  bullets: string[];
-}
-
-/**
- * Describes the dashboard content returned by the Tauri host during app bootstrap.
- */
-export interface DesktopShellState {
+export interface SetupGateState {
   appName: string;
   version: string;
   platformLabel: string;
-  introEyebrow: string;
-  introSummary: string;
-  highlights: ShellBadge[];
-  gettingStartedTitle: string;
-  gettingStartedSteps: string[];
-  helpTitle: string;
-  helpSummary: string;
-  helpBullets: string[];
-  sections: ShellSection[];
+  status: SetupGateStatus;
+  requiredStep: SetupRequiredStep;
+  summary: string;
+  guidance: string;
+  toolState: BdbToolState;
+  storage: ManagedStorageSettings;
+  defaultScanFolders: string[];
 }
 
 /**


### PR DESCRIPTION
## Summary
- replace the marketing-only shell with a required first-run setup experience
- add a typed setup-gate host contract that decides whether the workspace can open
- keep the workspace gated until the managed `bdb` tool is runnable, then open the new workspace shell

## Testing
- `npm run build`
- `npm run test`

Closes #14