### PR TITLE
Add desktop settings for folders and storage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@tauri-apps/api": "^2.10.1",
+        "@tauri-apps/plugin-dialog": "^2.7.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
       },
@@ -1811,6 +1812,15 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-dialog": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-dialog/-/plugin-dialog-2.7.0.tgz",
+      "integrity": "sha512-4nS/hfGMGCXiAS3LtVjH9AgsSAPJeG/7R+q8agTFqytjnMa4Zq95Bq8WzVDkckpanX+yyRHXnRtrKXkANKDHvw==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.10.1"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@tauri-apps/api": "^2.10.1",
+    "@tauri-apps/plugin-dialog": "^2.7.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -103,6 +103,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-dialog",
  "tempfile",
 ]
 
@@ -2070,6 +2071,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.1",
  "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2867,6 +2869,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3652,6 +3678,65 @@ dependencies = [
  "syn 2.0.117",
  "tauri-codegen",
  "tauri-utils",
+]
+
+[[package]]
+name = "tauri-plugin"
+version = "2.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddde7d51c907b940fb573006cdda9a642d6a7c8153657e88f8a5c3c9290cd4aa"
+dependencies = [
+ "anyhow",
+ "glob",
+ "plist",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "tauri-utils",
+ "toml 0.9.12+spec-1.1.0",
+ "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-dialog"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1fa4150c95ae391946cc8b8f905ab14797427caba3a8a2f79628e956da91809"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.18",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36e1ec28b79f3d0683f4507e1615c36292c0ea6716668770d4396b9b39871ed8"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "log",
+ "objc2-foundation",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "toml 0.9.12+spec-1.1.0",
+ "url",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -17,6 +17,7 @@ reqwest = { version = "0.12", default-features = false, features = ["blocking", 
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tauri = { version = "2", features = [] }
+tauri-plugin-dialog = "2"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -4,6 +4,7 @@
   "description": "Capability for the main window",
   "windows": ["main"],
   "permissions": [
-    "core:default"
+    "core:default",
+    "dialog:default"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -29,23 +29,38 @@ fn load_managed_storage_settings() -> Result<storage::ManagedStorageSettings, St
 }
 
 #[tauri::command]
+fn load_desktop_settings() -> Result<storage::DesktopSettings, String> {
+    storage::load_desktop_settings()
+}
+
+#[tauri::command]
 fn save_managed_storage_settings(
     overrides: storage::ManagedStorageOverridesInput,
 ) -> Result<storage::ManagedStorageSettings, String> {
     storage::save_managed_storage_settings(overrides)
 }
 
+#[tauri::command]
+fn save_desktop_settings(
+    input: storage::DesktopSettingsInput,
+) -> Result<storage::DesktopSettings, String> {
+    storage::save_desktop_settings(input)
+}
+
 /// Starts the Tauri desktop host for BE Home for Desktop.
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
+        .plugin(tauri_plugin_dialog::init())
         .invoke_handler(tauri::generate_handler![
             load_setup_gate_state,
             load_bdb_source_plan,
             load_bdb_tool_state,
             acquire_bdb_tool,
             load_managed_storage_settings,
-            save_managed_storage_settings
+            load_desktop_settings,
+            save_managed_storage_settings,
+            save_desktop_settings
         ])
         .run(tauri::generate_context!())
         .expect("error while running BE Home for Desktop");
@@ -103,6 +118,15 @@ mod tests {
             .get("apkLibrary")
             .and_then(|value| value.get("effectivePath"))
             .is_some());
+    }
+
+    #[test]
+    fn desktop_settings_serialize_with_scan_folders_and_bdb_path() {
+        let settings = super::load_desktop_settings().expect("desktop settings should load");
+        let serialized = serde_json::to_value(settings).expect("desktop settings should serialize");
+
+        assert!(serialized.get("scanFolders").is_some());
+        assert!(serialized.get("bdbExecutablePath").is_some());
     }
 
     #[test]

--- a/src-tauri/src/setup.rs
+++ b/src-tauri/src/setup.rs
@@ -1,11 +1,7 @@
 use crate::{bdb_tool, storage};
 use serde::Serialize;
-use std::collections::BTreeMap;
-use std::ffi::OsString;
-use std::path::PathBuf;
 
 const APP_NAME: &str = "BE Home for Desktop";
-const DOWNLOADS_DIRECTORY_NAME: &str = "Downloads";
 
 /// Describes whether the app must keep the player inside setup before opening the workspace.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
@@ -43,13 +39,22 @@ pub(crate) struct SetupGateState {
 
 /// Load the current setup-gate state used to decide whether the app can open the workspace.
 pub(crate) fn load_setup_gate_state() -> Result<SetupGateState, String> {
-    let storage = storage::load_managed_storage_settings()?;
+    let desktop_settings = storage::load_desktop_settings()?;
     let tool_state = bdb_tool::load_current_bdb_tool_state()?;
 
     Ok(build_setup_gate_state(
         tool_state,
-        storage,
-        resolve_default_scan_folders(),
+        storage::ManagedStorageSettings {
+            operating_system: desktop_settings.operating_system,
+            settings_file_path: desktop_settings.settings_file_path.clone(),
+            bdb_tools: desktop_settings.bdb_tools.clone(),
+            apk_library: desktop_settings.apk_library.clone(),
+        },
+        desktop_settings
+            .scan_folders
+            .iter()
+            .map(|folder| folder.path.clone())
+            .collect(),
     ))
 }
 
@@ -102,65 +107,6 @@ fn build_setup_gate_state(
     }
 }
 
-fn resolve_default_scan_folders() -> Vec<String> {
-    resolve_default_scan_folders_from_environment(&std::env::vars_os().collect::<BTreeMap<_, _>>())
-}
-
-fn resolve_default_scan_folders_from_environment(
-    environment: &BTreeMap<OsString, OsString>,
-) -> Vec<String> {
-    let mut folders = Vec::new();
-    if let Some(home_directory) = resolve_home_directory(environment) {
-        folders.push(
-            home_directory
-                .join(DOWNLOADS_DIRECTORY_NAME)
-                .to_string_lossy()
-                .into_owned(),
-        );
-    }
-
-    folders
-}
-
-fn resolve_home_directory(environment: &BTreeMap<OsString, OsString>) -> Option<PathBuf> {
-    #[cfg(target_os = "windows")]
-    {
-        lookup_environment_value(environment, "USERPROFILE")
-            .or_else(|| {
-                let drive = lookup_environment_value(environment, "HOMEDRIVE")?;
-                let path = lookup_environment_value(environment, "HOMEPATH")?;
-                Some(format!("{}{}", drive.to_string_lossy(), path.to_string_lossy()).into())
-            })
-            .map(PathBuf::from)
-            .filter(|path| !path.as_os_str().is_empty())
-    }
-
-    #[cfg(not(target_os = "windows"))]
-    {
-        lookup_environment_value(environment, "HOME")
-            .map(PathBuf::from)
-            .filter(|path| !path.as_os_str().is_empty())
-    }
-}
-
-fn lookup_environment_value(
-    environment: &BTreeMap<OsString, OsString>,
-    key: &str,
-) -> Option<OsString> {
-    #[cfg(target_os = "windows")]
-    {
-        environment
-            .iter()
-            .find(|(candidate, _)| candidate.to_string_lossy().eq_ignore_ascii_case(key))
-            .map(|(_, value)| value.clone())
-    }
-
-    #[cfg(not(target_os = "windows"))]
-    {
-        environment.get(&OsString::from(key)).cloned()
-    }
-}
-
 fn current_platform_label() -> &'static str {
     if cfg!(target_os = "windows") {
         "Windows"
@@ -175,10 +121,7 @@ fn current_platform_label() -> &'static str {
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        build_setup_gate_state, resolve_default_scan_folders_from_environment, SetupGateStatus,
-        SetupRequiredStep,
-    };
+    use super::{build_setup_gate_state, SetupGateStatus, SetupRequiredStep};
     use crate::{
         bdb::{
             BdbArchitecture, BdbDownloadSource, BdbOperatingSystem, BdbPlatformSupport,
@@ -190,9 +133,6 @@ mod tests {
             StorageOperatingSystem,
         },
     };
-    use std::collections::BTreeMap;
-    use std::ffi::OsString;
-
     #[test]
     fn missing_tool_requires_setup_download_step() {
         let state = build_setup_gate_state(
@@ -227,31 +167,6 @@ mod tests {
 
         assert_eq!(SetupGateStatus::Unsupported, state.status);
         assert_eq!(SetupRequiredStep::SystemCheck, state.required_step);
-    }
-
-    #[cfg(target_os = "windows")]
-    #[test]
-    fn windows_scan_folder_defaults_use_user_profile() {
-        let mut environment = BTreeMap::new();
-        environment.insert(
-            OsString::from("USERPROFILE"),
-            OsString::from(r"C:\Users\matt"),
-        );
-
-        let folders = resolve_default_scan_folders_from_environment(&environment);
-
-        assert_eq!(vec![r"C:\Users\matt\Downloads".to_string()], folders);
-    }
-
-    #[cfg(not(target_os = "windows"))]
-    #[test]
-    fn unix_scan_folder_defaults_use_home_downloads() {
-        let mut environment = BTreeMap::new();
-        environment.insert(OsString::from("HOME"), OsString::from("/home/matt"));
-
-        let folders = resolve_default_scan_folders_from_environment(&environment);
-
-        assert_eq!(vec!["/home/matt/Downloads".to_string()], folders);
     }
 
     fn sample_tool_state(

--- a/src-tauri/src/storage.rs
+++ b/src-tauri/src/storage.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::ffi::OsString;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -7,6 +7,7 @@ use std::path::{Path, PathBuf};
 const APP_VENDOR_DIRECTORY: &str = "Board Enthusiasts";
 const APP_PRODUCT_DIRECTORY: &str = "BE Home for Desktop";
 const APK_LIBRARY_DIRECTORY: &str = "apk-library";
+const DOWNLOADS_DIRECTORY: &str = "Downloads";
 const SETTINGS_DIRECTORY: &str = "settings";
 const STORAGE_SETTINGS_FILE_NAME: &str = "managed-storage.json";
 const TOOLS_DIRECTORY: &str = "tools";
@@ -28,6 +29,14 @@ pub(crate) enum ManagedStoragePathSource {
     Override,
 }
 
+/// Describes whether a scan folder is part of the app defaults or was added later.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) enum ConfiguredScanFolderSource {
+    Default,
+    Custom,
+}
+
 /// Describes one managed storage location and how its current path was chosen.
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -36,6 +45,14 @@ pub(crate) struct ManagedStorageLocation {
     pub(crate) override_path: Option<String>,
     pub(crate) effective_path: String,
     pub(crate) source: ManagedStoragePathSource,
+}
+
+/// Describes one active scan folder in the desktop settings model.
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ConfiguredScanFolder {
+    pub(crate) path: String,
+    pub(crate) source: ConfiguredScanFolderSource,
 }
 
 /// Describes the current managed storage configuration for the desktop app.
@@ -48,6 +65,18 @@ pub(crate) struct ManagedStorageSettings {
     pub(crate) apk_library: ManagedStorageLocation,
 }
 
+/// Describes the player-facing desktop settings model.
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct DesktopSettings {
+    pub(crate) operating_system: StorageOperatingSystem,
+    pub(crate) settings_file_path: String,
+    pub(crate) bdb_tools: ManagedStorageLocation,
+    pub(crate) apk_library: ManagedStorageLocation,
+    pub(crate) bdb_executable_path: String,
+    pub(crate) scan_folders: Vec<ConfiguredScanFolder>,
+}
+
 /// Represents the persisted override payload accepted by the desktop host.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -56,11 +85,20 @@ pub(crate) struct ManagedStorageOverridesInput {
     apk_library_override: Option<String>,
 }
 
+/// Represents the desktop-settings payload accepted by the host.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct DesktopSettingsInput {
+    apk_library_override: Option<String>,
+    scan_folder_paths: Vec<String>,
+}
+
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
-struct PersistedManagedStorageOverrides {
+struct PersistedDesktopSettings {
     bdb_tools_override: Option<String>,
     apk_library_override: Option<String>,
+    scan_folder_paths: Option<Vec<String>>,
 }
 
 #[derive(Clone, Debug)]
@@ -68,13 +106,21 @@ struct ManagedStorageContext {
     operating_system: StorageOperatingSystem,
     app_data_root: PathBuf,
     settings_file_path: PathBuf,
+    home_directory: Option<PathBuf>,
 }
 
 /// Load the current managed storage settings for the desktop app.
 pub(crate) fn load_managed_storage_settings() -> Result<ManagedStorageSettings, String> {
     let context = current_storage_context()?;
-    let persisted = load_persisted_overrides(&context.settings_file_path)?;
+    let persisted = load_persisted_settings(&context.settings_file_path)?;
     Ok(build_managed_storage_settings(&context, &persisted))
+}
+
+/// Load the player-facing desktop settings for the desktop app.
+pub(crate) fn load_desktop_settings() -> Result<DesktopSettings, String> {
+    let context = current_storage_context()?;
+    let persisted = load_persisted_settings(&context.settings_file_path)?;
+    Ok(build_desktop_settings(&context, &persisted))
 }
 
 /// Resolve the app-owned root directory used for desktop settings, tools, and cached files.
@@ -87,18 +133,30 @@ pub(crate) fn save_managed_storage_settings(
     input: ManagedStorageOverridesInput,
 ) -> Result<ManagedStorageSettings, String> {
     let context = current_storage_context()?;
-    let persisted = PersistedManagedStorageOverrides {
-        bdb_tools_override: normalize_override(input.bdb_tools_override)?,
-        apk_library_override: normalize_override(input.apk_library_override)?,
-    };
+    let mut persisted = load_persisted_settings(&context.settings_file_path)?;
+    persisted.bdb_tools_override = normalize_override(input.bdb_tools_override)?;
+    persisted.apk_library_override = normalize_override(input.apk_library_override)?;
 
-    save_persisted_overrides(&context.settings_file_path, &persisted)?;
+    save_persisted_settings(&context.settings_file_path, &persisted)?;
     Ok(build_managed_storage_settings(&context, &persisted))
+}
+
+/// Save the player-facing desktop settings and return the updated effective model.
+pub(crate) fn save_desktop_settings(
+    input: DesktopSettingsInput,
+) -> Result<DesktopSettings, String> {
+    let context = current_storage_context()?;
+    let mut persisted = load_persisted_settings(&context.settings_file_path)?;
+    persisted.apk_library_override = normalize_override(input.apk_library_override)?;
+    persisted.scan_folder_paths = Some(normalize_scan_folder_paths(input.scan_folder_paths)?);
+
+    save_persisted_settings(&context.settings_file_path, &persisted)?;
+    Ok(build_desktop_settings(&context, &persisted))
 }
 
 fn build_managed_storage_settings(
     context: &ManagedStorageContext,
-    persisted: &PersistedManagedStorageOverrides,
+    persisted: &PersistedDesktopSettings,
 ) -> ManagedStorageSettings {
     let default_bdb_tools_path = context.app_data_root.join(TOOLS_DIRECTORY);
     let default_apk_library_path = context.app_data_root.join(APK_LIBRARY_DIRECTORY);
@@ -110,6 +168,21 @@ fn build_managed_storage_settings(
         settings_file_path: path_to_string(&context.settings_file_path),
         bdb_tools: build_location(default_bdb_tools_path, bdb_tools_override),
         apk_library: build_location(default_apk_library_path, apk_library_override),
+    }
+}
+
+fn build_desktop_settings(
+    context: &ManagedStorageContext,
+    persisted: &PersistedDesktopSettings,
+) -> DesktopSettings {
+    let managed_storage = build_managed_storage_settings(context, persisted);
+    DesktopSettings {
+        operating_system: managed_storage.operating_system,
+        settings_file_path: managed_storage.settings_file_path.clone(),
+        bdb_tools: managed_storage.bdb_tools.clone(),
+        apk_library: managed_storage.apk_library.clone(),
+        bdb_executable_path: resolve_bdb_executable_path(&managed_storage.bdb_tools),
+        scan_folders: build_scan_folders(context, persisted),
     }
 }
 
@@ -131,8 +204,63 @@ fn build_location(default_path: PathBuf, override_path: Option<String>) -> Manag
     }
 }
 
+fn build_scan_folders(
+    context: &ManagedStorageContext,
+    persisted: &PersistedDesktopSettings,
+) -> Vec<ConfiguredScanFolder> {
+    let default_paths = default_scan_folder_paths(context)
+        .into_iter()
+        .map(|path| path_to_string(&path))
+        .collect::<Vec<_>>();
+    let default_keys = default_paths
+        .iter()
+        .map(|path| path_identity_key(path))
+        .collect::<BTreeSet<_>>();
+    let effective_paths = persisted
+        .scan_folder_paths
+        .as_ref()
+        .map(|paths| normalize_loaded_scan_folder_paths(paths.as_slice()))
+        .unwrap_or(default_paths);
+
+    effective_paths
+        .into_iter()
+        .map(|path| ConfiguredScanFolder {
+            source: if default_keys.contains(&path_identity_key(&path)) {
+                ConfiguredScanFolderSource::Default
+            } else {
+                ConfiguredScanFolderSource::Custom
+            },
+            path,
+        })
+        .collect()
+}
+
+fn default_scan_folder_paths(context: &ManagedStorageContext) -> Vec<PathBuf> {
+    context
+        .home_directory
+        .as_ref()
+        .map(|home_directory| vec![home_directory.join(DOWNLOADS_DIRECTORY)])
+        .unwrap_or_default()
+}
+
 fn normalize_loaded_override(value: Option<&str>) -> Option<String> {
     normalize_override(value.map(str::to_owned)).ok().flatten()
+}
+
+fn normalize_loaded_scan_folder_paths(values: &[String]) -> Vec<String> {
+    let mut normalized = Vec::new();
+    let mut seen = BTreeSet::new();
+
+    for value in values {
+        if let Ok(Some(path)) = normalize_override(Some(value.clone())) {
+            let key = path_identity_key(&path);
+            if seen.insert(key) {
+                normalized.push(path);
+            }
+        }
+    }
+
+    normalized
 }
 
 fn current_storage_context() -> Result<ManagedStorageContext, String> {
@@ -155,6 +283,7 @@ fn current_storage_context_from_environment(
                 .join(APP_PRODUCT_DIRECTORY)
                 .join(SETTINGS_DIRECTORY)
                 .join(STORAGE_SETTINGS_FILE_NAME),
+            home_directory: resolve_home_directory(environment),
         });
     }
 
@@ -171,6 +300,7 @@ fn current_storage_context_from_environment(
                 .join(SETTINGS_DIRECTORY)
                 .join(STORAGE_SETTINGS_FILE_NAME),
             app_data_root: root,
+            home_directory: Some(home_directory),
         });
     }
 
@@ -185,6 +315,7 @@ fn current_storage_context_from_environment(
             .join(SETTINGS_DIRECTORY)
             .join(STORAGE_SETTINGS_FILE_NAME),
         app_data_root: root,
+        home_directory: Some(home_directory),
     })
 }
 
@@ -200,6 +331,27 @@ fn require_environment_path(
                 "The desktop app could not resolve its managed storage defaults because the `{key}` environment variable was unavailable."
             )
         })
+}
+
+fn resolve_home_directory(environment: &BTreeMap<OsString, OsString>) -> Option<PathBuf> {
+    #[cfg(target_os = "windows")]
+    {
+        lookup_environment_value(environment, "USERPROFILE")
+            .or_else(|| {
+                let drive = lookup_environment_value(environment, "HOMEDRIVE")?;
+                let path = lookup_environment_value(environment, "HOMEPATH")?;
+                Some(format!("{}{}", drive.to_string_lossy(), path.to_string_lossy()).into())
+            })
+            .map(PathBuf::from)
+            .filter(|path| !path.as_os_str().is_empty())
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        lookup_environment_value(environment, "HOME")
+            .map(PathBuf::from)
+            .filter(|path| !path.as_os_str().is_empty())
+    }
 }
 
 fn lookup_environment_value(
@@ -220,11 +372,9 @@ fn lookup_environment_value(
     }
 }
 
-fn load_persisted_overrides(
-    settings_file_path: &Path,
-) -> Result<PersistedManagedStorageOverrides, String> {
+fn load_persisted_settings(settings_file_path: &Path) -> Result<PersistedDesktopSettings, String> {
     if !settings_file_path.exists() {
-        return Ok(PersistedManagedStorageOverrides::default());
+        return Ok(PersistedDesktopSettings::default());
     }
 
     let content = fs::read_to_string(settings_file_path).map_err(|error| {
@@ -242,9 +392,9 @@ fn load_persisted_overrides(
     })
 }
 
-fn save_persisted_overrides(
+fn save_persisted_settings(
     settings_file_path: &Path,
-    overrides: &PersistedManagedStorageOverrides,
+    persisted: &PersistedDesktopSettings,
 ) -> Result<(), String> {
     if let Some(parent) = settings_file_path.parent() {
         fs::create_dir_all(parent).map_err(|error| {
@@ -255,8 +405,8 @@ fn save_persisted_overrides(
         })?;
     }
 
-    let content = serde_json::to_string_pretty(overrides)
-        .expect("managed storage overrides should serialize");
+    let content =
+        serde_json::to_string_pretty(persisted).expect("desktop settings should serialize");
     fs::write(settings_file_path, content).map_err(|error| {
         format!(
             "The desktop app could not save its managed storage settings file at `{}`: {error}",
@@ -285,6 +435,50 @@ fn normalize_override(value: Option<String>) -> Result<Option<String>, String> {
     Ok(Some(path_to_string(&path)))
 }
 
+fn normalize_scan_folder_paths(values: Vec<String>) -> Result<Vec<String>, String> {
+    let mut normalized = Vec::new();
+    let mut seen = BTreeSet::new();
+
+    for value in values {
+        let Some(path) = normalize_override(Some(value))? else {
+            continue;
+        };
+        let key = path_identity_key(&path);
+        if seen.insert(key) {
+            normalized.push(path);
+        }
+    }
+
+    Ok(normalized)
+}
+
+fn path_identity_key(path: &str) -> String {
+    #[cfg(target_os = "windows")]
+    {
+        path.to_lowercase()
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        path.to_string()
+    }
+}
+
+fn resolve_bdb_executable_path(location: &ManagedStorageLocation) -> String {
+    PathBuf::from(&location.effective_path)
+        .join(bdb_executable_file_name())
+        .to_string_lossy()
+        .into_owned()
+}
+
+fn bdb_executable_file_name() -> &'static str {
+    if cfg!(target_os = "windows") {
+        "bdb.exe"
+    } else {
+        "bdb"
+    }
+}
+
 fn path_to_string(path: &Path) -> String {
     path.to_string_lossy().into_owned()
 }
@@ -292,13 +486,15 @@ fn path_to_string(path: &Path) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        build_managed_storage_settings, current_storage_context_from_environment,
-        load_persisted_overrides, normalize_override, save_persisted_overrides,
-        ManagedStorageContext, PersistedManagedStorageOverrides, StorageOperatingSystem,
+        build_desktop_settings, build_managed_storage_settings,
+        current_storage_context_from_environment, load_persisted_settings, normalize_override,
+        normalize_scan_folder_paths, save_desktop_settings, save_managed_storage_settings,
+        save_persisted_settings, DesktopSettingsInput, ManagedStorageContext,
+        ManagedStorageOverridesInput, PersistedDesktopSettings, StorageOperatingSystem,
     };
     use std::collections::BTreeMap;
     use std::ffi::OsString;
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
 
     fn sample_tools_override_path() -> String {
         if cfg!(target_os = "windows") {
@@ -316,6 +512,14 @@ mod tests {
         }
     }
 
+    fn sample_scan_folder_path() -> String {
+        if cfg!(target_os = "windows") {
+            r"C:\Users\matt\Games".into()
+        } else {
+            "/home/matt/Games".into()
+        }
+    }
+
     #[cfg(target_os = "windows")]
     #[test]
     fn windows_defaults_use_local_app_data() {
@@ -323,6 +527,10 @@ mod tests {
         environment.insert(
             OsString::from("LOCALAPPDATA"),
             OsString::from(r"C:\Users\matt\AppData\Local"),
+        );
+        environment.insert(
+            OsString::from("USERPROFILE"),
+            OsString::from(r"C:\Users\matt"),
         );
 
         let context = current_storage_context_from_environment(&environment)
@@ -335,12 +543,9 @@ mod tests {
                 .join("BE Home for Desktop")
                 .join("tools"),
             PathBuf::from(
-                build_managed_storage_settings(
-                    &context,
-                    &PersistedManagedStorageOverrides::default(),
-                )
-                .bdb_tools
-                .effective_path
+                build_managed_storage_settings(&context, &PersistedDesktopSettings::default(),)
+                    .bdb_tools
+                    .effective_path
             )
         );
     }
@@ -353,6 +558,10 @@ mod tests {
             OsString::from("LocalAppData"),
             OsString::from(r"C:\Users\matt\AppData\Local"),
         );
+        environment.insert(
+            OsString::from("UserProfile"),
+            OsString::from(r"C:\Users\matt"),
+        );
 
         let context = current_storage_context_from_environment(&environment)
             .expect("windows context should resolve");
@@ -364,12 +573,9 @@ mod tests {
                 .join("BE Home for Desktop")
                 .join("tools"),
             PathBuf::from(
-                build_managed_storage_settings(
-                    &context,
-                    &PersistedManagedStorageOverrides::default(),
-                )
-                .bdb_tools
-                .effective_path
+                build_managed_storage_settings(&context, &PersistedDesktopSettings::default(),)
+                    .bdb_tools
+                    .effective_path
             )
         );
     }
@@ -392,12 +598,9 @@ mod tests {
                 .join("BE Home for Desktop")
                 .join("apk-library"),
             PathBuf::from(
-                build_managed_storage_settings(
-                    &context,
-                    &PersistedManagedStorageOverrides::default(),
-                )
-                .apk_library
-                .effective_path
+                build_managed_storage_settings(&context, &PersistedDesktopSettings::default(),)
+                    .apk_library
+                    .effective_path
             )
         );
     }
@@ -420,12 +623,9 @@ mod tests {
                 .join("BE Home for Desktop")
                 .join("tools"),
             PathBuf::from(
-                build_managed_storage_settings(
-                    &context,
-                    &PersistedManagedStorageOverrides::default(),
-                )
-                .bdb_tools
-                .effective_path
+                build_managed_storage_settings(&context, &PersistedDesktopSettings::default(),)
+                    .bdb_tools
+                    .effective_path
             )
         );
     }
@@ -438,24 +638,25 @@ mod tests {
     }
 
     #[test]
+    fn scan_folder_paths_must_be_absolute() {
+        let result = normalize_scan_folder_paths(vec!["relative/path".into()]);
+
+        assert!(result.is_err());
+    }
+
+    #[test]
     fn round_tripped_overrides_preserve_effective_paths() {
         let temp_directory = tempfile::tempdir().expect("temporary directory should exist");
-        let context = ManagedStorageContext {
-            operating_system: StorageOperatingSystem::Linux,
-            app_data_root: temp_directory.path().join("app-data"),
-            settings_file_path: temp_directory
-                .path()
-                .join("settings")
-                .join("managed-storage.json"),
-        };
-        let overrides = PersistedManagedStorageOverrides {
+        let context = sample_context(temp_directory.path());
+        let persisted = PersistedDesktopSettings {
             bdb_tools_override: Some(sample_tools_override_path()),
             apk_library_override: Some(sample_apk_library_override_path()),
+            scan_folder_paths: Some(vec![sample_scan_folder_path()]),
         };
 
-        save_persisted_overrides(&context.settings_file_path, &overrides)
+        save_persisted_settings(&context.settings_file_path, &persisted)
             .expect("settings file should save");
-        let loaded = load_persisted_overrides(&context.settings_file_path)
+        let loaded = load_persisted_settings(&context.settings_file_path)
             .expect("settings file should load");
         let settings = build_managed_storage_settings(&context, &loaded);
 
@@ -463,7 +664,10 @@ mod tests {
             Some(sample_tools_override_path().as_str()),
             settings.bdb_tools.override_path.as_deref()
         );
-        assert_eq!(sample_tools_override_path(), settings.bdb_tools.effective_path);
+        assert_eq!(
+            sample_tools_override_path(),
+            settings.bdb_tools.effective_path
+        );
         assert_eq!(
             Some(sample_apk_library_override_path().as_str()),
             settings.apk_library.override_path.as_deref()
@@ -477,17 +681,11 @@ mod tests {
     #[test]
     fn invalid_loaded_overrides_fall_back_to_defaults() {
         let temp_directory = tempfile::tempdir().expect("temporary directory should exist");
-        let context = ManagedStorageContext {
-            operating_system: StorageOperatingSystem::Linux,
-            app_data_root: temp_directory.path().join("app-data"),
-            settings_file_path: temp_directory
-                .path()
-                .join("settings")
-                .join("managed-storage.json"),
-        };
-        let persisted = PersistedManagedStorageOverrides {
+        let context = sample_context(temp_directory.path());
+        let persisted = PersistedDesktopSettings {
             bdb_tools_override: Some("relative/tools".into()),
             apk_library_override: Some(sample_apk_library_override_path()),
+            scan_folder_paths: Some(vec!["relative/Downloads".into()]),
         };
 
         let settings = build_managed_storage_settings(&context, &persisted);
@@ -501,5 +699,163 @@ mod tests {
             Some(sample_apk_library_override_path().as_str()),
             settings.apk_library.override_path.as_deref()
         );
+    }
+
+    #[test]
+    fn desktop_settings_default_to_downloads_scan_folder() {
+        let temp_directory = tempfile::tempdir().expect("temporary directory should exist");
+        let context = sample_context(temp_directory.path());
+        let settings = build_desktop_settings(&context, &PersistedDesktopSettings::default());
+        let expected_downloads_path = context
+            .home_directory
+            .as_ref()
+            .expect("sample context should include a home directory")
+            .join("Downloads")
+            .to_string_lossy()
+            .into_owned();
+
+        assert_eq!(1, settings.scan_folders.len());
+        assert_eq!(expected_downloads_path, settings.scan_folders[0].path);
+        assert_eq!(
+            "default",
+            serde_json::to_value(&settings.scan_folders[0])
+                .expect("scan folder should serialize")
+                .get("source")
+                .and_then(|value| value.as_str())
+                .expect("source should serialize")
+        );
+    }
+
+    #[test]
+    fn save_desktop_settings_persists_scan_folders_and_library_override() {
+        let temp_directory = tempfile::tempdir().expect("temporary directory should exist");
+        let previous_home = std::env::var_os("HOME");
+        let previous_local_app_data = std::env::var_os("LOCALAPPDATA");
+        let previous_user_profile = std::env::var_os("USERPROFILE");
+
+        if cfg!(target_os = "windows") {
+            unsafe {
+                std::env::set_var("LOCALAPPDATA", temp_directory.path().join("local-app-data"));
+                std::env::set_var("USERPROFILE", temp_directory.path().join("home"));
+            }
+        } else {
+            unsafe {
+                std::env::set_var("HOME", temp_directory.path().join("home"));
+            }
+        }
+
+        let result = save_desktop_settings(DesktopSettingsInput {
+            apk_library_override: Some(sample_apk_library_override_path()),
+            scan_folder_paths: vec![sample_scan_folder_path()],
+        })
+        .expect("desktop settings should save");
+
+        restore_env(
+            previous_home,
+            previous_local_app_data,
+            previous_user_profile,
+        );
+
+        assert_eq!(sample_scan_folder_path(), result.scan_folders[0].path);
+        assert_eq!(
+            Some(sample_apk_library_override_path().as_str()),
+            result.apk_library.override_path.as_deref()
+        );
+        assert!(PathBuf::from(&result.settings_file_path).exists());
+    }
+
+    #[test]
+    fn saving_managed_storage_keeps_existing_scan_folders() {
+        let temp_directory = tempfile::tempdir().expect("temporary directory should exist");
+        let settings_file_path = temp_directory
+            .path()
+            .join("settings")
+            .join("managed-storage.json");
+        let previous_home = std::env::var_os("HOME");
+        let previous_local_app_data = std::env::var_os("LOCALAPPDATA");
+        let previous_user_profile = std::env::var_os("USERPROFILE");
+
+        if cfg!(target_os = "windows") {
+            unsafe {
+                std::env::set_var("LOCALAPPDATA", temp_directory.path().join("local-app-data"));
+                std::env::set_var("USERPROFILE", temp_directory.path().join("home"));
+            }
+        } else {
+            unsafe {
+                std::env::set_var("HOME", temp_directory.path().join("home"));
+            }
+        }
+
+        save_persisted_settings(
+            &settings_file_path,
+            &PersistedDesktopSettings {
+                bdb_tools_override: None,
+                apk_library_override: None,
+                scan_folder_paths: Some(vec![sample_scan_folder_path()]),
+            },
+        )
+        .expect("seed settings should save");
+
+        let updated = save_managed_storage_settings(ManagedStorageOverridesInput {
+            bdb_tools_override: Some(sample_tools_override_path()),
+            apk_library_override: None,
+        })
+        .expect("managed storage settings should save");
+
+        let loaded =
+            load_persisted_settings(&settings_file_path).expect("updated settings should load");
+        restore_env(
+            previous_home,
+            previous_local_app_data,
+            previous_user_profile,
+        );
+
+        assert_eq!(
+            Some(sample_tools_override_path().as_str()),
+            updated.bdb_tools.override_path.as_deref()
+        );
+        assert_eq!(
+            Some(vec![sample_scan_folder_path()]),
+            loaded.scan_folder_paths
+        );
+    }
+
+    fn sample_context(root: &Path) -> ManagedStorageContext {
+        let home = if cfg!(target_os = "windows") {
+            root.join("home")
+        } else {
+            PathBuf::from("/home/matt")
+        };
+
+        ManagedStorageContext {
+            operating_system: StorageOperatingSystem::Linux,
+            app_data_root: root.join("app-data"),
+            settings_file_path: root.join("settings").join("managed-storage.json"),
+            home_directory: Some(home),
+        }
+    }
+
+    fn restore_env(
+        previous_home: Option<OsString>,
+        previous_local_app_data: Option<OsString>,
+        previous_user_profile: Option<OsString>,
+    ) {
+        if cfg!(target_os = "windows") {
+            unsafe {
+                restore_var("LOCALAPPDATA", previous_local_app_data);
+                restore_var("USERPROFILE", previous_user_profile);
+            }
+        } else {
+            unsafe {
+                restore_var("HOME", previous_home);
+            }
+        }
+    }
+
+    unsafe fn restore_var(key: &str, value: Option<OsString>) {
+        match value {
+            Some(value) => std::env::set_var(key, value),
+            None => std::env::remove_var(key),
+        }
     }
 }

--- a/src/App.css
+++ b/src/App.css
@@ -184,6 +184,72 @@
   color: rgba(220, 247, 234, 0.68);
 }
 
+.desktop-settings-group {
+  display: grid;
+  gap: 1rem;
+  margin-top: 1.75rem;
+}
+
+.desktop-settings-group-copy {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.desktop-settings-group-copy h3 {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: #ffffff;
+}
+
+.desktop-settings-group-copy p,
+.desktop-folder-meta,
+.desktop-folder-path {
+  margin: 0;
+  color: rgb(203 213 225 / 1);
+  line-height: 1.7;
+}
+
+.desktop-folder-list {
+  display: grid;
+  gap: 0.75rem;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.desktop-folder-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.9rem 1rem;
+  border-radius: 1rem;
+  background: rgba(18, 17, 23, 0.55);
+  border: 1px solid rgba(118, 255, 170, 0.12);
+}
+
+.desktop-folder-copy {
+  display: grid;
+  gap: 0.2rem;
+  min-width: 0;
+}
+
+.desktop-folder-path {
+  font-weight: 700;
+  color: #f7fff8;
+  overflow-wrap: anywhere;
+}
+
+.desktop-folder-meta {
+  font-size: 0.88rem;
+}
+
+.desktop-inline-button {
+  min-height: auto;
+  padding-block: 0.65rem;
+}
+
 .desktop-inline-card,
 .desktop-inline-message {
   display: grid;
@@ -334,7 +400,13 @@
 
   .primary-button,
   .secondary-button,
-  .tertiary-button {
+  .tertiary-button,
+  .desktop-inline-button {
     width: 100%;
+  }
+
+  .desktop-folder-item {
+    align-items: stretch;
+    flex-direction: column;
   }
 }

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,14 +1,20 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { invoke } from "@tauri-apps/api/core";
+import { open } from "@tauri-apps/plugin-dialog";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import App from "./App";
-import type { SetupGateState } from "./desktop/types";
+import type { DesktopSettings, SetupGateState } from "./desktop/types";
 
 vi.mock("@tauri-apps/api/core", () => ({
   invoke: vi.fn(),
 }));
 
+vi.mock("@tauri-apps/plugin-dialog", () => ({
+  open: vi.fn(),
+}));
+
 const invokeMock = vi.mocked(invoke);
+const openMock = vi.mocked(open);
 
 const missingToolFixture: SetupGateState = {
   appName: "BE Home for Desktop",
@@ -101,9 +107,25 @@ const runnableFixture: SetupGateState = {
   },
 };
 
+const desktopSettingsFixture: DesktopSettings = {
+  operatingSystem: "windows",
+  settingsFilePath:
+    "C:\\Users\\Matt\\AppData\\Local\\Board Enthusiasts\\BE Home for Desktop\\settings\\managed-storage.json",
+  bdbTools: missingToolFixture.storage.bdbTools,
+  apkLibrary: missingToolFixture.storage.apkLibrary,
+  bdbExecutablePath: missingToolFixture.toolState.executablePath,
+  scanFolders: [
+    {
+      path: "C:\\Users\\Matt\\Downloads",
+      source: "default",
+    },
+  ],
+};
+
 describe("App", () => {
   beforeEach(() => {
     invokeMock.mockReset();
+    openMock.mockReset();
   });
 
   it("keeps players inside the setup flow when bdb is missing", async () => {
@@ -129,6 +151,10 @@ describe("App", () => {
         return runnableFixture;
       }
 
+      if (command === "load_desktop_settings") {
+        return desktopSettingsFixture;
+      }
+
       throw new Error(`Unexpected command: ${command}`);
     });
 
@@ -145,6 +171,10 @@ describe("App", () => {
       if (command === "load_setup_gate_state") {
         setupGateReads += 1;
         return setupGateReads === 1 ? missingToolFixture : runnableFixture;
+      }
+
+      if (command === "load_desktop_settings") {
+        return desktopSettingsFixture;
       }
 
       if (command === "acquire_bdb_tool") {
@@ -166,6 +196,51 @@ describe("App", () => {
 
     expect(await screen.findByText("Review the local defaults BE Home will start with.")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Open workspace" })).toBeInTheDocument();
+  });
+
+  it("lets players add a scan folder from settings", async () => {
+    openMock.mockResolvedValue("C:\\Users\\Matt\\Games");
+    invokeMock.mockImplementation(async (command, args) => {
+      if (command === "load_setup_gate_state") {
+        return runnableFixture;
+      }
+
+      if (command === "load_desktop_settings") {
+        return desktopSettingsFixture;
+      }
+
+      if (command === "save_desktop_settings") {
+        expect(args).toEqual({
+          input: {
+            apkLibraryOverride: null,
+            scanFolderPaths: ["C:\\Users\\Matt\\Downloads", "C:\\Users\\Matt\\Games"],
+          },
+        });
+        return {
+          ...desktopSettingsFixture,
+          scanFolders: [
+            ...desktopSettingsFixture.scanFolders,
+            {
+              path: "C:\\Users\\Matt\\Games",
+              source: "custom",
+            },
+          ],
+        };
+      }
+
+      throw new Error(`Unexpected command: ${command}`);
+    });
+
+    render(<App />);
+
+    expect(await screen.findByText("Your desktop install space is ready")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Settings/ }));
+    expect(await screen.findByText("Keep folders and storage understandable.")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Add scan folder" }));
+
+    expect(await screen.findByText("C:\\Users\\Matt\\Games")).toBeInTheDocument();
+    expect(screen.getByText("BE Home added a new scan folder.")).toBeInTheDocument();
   });
 
   it("shows a friendly host failure message", async () => {

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { invoke } from "@tauri-apps/api/core";
 import { open } from "@tauri-apps/plugin-dialog";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -241,6 +241,67 @@ describe("App", () => {
 
     expect(await screen.findByText("C:\\Users\\Matt\\Games")).toBeInTheDocument();
     expect(screen.getByText("BE Home added a new scan folder.")).toBeInTheDocument();
+  });
+
+  it("keeps settings repairs inside the workspace and disables repeat submits", async () => {
+    let resolveRepair!: (value: {
+      outcome: "repaired";
+      summary: string;
+      guidance: string;
+      toolState: SetupGateState["toolState"];
+    }) => void;
+    const repairPromise = new Promise<{
+      outcome: "repaired";
+      summary: string;
+      guidance: string;
+      toolState: SetupGateState["toolState"];
+    }>((resolve) => {
+      resolveRepair = resolve;
+    });
+
+    invokeMock.mockImplementation(async (command) => {
+      if (command === "load_setup_gate_state") {
+        return runnableFixture;
+      }
+
+      if (command === "load_desktop_settings") {
+        return desktopSettingsFixture;
+      }
+
+      if (command === "acquire_bdb_tool") {
+        return repairPromise;
+      }
+
+      throw new Error(`Unexpected command: ${command}`);
+    });
+
+    render(<App />);
+
+    expect(await screen.findByText("Your desktop install space is ready")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Settings/ }));
+    expect(await screen.findByText("Keep folders and storage understandable.")).toBeInTheDocument();
+
+    const repairButton = screen.getByRole("button", { name: "Repair bdb" });
+    fireEvent.click(repairButton);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Repair bdb" })).toBeDisabled();
+    });
+
+    resolveRepair({
+      outcome: "repaired",
+      summary: "BE Home repaired the managed bdb install.",
+      guidance: "The managed bdb binary is ready again.",
+      toolState: runnableFixture.toolState,
+    });
+
+    expect(
+      await screen.findByText("BE Home repaired the managed bdb install."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Keep folders and storage understandable.")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Review the local defaults BE Home will start with."),
+    ).not.toBeInTheDocument();
   });
 
   it("shows a friendly host failure message", async () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -176,6 +176,9 @@ function App() {
 
   async function handleAcquireBdbTool(
     repair: boolean,
+    options?: {
+      showReviewDefaultsOnReady?: boolean;
+    },
   ): Promise<BdbAcquisitionResult | null> {
     setToolActionState({
       loading: true,
@@ -192,10 +195,12 @@ function App() {
         detail: result.guidance,
         lastOutcome: result.outcome,
       });
+      const shouldShowReviewDefaults =
+        options?.showReviewDefaultsOnReady === true &&
+        result.toolState.status === "runnable" &&
+        (result.outcome === "downloaded" || result.outcome === "repaired");
       await refreshSetupGateState({
-        showReviewDefaultsOnReady:
-          result.toolState.status === "runnable" &&
-          (result.outcome === "downloaded" || result.outcome === "repaired"),
+        showReviewDefaultsOnReady: shouldShowReviewDefaults,
       });
       return result;
     } catch {
@@ -332,7 +337,15 @@ function App() {
   }
 
   async function handleRepairFromSettings(): Promise<void> {
-    const result = await handleAcquireBdbTool(true);
+    setSettingsActionState({
+      loading: true,
+      message: null,
+      detail: null,
+    });
+
+    const result = await handleAcquireBdbTool(true, {
+      showReviewDefaultsOnReady: false,
+    });
     if (result === null) {
       setSettingsActionState({
         loading: false,
@@ -450,8 +463,16 @@ function App() {
                   setupGateState={setupGateState}
                   toolActionState={toolActionState}
                   onBack={() => setSetupViewStep("systemCheck")}
-                  onDownload={() => void handleAcquireBdbTool(false)}
-                  onRepair={() => void handleAcquireBdbTool(true)}
+                  onDownload={() =>
+                    void handleAcquireBdbTool(false, {
+                      showReviewDefaultsOnReady: true,
+                    })
+                  }
+                  onRepair={() =>
+                    void handleAcquireBdbTool(true, {
+                      showReviewDefaultsOnReady: true,
+                    })
+                  }
                   onRefresh={() => void refreshSetupGateState()}
                 />
               ) : null}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,15 @@
+import { open } from "@tauri-apps/plugin-dialog";
 import { useEffect, useMemo, useState } from "react";
-import { acquireBdbTool, loadSetupGateState } from "./desktop/client";
+import {
+  acquireBdbTool,
+  loadDesktopSettings,
+  loadSetupGateState,
+  saveDesktopSettings,
+} from "./desktop/client";
 import type {
   BdbAcquisitionResult,
-  BdbPlatformSupport,
+  DesktopSettings,
+  DesktopSettingsInput,
   ManagedStorageLocation,
   SetupGateState,
 } from "./desktop/types";
@@ -76,6 +83,7 @@ const workspaceSections: WorkspaceSection[] = [
 
 function App() {
   const [setupGateState, setSetupGateState] = useState<SetupGateState | null>(null);
+  const [desktopSettings, setDesktopSettings] = useState<DesktopSettings | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [setupViewStep, setSetupViewStep] = useState<SetupViewStep>("systemCheck");
   const [showReviewDefaults, setShowReviewDefaults] = useState(false);
@@ -90,6 +98,15 @@ function App() {
     detail: null,
     lastOutcome: null,
   });
+  const [settingsActionState, setSettingsActionState] = useState<{
+    loading: boolean;
+    message: string | null;
+    detail: string | null;
+  }>({
+    loading: false,
+    message: null,
+    detail: null,
+  });
   const [activeWorkspaceSection, setActiveWorkspaceSection] =
     useState<WorkspaceSectionId>("device");
 
@@ -97,12 +114,22 @@ function App() {
     void refreshSetupGateState();
   }, []);
 
+  useEffect(() => {
+    if (setupGateState?.status === "ready") {
+      void refreshDesktopSettings();
+    } else {
+      setDesktopSettings(null);
+    }
+  }, [setupGateState?.status]);
+
   const shouldShowSetup =
     setupGateState !== null &&
     (setupGateState.status !== "ready" || showReviewDefaults);
 
   const activeWorkspaceSectionState = useMemo(
-    () => workspaceSections.find((section) => section.id === activeWorkspaceSection) ?? workspaceSections[0],
+    () =>
+      workspaceSections.find((section) => section.id === activeWorkspaceSection) ??
+      workspaceSections[0],
     [activeWorkspaceSection],
   );
 
@@ -134,7 +161,22 @@ function App() {
     }
   }
 
-  async function handleAcquireBdbTool(repair: boolean): Promise<void> {
+  async function refreshDesktopSettings(): Promise<void> {
+    try {
+      const settings = await loadDesktopSettings();
+      setDesktopSettings(settings);
+    } catch {
+      setSettingsActionState({
+        loading: false,
+        message: "BE Home couldn't load your settings just yet.",
+        detail: "Try refreshing the app or reopening the settings section.",
+      });
+    }
+  }
+
+  async function handleAcquireBdbTool(
+    repair: boolean,
+  ): Promise<BdbAcquisitionResult | null> {
     setToolActionState({
       loading: true,
       message: null,
@@ -155,6 +197,7 @@ function App() {
           result.toolState.status === "runnable" &&
           (result.outcome === "downloaded" || result.outcome === "repaired"),
       });
+      return result;
     } catch {
       setToolActionState({
         loading: false,
@@ -162,7 +205,148 @@ function App() {
         detail: "Please try again in a moment.",
         lastOutcome: "failed",
       });
+      return null;
     }
+  }
+
+  async function persistDesktopSettings(
+    input: DesktopSettingsInput,
+    successMessage: string,
+  ): Promise<void> {
+    setSettingsActionState({
+      loading: true,
+      message: null,
+      detail: null,
+    });
+
+    try {
+      const savedSettings = await saveDesktopSettings(input);
+      setDesktopSettings(savedSettings);
+      setSettingsActionState({
+        loading: false,
+        message: successMessage,
+        detail: "Your changes are saved and will still be here when you reopen the app.",
+      });
+      await refreshSetupGateState();
+    } catch {
+      setSettingsActionState({
+        loading: false,
+        message: "BE Home couldn't save those settings.",
+        detail: "Please try again in a moment.",
+      });
+    }
+  }
+
+  async function handleAddScanFolder(): Promise<void> {
+    if (desktopSettings === null) {
+      return;
+    }
+
+    const selectedPath = await pickSinglePath(
+      await open({
+        directory: true,
+        multiple: false,
+        defaultPath:
+          desktopSettings.scanFolders[desktopSettings.scanFolders.length - 1]?.path ??
+          desktopSettings.apkLibrary.effectivePath,
+      }),
+    );
+    if (selectedPath === null) {
+      return;
+    }
+
+    if (desktopSettings.scanFolders.some((folder) => folder.path === selectedPath)) {
+      setSettingsActionState({
+        loading: false,
+        message: "That folder is already on your scan list.",
+        detail: "Choose another folder if you want BE Home to watch an additional place.",
+      });
+      return;
+    }
+
+    await persistDesktopSettings(
+      {
+        apkLibraryOverride: desktopSettings.apkLibrary.overridePath,
+        scanFolderPaths: [
+          ...desktopSettings.scanFolders.map((folder) => folder.path),
+          selectedPath,
+        ],
+      },
+      "BE Home added a new scan folder.",
+    );
+  }
+
+  async function handleRemoveScanFolder(path: string): Promise<void> {
+    if (desktopSettings === null) {
+      return;
+    }
+
+    await persistDesktopSettings(
+      {
+        apkLibraryOverride: desktopSettings.apkLibrary.overridePath,
+        scanFolderPaths: desktopSettings.scanFolders
+          .map((folder) => folder.path)
+          .filter((scanFolderPath) => scanFolderPath !== path),
+      },
+      "BE Home updated your scan folder list.",
+    );
+  }
+
+  async function handleChangeApkLibraryLocation(): Promise<void> {
+    if (desktopSettings === null) {
+      return;
+    }
+
+    const selectedPath = await pickSinglePath(
+      await open({
+        directory: true,
+        multiple: false,
+        defaultPath: desktopSettings.apkLibrary.effectivePath,
+      }),
+    );
+    if (selectedPath === null) {
+      return;
+    }
+
+    await persistDesktopSettings(
+      {
+        apkLibraryOverride: selectedPath,
+        scanFolderPaths: desktopSettings.scanFolders.map((folder) => folder.path),
+      },
+      "BE Home updated the managed APK library location.",
+    );
+  }
+
+  async function handleResetApkLibraryLocation(): Promise<void> {
+    if (desktopSettings === null) {
+      return;
+    }
+
+    await persistDesktopSettings(
+      {
+        apkLibraryOverride: null,
+        scanFolderPaths: desktopSettings.scanFolders.map((folder) => folder.path),
+      },
+      "BE Home switched the APK library back to the app default folder.",
+    );
+  }
+
+  async function handleRepairFromSettings(): Promise<void> {
+    const result = await handleAcquireBdbTool(true);
+    if (result === null) {
+      setSettingsActionState({
+        loading: false,
+        message: "BE Home couldn't start the bdb repair just yet.",
+        detail: "Please try again in a moment.",
+      });
+      return;
+    }
+
+    setSettingsActionState({
+      loading: false,
+      message: result.summary,
+      detail: result.guidance,
+    });
   }
 
   if (errorMessage !== null) {
@@ -187,7 +371,8 @@ function App() {
             <div className="eyebrow">Opening BE Home for Desktop</div>
             <h2>Just a moment while we check your setup.</h2>
             <p className="panel-description">
-              We're checking whether Board's install tool is ready and whether your desktop workspace can open.
+              We're checking whether Board's install tool is ready and whether your desktop
+              workspace can open.
             </p>
           </section>
         </section>
@@ -201,7 +386,11 @@ function App() {
         <section className="hero-panel desktop-banner">
           <div className="hero-copy desktop-banner-copy">
             <div className="eyebrow">BE Home for Desktop</div>
-            <h1>{shouldShowSetup ? "Get your install workspace ready" : "Your desktop install space is ready"}</h1>
+            <h1>
+              {shouldShowSetup
+                ? "Get your install workspace ready"
+                : "Your desktop install space is ready"}
+            </h1>
             <p>{setupGateState.summary}</p>
             <p className="desktop-platform-note">
               {setupGateState.platformLabel} desktop · v{setupGateState.version}
@@ -301,36 +490,51 @@ function App() {
             </aside>
 
             <section className="desktop-workspace-main">
-              <article className="panel desktop-workspace-panel">
-                <div className="eyebrow">{activeWorkspaceSectionState.eyebrow}</div>
-                <h2>{activeWorkspaceSectionState.title}</h2>
-                <p className="panel-description">{activeWorkspaceSectionState.summary}</p>
-                <ul className="desktop-list">
-                  {activeWorkspaceSectionState.bullets.map((item) => (
-                    <li key={`${activeWorkspaceSectionState.id}-${item}`}>{item}</li>
-                  ))}
-                </ul>
-              </article>
+              {activeWorkspaceSection === "settings" ? (
+                <SettingsWorkspacePanel
+                  desktopSettings={desktopSettings}
+                  setupGateState={setupGateState}
+                  settingsActionState={settingsActionState}
+                  onAddScanFolder={() => void handleAddScanFolder()}
+                  onRemoveScanFolder={(path) => void handleRemoveScanFolder(path)}
+                  onChangeApkLibraryLocation={() => void handleChangeApkLibraryLocation()}
+                  onResetApkLibraryLocation={() => void handleResetApkLibraryLocation()}
+                  onRepairBdb={() => void handleRepairFromSettings()}
+                />
+              ) : (
+                <>
+                  <article className="panel desktop-workspace-panel">
+                    <div className="eyebrow">{activeWorkspaceSectionState.eyebrow}</div>
+                    <h2>{activeWorkspaceSectionState.title}</h2>
+                    <p className="panel-description">{activeWorkspaceSectionState.summary}</p>
+                    <ul className="desktop-list">
+                      {activeWorkspaceSectionState.bullets.map((item) => (
+                        <li key={`${activeWorkspaceSectionState.id}-${item}`}>{item}</li>
+                      ))}
+                    </ul>
+                  </article>
 
-              <article className="panel desktop-workspace-panel">
-                <div className="eyebrow">Ready now</div>
-                <h2>Board's install tool is already checked.</h2>
-                <p className="panel-description">{setupGateState.toolState.summary}</p>
-                <dl className="desktop-detail-grid">
-                  <DetailRow
-                    label="Managed bdb location"
-                    value={setupGateState.toolState.executablePath}
-                  />
-                  <DetailRow
-                    label="Managed APK library"
-                    value={setupGateState.storage.apkLibrary.effectivePath}
-                  />
-                  <DetailRow
-                    label="Default scan folder"
-                    value={formatScanFolders(setupGateState.defaultScanFolders)}
-                  />
-                </dl>
-              </article>
+                  <article className="panel desktop-workspace-panel">
+                    <div className="eyebrow">Ready now</div>
+                    <h2>Board's install tool is already checked.</h2>
+                    <p className="panel-description">{setupGateState.toolState.summary}</p>
+                    <dl className="desktop-detail-grid">
+                      <DetailRow
+                        label="Managed bdb location"
+                        value={setupGateState.toolState.executablePath}
+                      />
+                      <DetailRow
+                        label="Managed APK library"
+                        value={setupGateState.storage.apkLibrary.effectivePath}
+                      />
+                      <DetailRow
+                        label="Active scan folder"
+                        value={formatScanFolders(setupGateState.defaultScanFolders)}
+                      />
+                    </dl>
+                  </article>
+                </>
+              )}
             </section>
           </section>
         )}
@@ -364,7 +568,11 @@ interface SystemCheckStepProps {
   onRefresh: () => void;
 }
 
-function SystemCheckStep({ setupGateState, onContinue, onRefresh }: SystemCheckStepProps) {
+function SystemCheckStep({
+  setupGateState,
+  onContinue,
+  onRefresh,
+}: SystemCheckStepProps) {
   const support = setupGateState.toolState.sourcePlan.support;
   const isBlocked = setupGateState.status === "unsupported";
 
@@ -379,7 +587,11 @@ function SystemCheckStep({ setupGateState, onContinue, onRefresh }: SystemCheckS
         <DetailRow label="Architecture" value={support.architecture} />
         <DetailRow
           label="Windows build"
-          value={support.windowsBuild === null ? "Not needed on this platform" : String(support.windowsBuild)}
+          value={
+            support.windowsBuild === null
+              ? "Not needed on this platform"
+              : String(support.windowsBuild)
+          }
         />
       </dl>
 
@@ -390,7 +602,12 @@ function SystemCheckStep({ setupGateState, onContinue, onRefresh }: SystemCheckS
       />
 
       <div className="desktop-action-row">
-        <button className="primary-button" disabled={isBlocked} onClick={onContinue} type="button">
+        <button
+          className="primary-button"
+          disabled={isBlocked}
+          onClick={onContinue}
+          type="button"
+        >
           Continue to bdb setup
         </button>
         <button className="secondary-button" onClick={onRefresh} type="button">
@@ -432,9 +649,18 @@ function ToolSetupStep({
       <h2>Get Board's install tool ready.</h2>
       <p className="panel-description">{setupGateState.toolState.guidance}</p>
       <dl className="desktop-detail-grid">
-        <DetailRow label="Managed tool folder" value={setupGateState.toolState.storage.effectivePath} />
-        <DetailRow label="Executable path" value={setupGateState.toolState.executablePath} />
-        <DetailRow label="Runnable check" value={statusLabel(setupGateState.toolState.validation.status)} />
+        <DetailRow
+          label="Managed tool folder"
+          value={setupGateState.toolState.storage.effectivePath}
+        />
+        <DetailRow
+          label="Executable path"
+          value={setupGateState.toolState.executablePath}
+        />
+        <DetailRow
+          label="Runnable check"
+          value={statusLabel(setupGateState.toolState.validation.status)}
+        />
       </dl>
 
       <StatusSummaryCard
@@ -465,10 +691,20 @@ function ToolSetupStep({
         >
           {toolActionState.loading ? "Working..." : primaryActionLabel}
         </button>
-        <button className="secondary-button" disabled={toolActionState.loading} onClick={onRefresh} type="button">
+        <button
+          className="secondary-button"
+          disabled={toolActionState.loading}
+          onClick={onRefresh}
+          type="button"
+        >
           Refresh checks
         </button>
-        <button className="tertiary-button" disabled={toolActionState.loading} onClick={onBack} type="button">
+        <button
+          className="tertiary-button"
+          disabled={toolActionState.loading}
+          onClick={onBack}
+          type="button"
+        >
           Back
         </button>
       </div>
@@ -482,18 +718,32 @@ interface ReviewDefaultsStepProps {
   onBack: () => void;
 }
 
-function ReviewDefaultsStep({ setupGateState, onOpenWorkspace, onBack }: ReviewDefaultsStepProps) {
+function ReviewDefaultsStep({
+  setupGateState,
+  onOpenWorkspace,
+  onBack,
+}: ReviewDefaultsStepProps) {
   return (
     <>
       <div className="eyebrow">Step 3</div>
       <h2>Review the local defaults BE Home will start with.</h2>
       <p className="panel-description">
-        You can change these locations later, but this is the familiar starting point BE Home will use today.
+        You can change these locations later, but this is the familiar starting
+        point BE Home will use today.
       </p>
       <dl className="desktop-detail-grid">
-        <DetailRow label="Managed bdb folder" value={setupGateState.storage.bdbTools.effectivePath} />
-        <DetailRow label="Managed APK library" value={setupGateState.storage.apkLibrary.effectivePath} />
-        <DetailRow label="Default scan folder" value={formatScanFolders(setupGateState.defaultScanFolders)} />
+        <DetailRow
+          label="Managed bdb folder"
+          value={setupGateState.storage.bdbTools.effectivePath}
+        />
+        <DetailRow
+          label="Managed APK library"
+          value={setupGateState.storage.apkLibrary.effectivePath}
+        />
+        <DetailRow
+          label="Default scan folder"
+          value={formatScanFolders(setupGateState.defaultScanFolders)}
+        />
       </dl>
       <div className="desktop-action-row">
         <button className="primary-button" onClick={onOpenWorkspace} type="button">
@@ -503,6 +753,180 @@ function ReviewDefaultsStep({ setupGateState, onOpenWorkspace, onBack }: ReviewD
           Back
         </button>
       </div>
+    </>
+  );
+}
+
+interface SettingsWorkspacePanelProps {
+  desktopSettings: DesktopSettings | null;
+  setupGateState: SetupGateState;
+  settingsActionState: {
+    loading: boolean;
+    message: string | null;
+    detail: string | null;
+  };
+  onAddScanFolder: () => void;
+  onRemoveScanFolder: (path: string) => void;
+  onChangeApkLibraryLocation: () => void;
+  onResetApkLibraryLocation: () => void;
+  onRepairBdb: () => void;
+}
+
+function SettingsWorkspacePanel({
+  desktopSettings,
+  setupGateState,
+  settingsActionState,
+  onAddScanFolder,
+  onRemoveScanFolder,
+  onChangeApkLibraryLocation,
+  onResetApkLibraryLocation,
+  onRepairBdb,
+}: SettingsWorkspacePanelProps) {
+  if (desktopSettings === null) {
+    return (
+      <>
+        <article className="panel desktop-workspace-panel">
+          <div className="eyebrow">Settings</div>
+          <h2>Loading your folder settings.</h2>
+          <p className="panel-description">
+            BE Home is loading your current scan folders and storage choices.
+          </p>
+        </article>
+        <article className="panel desktop-workspace-panel">
+          <div className="eyebrow">Ready now</div>
+          <h2>Board's install tool is still checked.</h2>
+          <p className="panel-description">{setupGateState.toolState.summary}</p>
+        </article>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <article className="panel desktop-workspace-panel">
+        <div className="eyebrow">Settings</div>
+        <h2>Keep folders and storage understandable.</h2>
+        <p className="panel-description">
+          These settings stay focused on the places BE Home actually uses, so you
+          can shape your install routine without hunting through app files.
+        </p>
+
+        {settingsActionState.message !== null ? (
+          <article className="desktop-inline-message">
+            <h3>{settingsActionState.message}</h3>
+            {settingsActionState.detail !== null ? (
+              <p>{settingsActionState.detail}</p>
+            ) : null}
+          </article>
+        ) : null}
+
+        <section className="desktop-settings-group">
+          <div className="desktop-settings-group-copy">
+            <h3>Scan folders</h3>
+            <p>BE Home starts with places that already feel familiar, like Downloads.</p>
+          </div>
+          <ul className="desktop-folder-list">
+            {desktopSettings.scanFolders.map((folder) => (
+              <li className="desktop-folder-item" key={folder.path}>
+                <div className="desktop-folder-copy">
+                  <span className="desktop-folder-path">{folder.path}</span>
+                  <span className="desktop-folder-meta">
+                    {folder.source === "default" ? "App default" : "Added by you"}
+                  </span>
+                </div>
+                <button
+                  className="tertiary-button desktop-inline-button"
+                  disabled={settingsActionState.loading}
+                  onClick={() => onRemoveScanFolder(folder.path)}
+                  type="button"
+                >
+                  Remove
+                </button>
+              </li>
+            ))}
+          </ul>
+          <button
+            className="secondary-button"
+            disabled={settingsActionState.loading}
+            onClick={onAddScanFolder}
+            type="button"
+          >
+            Add scan folder
+          </button>
+        </section>
+
+        <section className="desktop-settings-group">
+          <div className="desktop-settings-group-copy">
+            <h3>Managed APK library</h3>
+            <p>
+              Keep reused APKs in one steady place so reinstalling later takes fewer steps.
+            </p>
+          </div>
+          <dl className="desktop-detail-grid">
+            <DetailRow
+              label="Current location"
+              value={desktopSettings.apkLibrary.effectivePath}
+            />
+            <DetailRow
+              label="Location style"
+              value={locationSourceLabel(desktopSettings.apkLibrary)}
+            />
+          </dl>
+          <div className="desktop-action-row">
+            <button
+              className="secondary-button"
+              disabled={settingsActionState.loading}
+              onClick={onChangeApkLibraryLocation}
+              type="button"
+            >
+              Choose another folder
+            </button>
+            {desktopSettings.apkLibrary.overridePath !== null ? (
+              <button
+                className="tertiary-button"
+                disabled={settingsActionState.loading}
+                onClick={onResetApkLibraryLocation}
+                type="button"
+              >
+                Use app default
+              </button>
+            ) : null}
+          </div>
+        </section>
+      </article>
+
+      <article className="panel desktop-workspace-panel">
+        <div className="eyebrow">Board tool</div>
+        <h2>Keep bdb easy to find and easy to repair.</h2>
+        <p className="panel-description">
+          BE Home keeps the Board install tool in its own managed folder for MVP,
+          then offers repair here if the stored copy ever needs attention.
+        </p>
+        <dl className="desktop-detail-grid">
+          <DetailRow
+            label="Managed bdb location"
+            value={desktopSettings.bdbExecutablePath}
+          />
+          <DetailRow
+            label="Current status"
+            value={setupGateState.toolState.summary}
+          />
+          <DetailRow
+            label="Settings file"
+            value={desktopSettings.settingsFilePath}
+          />
+        </dl>
+        <div className="desktop-action-row">
+          <button
+            className="primary-button"
+            disabled={settingsActionState.loading}
+            onClick={onRepairBdb}
+            type="button"
+          >
+            Repair bdb
+          </button>
+        </div>
+      </article>
     </>
   );
 }
@@ -567,10 +991,17 @@ function describeSetupStepStatus(
 }
 
 function formatScanFolders(scanFolders: string[]): string {
-  return scanFolders.length === 0 ? "Downloads will be added when BE Home can resolve them on this computer." : scanFolders.join(", ");
+  return scanFolders.length === 0
+    ? "Add a folder when you want BE Home to look beyond manual file picks."
+    : scanFolders.join(", ");
 }
 
-function statusLabel(value: SetupGateState["status"] | SetupGateState["toolState"]["status"] | SetupGateState["toolState"]["validation"]["status"]): string {
+function statusLabel(
+  value:
+    | SetupGateState["status"]
+    | SetupGateState["toolState"]["status"]
+    | SetupGateState["toolState"]["validation"]["status"],
+): string {
   switch (value) {
     case "requiresSetup":
       return "Needs setup";
@@ -595,10 +1026,18 @@ function locationSourceLabel(location: ManagedStorageLocation): string {
   return location.source === "override" ? "Custom location" : "App default";
 }
 
-export function supportStatusSummary(support: BdbPlatformSupport): string {
-  return support.status === "supported"
-    ? "This computer matches one of Board's current install-tool downloads."
-    : support.guidance;
+async function pickSinglePath(
+  selection: string | string[] | null,
+): Promise<string | null> {
+  if (selection === null) {
+    return null;
+  }
+
+  if (Array.isArray(selection)) {
+    return selection[0] ?? null;
+  }
+
+  return selection;
 }
 
 export default App;

--- a/src/desktop/client.ts
+++ b/src/desktop/client.ts
@@ -3,6 +3,8 @@ import type {
   BdbAcquisitionResult,
   BdbSourcePlan,
   BdbToolState,
+  DesktopSettings,
+  DesktopSettingsInput,
   ManagedStorageOverridesInput,
   ManagedStorageSettings,
   SetupGateState,
@@ -44,6 +46,13 @@ export function loadManagedStorageSettings(): Promise<ManagedStorageSettings> {
 }
 
 /**
+ * Loads the player-facing desktop settings model from the desktop host.
+ */
+export function loadDesktopSettings(): Promise<DesktopSettings> {
+  return invoke<DesktopSettings>("load_desktop_settings");
+}
+
+/**
  * Saves managed storage overrides and returns the updated effective settings.
  */
 export function saveManagedStorageSettings(
@@ -51,5 +60,14 @@ export function saveManagedStorageSettings(
 ): Promise<ManagedStorageSettings> {
   return invoke<ManagedStorageSettings>("save_managed_storage_settings", {
     overrides,
+  });
+}
+
+/**
+ * Saves desktop settings such as scan folders and the managed APK library location.
+ */
+export function saveDesktopSettings(input: DesktopSettingsInput): Promise<DesktopSettings> {
+  return invoke<DesktopSettings>("save_desktop_settings", {
+    input,
   });
 }

--- a/src/desktop/types.ts
+++ b/src/desktop/types.ts
@@ -153,6 +153,19 @@ export interface ManagedStorageLocation {
 }
 
 /**
+ * Describes whether a scan folder comes from the app defaults or was added later.
+ */
+export type ConfiguredScanFolderSource = "default" | "custom";
+
+/**
+ * Describes one active scan folder in the desktop settings model.
+ */
+export interface ConfiguredScanFolder {
+  path: string;
+  source: ConfiguredScanFolderSource;
+}
+
+/**
  * Describes the normalized operating system used for managed-storage defaults.
  */
 export type StorageOperatingSystem = "windows" | "macos" | "linux";
@@ -168,9 +181,29 @@ export interface ManagedStorageSettings {
 }
 
 /**
+ * Describes the player-facing desktop settings model.
+ */
+export interface DesktopSettings {
+  operatingSystem: StorageOperatingSystem;
+  settingsFilePath: string;
+  bdbTools: ManagedStorageLocation;
+  apkLibrary: ManagedStorageLocation;
+  bdbExecutablePath: string;
+  scanFolders: ConfiguredScanFolder[];
+}
+
+/**
  * Represents the persisted override payload accepted by the desktop host.
  */
 export interface ManagedStorageOverridesInput {
   bdbToolsOverride: string | null;
   apkLibraryOverride: string | null;
+}
+
+/**
+ * Describes the desktop settings payload accepted by the host.
+ */
+export interface DesktopSettingsInput {
+  apkLibraryOverride: string | null;
+  scanFolderPaths: string[];
 }


### PR DESCRIPTION
## Summary
- persist player-friendly desktop settings for scan folders and the managed APK library
- add native folder pickers for scan folders and the APK library location
- surface a settings workspace with read-only bdb location details and repair actions

## Testing
- `npm run build`
- `npm run test`

Closes #15