### PR TITLE
Add device status polling and bdb version checks

### DIFF
--- a/src-tauri/src/device.rs
+++ b/src-tauri/src/device.rs
@@ -1,0 +1,536 @@
+use crate::bdb_tool;
+use serde::Serialize;
+use std::io;
+use std::path::Path;
+use std::process::Command;
+
+const BDB_STATUS_ARGUMENT: &str = "status";
+const BDB_VERSION_ARGUMENT: &str = "version";
+const DEVICE_STATUS_POLL_INTERVAL_MS: u32 = 5_000;
+
+/// Describes the normalized connection state that the device workspace can consume.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) enum DeviceStatusKind {
+    ToolMissing,
+    ToolBroken,
+    UnsupportedHost,
+    BoardDisconnected,
+    BoardConnected,
+    ExecutionError,
+}
+
+/// Describes whether BE Home could read a friendly `bdb version` string.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) enum BdbVersionStatus {
+    Available,
+    Unavailable,
+}
+
+/// Describes the latest `bdb version` check for the current session.
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct BdbVersionDetails {
+    pub(crate) status: BdbVersionStatus,
+    pub(crate) command: String,
+    pub(crate) value: Option<String>,
+    pub(crate) exit_code: Option<i32>,
+    pub(crate) summary: String,
+    pub(crate) detail: Option<String>,
+}
+
+/// Describes the current Board connection state and related `bdb` diagnostics.
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct DeviceStatusSnapshot {
+    pub(crate) status: DeviceStatusKind,
+    pub(crate) summary: String,
+    pub(crate) guidance: String,
+    pub(crate) detail: Option<String>,
+    pub(crate) poll_interval_ms: u32,
+    pub(crate) bdb_version: BdbVersionDetails,
+}
+
+#[derive(Clone, Debug)]
+struct ProcessRunOutput {
+    exit_code: Option<i32>,
+    stdout: String,
+    stderr: String,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ProcessRunFailureKind {
+    PermissionDenied,
+    NotFound,
+    Other,
+}
+
+#[derive(Clone, Debug)]
+struct ProcessRunFailure {
+    kind: ProcessRunFailureKind,
+    detail: String,
+}
+
+trait ProcessRunner {
+    fn run(
+        &self,
+        executable_path: &Path,
+        args: &[&str],
+    ) -> Result<ProcessRunOutput, ProcessRunFailure>;
+}
+
+struct CommandProcessRunner;
+
+impl ProcessRunner for CommandProcessRunner {
+    fn run(
+        &self,
+        executable_path: &Path,
+        args: &[&str],
+    ) -> Result<ProcessRunOutput, ProcessRunFailure> {
+        let output = Command::new(executable_path)
+            .args(args)
+            .output()
+            .map_err(classify_process_failure)?;
+
+        Ok(ProcessRunOutput {
+            exit_code: output.status.code(),
+            stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+            stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        })
+    }
+}
+
+/// Load the current device-status snapshot for the managed `bdb` session.
+pub(crate) fn load_current_device_status_snapshot() -> Result<DeviceStatusSnapshot, String> {
+    let tool_state = bdb_tool::load_current_bdb_tool_state()?;
+    Ok(load_device_status_snapshot_with_runner(
+        &tool_state,
+        &CommandProcessRunner,
+    ))
+}
+
+fn load_device_status_snapshot_with_runner<P: ProcessRunner>(
+    tool_state: &bdb_tool::BdbToolState,
+    runner: &P,
+) -> DeviceStatusSnapshot {
+    match tool_state.status {
+        bdb_tool::BdbToolStatus::Unsupported => DeviceStatusSnapshot {
+            status: DeviceStatusKind::UnsupportedHost,
+            summary: "This computer is outside Board's current support for the desktop install tool."
+                .into(),
+            guidance: tool_state.guidance.clone(),
+            detail: None,
+            poll_interval_ms: DEVICE_STATUS_POLL_INTERVAL_MS,
+            bdb_version: unavailable_version_details(&tool_state.executable_path, tool_state.summary.clone()),
+        },
+        bdb_tool::BdbToolStatus::Missing => DeviceStatusSnapshot {
+            status: DeviceStatusKind::ToolMissing,
+            summary: "Board's install tool still needs to be downloaded before device checks can start."
+                .into(),
+            guidance: tool_state.guidance.clone(),
+            detail: None,
+            poll_interval_ms: DEVICE_STATUS_POLL_INTERVAL_MS,
+            bdb_version: unavailable_version_details(
+                &tool_state.executable_path,
+                "BE Home has not downloaded bdb yet.".into(),
+            ),
+        },
+        bdb_tool::BdbToolStatus::Downloaded => DeviceStatusSnapshot {
+            status: DeviceStatusKind::ToolBroken,
+            summary: "BE Home found the Board install tool, but this computer is not letting it run cleanly yet."
+                .into(),
+            guidance: tool_state.guidance.clone(),
+            detail: Some("Choose repair in settings to fetch a fresh copy of bdb.".into()),
+            poll_interval_ms: DEVICE_STATUS_POLL_INTERVAL_MS,
+            bdb_version: unavailable_version_details(
+                &tool_state.executable_path,
+                "BE Home could not trust the stored bdb copy enough to read its version.".into(),
+            ),
+        },
+        bdb_tool::BdbToolStatus::Runnable => inspect_runnable_device_status(tool_state, runner),
+    }
+}
+
+fn inspect_runnable_device_status<P: ProcessRunner>(
+    tool_state: &bdb_tool::BdbToolState,
+    runner: &P,
+) -> DeviceStatusSnapshot {
+    let executable_path = Path::new(&tool_state.executable_path);
+    let version = load_bdb_version(executable_path, runner);
+    let status_command = build_command_string(&tool_state.executable_path, BDB_STATUS_ARGUMENT);
+
+    match runner.run(executable_path, &[BDB_STATUS_ARGUMENT]) {
+        Ok(output) => normalize_status_output(output, version),
+        Err(failure) => {
+            let (status, summary, guidance, detail) = match failure.kind {
+                ProcessRunFailureKind::PermissionDenied => (
+                    DeviceStatusKind::ToolBroken,
+                    "BE Home could not reopen Board's install tool for the latest device check."
+                        .into(),
+                    "Choose repair in settings to fetch a fresh copy of bdb, then try again.".into(),
+                    Some(failure.detail),
+                ),
+                ProcessRunFailureKind::NotFound => (
+                    DeviceStatusKind::ToolMissing,
+                    "The managed Board install tool was no longer available when BE Home checked for your device."
+                        .into(),
+                    "Download or repair bdb again, then refresh the device check.".into(),
+                    Some(failure.detail),
+                ),
+                ProcessRunFailureKind::Other => (
+                    DeviceStatusKind::ExecutionError,
+                    "BE Home could not finish the latest Board connection check.".into(),
+                    "Keep Board connected, close anything else using bdb, then refresh the device check.".into(),
+                    Some(format!("The last check attempted `{status_command}`.")),
+                ),
+            };
+
+            DeviceStatusSnapshot {
+                status,
+                summary,
+                guidance,
+                detail,
+                poll_interval_ms: DEVICE_STATUS_POLL_INTERVAL_MS,
+                bdb_version: version,
+            }
+        }
+    }
+}
+
+fn normalize_status_output(
+    output: ProcessRunOutput,
+    version: BdbVersionDetails,
+) -> DeviceStatusSnapshot {
+    let combined_text = combined_output_text(&output);
+    let normalized_text = combined_text.to_ascii_lowercase();
+
+    let (status, summary, guidance, detail) = if contains_any(
+        &normalized_text,
+        &[
+            "not connected",
+            "no device",
+            "device not found",
+            "waiting for device",
+            "disconnected",
+        ],
+    ) {
+        (
+            DeviceStatusKind::BoardDisconnected,
+            "Board is not connected yet.".into(),
+            "Connect your Board with USB, unlock it if needed, then choose refresh.".into(),
+            Some(
+                "Once Board is connected, BE Home will keep install and inventory actions close by."
+                    .into(),
+            ),
+        )
+    } else if output.exit_code == Some(0)
+        || contains_any(&normalized_text, &["connected", "ready"])
+    {
+        (
+            DeviceStatusKind::BoardConnected,
+            "Board connection looks ready.".into(),
+            "You can keep using the desktop workspace while BE Home refreshes the connection in the background.".into(),
+            first_non_empty_line(&combined_text)
+                .filter(|line| !line.eq_ignore_ascii_case("connected"))
+                .filter(|line| !line.eq_ignore_ascii_case("ready")),
+        )
+    } else {
+        (
+            DeviceStatusKind::ExecutionError,
+            "BE Home could not turn the latest Board response into a reliable ready state.".into(),
+            "Refresh the connection check. If this keeps happening, reconnect Board and try again.".into(),
+            first_non_empty_line(&combined_text)
+                .map(|_| "The last bdb status response did not look like a normal connected or disconnected state.".into()),
+        )
+    };
+
+    DeviceStatusSnapshot {
+        status,
+        summary,
+        guidance,
+        detail,
+        poll_interval_ms: DEVICE_STATUS_POLL_INTERVAL_MS,
+        bdb_version: version,
+    }
+}
+
+fn load_bdb_version<P: ProcessRunner>(
+    executable_path: &Path,
+    runner: &P,
+) -> BdbVersionDetails {
+    let command = build_command_string(&path_to_string(executable_path), BDB_VERSION_ARGUMENT);
+
+    match runner.run(executable_path, &[BDB_VERSION_ARGUMENT]) {
+        Ok(output) => {
+            let version_value = first_non_empty_line(&combined_output_text(&output));
+            match version_value {
+                Some(version_value) => BdbVersionDetails {
+                    status: BdbVersionStatus::Available,
+                    command,
+                    value: Some(version_value.clone()),
+                    exit_code: output.exit_code,
+                    summary: format!("BE Home is using `{version_value}`."),
+                    detail: None,
+                },
+                None => BdbVersionDetails {
+                    status: BdbVersionStatus::Unavailable,
+                    command,
+                    value: None,
+                    exit_code: output.exit_code,
+                    summary: "BE Home could not read a friendly version string from bdb.".into(),
+                    detail: Some(
+                        "The tool opened, but it did not return a readable version line.".into(),
+                    ),
+                },
+            }
+        }
+        Err(failure) => BdbVersionDetails {
+            status: BdbVersionStatus::Unavailable,
+            command,
+            value: None,
+            exit_code: None,
+            summary: "BE Home could not confirm which bdb version is loaded right now.".into(),
+            detail: Some(failure.detail),
+        },
+    }
+}
+
+fn unavailable_version_details(executable_path: &str, summary: String) -> BdbVersionDetails {
+    BdbVersionDetails {
+        status: BdbVersionStatus::Unavailable,
+        command: build_command_string(executable_path, BDB_VERSION_ARGUMENT),
+        value: None,
+        exit_code: None,
+        summary,
+        detail: None,
+    }
+}
+
+fn combined_output_text(output: &ProcessRunOutput) -> String {
+    [output.stdout.trim(), output.stderr.trim()]
+        .into_iter()
+        .filter(|segment| !segment.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn contains_any(value: &str, candidates: &[&str]) -> bool {
+    candidates.iter().any(|candidate| value.contains(candidate))
+}
+
+fn first_non_empty_line(value: &str) -> Option<String> {
+    value.lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .map(str::to_owned)
+}
+
+fn classify_process_failure(error: io::Error) -> ProcessRunFailure {
+    let detail = error.to_string();
+    let kind = match error.kind() {
+        io::ErrorKind::PermissionDenied => ProcessRunFailureKind::PermissionDenied,
+        io::ErrorKind::NotFound => ProcessRunFailureKind::NotFound,
+        _ => ProcessRunFailureKind::Other,
+    };
+
+    ProcessRunFailure { kind, detail }
+}
+
+fn build_command_string(executable_path: &str, argument: &str) -> String {
+    format!("{executable_path} {argument}")
+}
+
+fn path_to_string(path: &Path) -> String {
+    path.to_string_lossy().into_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        load_device_status_snapshot_with_runner, BdbVersionStatus, DeviceStatusKind,
+        DeviceStatusSnapshot, ProcessRunFailure, ProcessRunFailureKind, ProcessRunOutput,
+        ProcessRunner,
+    };
+    use crate::{
+        bdb::{
+            BdbArchitecture, BdbDownloadSource, BdbOperatingSystem, BdbPlatformSupport,
+            BdbSourcePlan, BdbSupportStatus,
+        },
+        bdb_tool::{BdbRunnableStatus, BdbRunnableValidation, BdbToolState, BdbToolStatus},
+        storage::{ManagedStorageLocation, ManagedStoragePathSource},
+    };
+    use std::path::Path;
+
+    struct StaticRunner {
+        version: Result<ProcessRunOutput, ProcessRunFailure>,
+        status: Result<ProcessRunOutput, ProcessRunFailure>,
+    }
+
+    impl ProcessRunner for StaticRunner {
+        fn run(
+            &self,
+            _executable_path: &Path,
+            args: &[&str],
+        ) -> Result<ProcessRunOutput, ProcessRunFailure> {
+            match args.first().copied() {
+                Some("version") => self.version.clone(),
+                Some("status") => self.status.clone(),
+                _ => panic!("unexpected command arguments: {args:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn missing_tool_skips_runtime_commands() {
+        let snapshot = load_device_status_snapshot_with_runner(
+            &sample_tool_state(BdbToolStatus::Missing, BdbRunnableStatus::Missing),
+            &StaticRunner {
+                version: Err(ProcessRunFailure {
+                    kind: ProcessRunFailureKind::Other,
+                    detail: "should not be called".into(),
+                }),
+                status: Err(ProcessRunFailure {
+                    kind: ProcessRunFailureKind::Other,
+                    detail: "should not be called".into(),
+                }),
+            },
+        );
+
+        assert_eq!(DeviceStatusKind::ToolMissing, snapshot.status);
+        assert_eq!(BdbVersionStatus::Unavailable, snapshot.bdb_version.status);
+    }
+
+    #[test]
+    fn connected_status_surfaces_a_ready_snapshot_and_version() {
+        let snapshot = runnable_snapshot_with_runner(StaticRunner {
+            version: Ok(ProcessRunOutput {
+                exit_code: Some(0),
+                stdout: "bdb 0.19.0".into(),
+                stderr: String::new(),
+            }),
+            status: Ok(ProcessRunOutput {
+                exit_code: Some(0),
+                stdout: "Board connected and ready.".into(),
+                stderr: String::new(),
+            }),
+        });
+
+        assert_eq!(DeviceStatusKind::BoardConnected, snapshot.status);
+        assert_eq!(Some("bdb 0.19.0"), snapshot.bdb_version.value.as_deref());
+    }
+
+    #[test]
+    fn disconnected_markers_map_to_board_disconnected() {
+        let snapshot = runnable_snapshot_with_runner(StaticRunner {
+            version: Ok(ProcessRunOutput {
+                exit_code: Some(0),
+                stdout: "bdb 0.19.0".into(),
+                stderr: String::new(),
+            }),
+            status: Ok(ProcessRunOutput {
+                exit_code: Some(1),
+                stdout: "Board not connected. Connect via USB and try again.".into(),
+                stderr: String::new(),
+            }),
+        });
+
+        assert_eq!(DeviceStatusKind::BoardDisconnected, snapshot.status);
+        assert_eq!(
+            "Connect your Board with USB, unlock it if needed, then choose refresh.",
+            snapshot.guidance
+        );
+    }
+
+    #[test]
+    fn permission_denied_during_status_is_treated_as_a_broken_tool_state() {
+        let snapshot = runnable_snapshot_with_runner(StaticRunner {
+            version: Ok(ProcessRunOutput {
+                exit_code: Some(0),
+                stdout: "bdb 0.19.0".into(),
+                stderr: String::new(),
+            }),
+            status: Err(ProcessRunFailure {
+                kind: ProcessRunFailureKind::PermissionDenied,
+                detail: "Access is denied".into(),
+            }),
+        });
+
+        assert_eq!(DeviceStatusKind::ToolBroken, snapshot.status);
+        assert_eq!(Some("Access is denied"), snapshot.detail.as_deref());
+    }
+
+    #[test]
+    fn unexpected_status_output_becomes_execution_error() {
+        let snapshot = runnable_snapshot_with_runner(StaticRunner {
+            version: Ok(ProcessRunOutput {
+                exit_code: Some(0),
+                stdout: "bdb 0.19.0".into(),
+                stderr: String::new(),
+            }),
+            status: Ok(ProcessRunOutput {
+                exit_code: Some(2),
+                stdout: "rpc handshake failed".into(),
+                stderr: String::new(),
+            }),
+        });
+
+        assert_eq!(DeviceStatusKind::ExecutionError, snapshot.status);
+        assert!(snapshot.guidance.contains("Refresh the connection check"));
+    }
+
+    fn runnable_snapshot_with_runner(runner: StaticRunner) -> DeviceStatusSnapshot {
+        load_device_status_snapshot_with_runner(
+            &sample_tool_state(BdbToolStatus::Runnable, BdbRunnableStatus::Runnable),
+            &runner,
+        )
+    }
+
+    fn sample_tool_state(
+        status: BdbToolStatus,
+        runnable_status: BdbRunnableStatus,
+    ) -> BdbToolState {
+        BdbToolState {
+            status,
+            summary: "sample summary".into(),
+            guidance: "sample guidance".into(),
+            executable_path: "/tmp/bdb".into(),
+            executable_exists: matches!(
+                status,
+                BdbToolStatus::Downloaded | BdbToolStatus::Runnable
+            ),
+            storage: ManagedStorageLocation {
+                default_path: "/tmp/tools".into(),
+                override_path: None,
+                effective_path: "/tmp/tools".into(),
+                source: ManagedStoragePathSource::Default,
+            },
+            source_plan: BdbSourcePlan {
+                manifest_source: "bundled".into(),
+                remote_manifest_url: "https://example.com/bdb-sources.json".into(),
+                manifest_cache_path: None,
+                manifest_schema_version: 1,
+                support: BdbPlatformSupport {
+                    status: BdbSupportStatus::Supported,
+                    operating_system: BdbOperatingSystem::Linux,
+                    architecture: BdbArchitecture::X86_64,
+                    windows_build: None,
+                    platform_key: Some("linux-x86_64".into()),
+                    reason: None,
+                    guidance: "This machine matches a Board-published bdb target.".into(),
+                },
+                source: Some(BdbDownloadSource {
+                    platform_key: "linux-x86_64".into(),
+                    download_url: "https://example.com/bdb".into(),
+                }),
+            },
+            validation: BdbRunnableValidation {
+                status: runnable_status,
+                command: "/tmp/bdb help".into(),
+                exit_code: Some(0),
+                summary: "validation summary".into(),
+                detail: None,
+            },
+        }
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,5 +1,6 @@
 mod bdb;
 mod bdb_tool;
+mod device;
 mod setup;
 mod storage;
 
@@ -21,6 +22,11 @@ fn load_bdb_tool_state() -> Result<bdb_tool::BdbToolState, String> {
 #[tauri::command]
 fn acquire_bdb_tool(repair: bool) -> Result<bdb_tool::BdbAcquisitionResult, String> {
     bdb_tool::acquire_current_bdb_tool(repair)
+}
+
+#[tauri::command]
+fn load_device_status_snapshot() -> Result<device::DeviceStatusSnapshot, String> {
+    device::load_current_device_status_snapshot()
 }
 
 #[tauri::command]
@@ -57,6 +63,7 @@ pub fn run() {
             load_bdb_source_plan,
             load_bdb_tool_state,
             acquire_bdb_tool,
+            load_device_status_snapshot,
             load_managed_storage_settings,
             load_desktop_settings,
             save_managed_storage_settings,
@@ -139,6 +146,22 @@ mod tests {
         assert!(serialized.get("sourcePlan").is_some());
         assert!(serialized
             .get("validation")
+            .and_then(|value| value.get("status"))
+            .is_some());
+    }
+
+    #[test]
+    fn device_status_snapshot_serializes_the_runtime_contract() {
+        let snapshot =
+            super::load_device_status_snapshot().expect("device status snapshot should load");
+        let serialized =
+            serde_json::to_value(snapshot).expect("device status snapshot should serialize");
+
+        assert!(serialized.get("status").is_some());
+        assert!(serialized.get("guidance").is_some());
+        assert!(serialized.get("pollIntervalMs").is_some());
+        assert!(serialized
+            .get("bdbVersion")
             .and_then(|value| value.get("status"))
             .is_some());
     }

--- a/src/App.css
+++ b/src/App.css
@@ -167,6 +167,60 @@
   margin: 1.5rem 0 0;
 }
 
+.desktop-status-band {
+  display: grid;
+  gap: 0.45rem;
+  margin-top: 1.5rem;
+  padding: 1rem 1.1rem;
+  border-radius: 1.25rem;
+  border: 1px solid rgba(118, 255, 170, 0.18);
+  background:
+    radial-gradient(circle at 0% 0%, rgba(96, 255, 164, 0.08), transparent 26%),
+    rgba(18, 17, 23, 0.72);
+}
+
+.desktop-status-band--success {
+  border-color: rgba(118, 255, 170, 0.3);
+  background:
+    radial-gradient(circle at 0% 0%, rgba(96, 255, 164, 0.12), transparent 28%),
+    rgba(18, 17, 23, 0.72);
+}
+
+.desktop-status-band--warning {
+  border-color: rgba(243, 177, 58, 0.28);
+  background:
+    radial-gradient(circle at 0% 0%, rgba(243, 177, 58, 0.1), transparent 28%),
+    rgba(18, 17, 23, 0.72);
+}
+
+.desktop-status-band--neutral {
+  border-color: rgba(118, 177, 255, 0.22);
+  background:
+    radial-gradient(circle at 0% 0%, rgba(118, 177, 255, 0.08), transparent 28%),
+    rgba(18, 17, 23, 0.72);
+}
+
+.desktop-status-band-label {
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(220, 247, 234, 0.68);
+}
+
+.desktop-status-band h3 {
+  margin: 0;
+  font-size: 1.12rem;
+  font-weight: 700;
+  color: #ffffff;
+}
+
+.desktop-status-band p {
+  margin: 0;
+  color: rgb(203 213 225 / 1);
+  line-height: 1.7;
+}
+
 .desktop-detail-row {
   display: grid;
   gap: 0.25rem;

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,12 +1,25 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { invoke } from "@tauri-apps/api/core";
+import { getCurrentWindow } from "@tauri-apps/api/window";
 import { open } from "@tauri-apps/plugin-dialog";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import App from "./App";
-import type { DesktopSettings, SetupGateState } from "./desktop/types";
+import type {
+  DesktopSettings,
+  DeviceStatusSnapshot,
+  SetupGateState,
+} from "./desktop/types";
 
 vi.mock("@tauri-apps/api/core", () => ({
   invoke: vi.fn(),
+}));
+
+const onFocusChangedMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@tauri-apps/api/window", () => ({
+  getCurrentWindow: vi.fn(() => ({
+    onFocusChanged: onFocusChangedMock,
+  })),
 }));
 
 vi.mock("@tauri-apps/plugin-dialog", () => ({
@@ -14,6 +27,7 @@ vi.mock("@tauri-apps/plugin-dialog", () => ({
 }));
 
 const invokeMock = vi.mocked(invoke);
+const getCurrentWindowMock = vi.mocked(getCurrentWindow);
 const openMock = vi.mocked(open);
 
 const missingToolFixture: SetupGateState = {
@@ -122,9 +136,29 @@ const desktopSettingsFixture: DesktopSettings = {
   ],
 };
 
+const deviceStatusFixture: DeviceStatusSnapshot = {
+  status: "boardConnected",
+  summary: "Board connection looks ready.",
+  guidance:
+    "You can keep using the desktop workspace while BE Home refreshes the connection in the background.",
+  detail: "Board connected and ready.",
+  pollIntervalMs: 5000,
+  bdbVersion: {
+    status: "available",
+    command: "bdb version",
+    value: "bdb 0.19.0",
+    exitCode: 0,
+    summary: "BE Home is using `bdb 0.19.0`.",
+    detail: null,
+  },
+};
+
 describe("App", () => {
   beforeEach(() => {
     invokeMock.mockReset();
+    getCurrentWindowMock.mockClear();
+    onFocusChangedMock.mockReset();
+    onFocusChangedMock.mockResolvedValue(() => undefined);
     openMock.mockReset();
   });
 
@@ -155,6 +189,10 @@ describe("App", () => {
         return desktopSettingsFixture;
       }
 
+      if (command === "load_device_status_snapshot") {
+        return deviceStatusFixture;
+      }
+
       throw new Error(`Unexpected command: ${command}`);
     });
 
@@ -162,7 +200,8 @@ describe("App", () => {
 
     expect(await screen.findByText("Your desktop install space is ready")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Device/ })).toBeInTheDocument();
-    expect(screen.getByText("Board's install tool is already checked.")).toBeInTheDocument();
+    expect(await screen.findByText("Board connection looks ready.")).toBeInTheDocument();
+    expect(screen.getByText("bdb 0.19.0")).toBeInTheDocument();
   });
 
   it("shows the review-defaults step after a successful bdb download", async () => {
@@ -175,6 +214,10 @@ describe("App", () => {
 
       if (command === "load_desktop_settings") {
         return desktopSettingsFixture;
+      }
+
+      if (command === "load_device_status_snapshot") {
+        return deviceStatusFixture;
       }
 
       if (command === "acquire_bdb_tool") {
@@ -209,6 +252,10 @@ describe("App", () => {
         return desktopSettingsFixture;
       }
 
+      if (command === "load_device_status_snapshot") {
+        return deviceStatusFixture;
+      }
+
       if (command === "save_desktop_settings") {
         expect(args).toEqual({
           input: {
@@ -241,6 +288,38 @@ describe("App", () => {
 
     expect(await screen.findByText("C:\\Users\\Matt\\Games")).toBeInTheDocument();
     expect(screen.getByText("BE Home added a new scan folder.")).toBeInTheDocument();
+  });
+
+  it("polls device status while the workspace stays visible", async () => {
+    let deviceStatusReads = 0;
+    invokeMock.mockImplementation(async (command) => {
+      if (command === "load_setup_gate_state") {
+        return runnableFixture;
+      }
+
+      if (command === "load_desktop_settings") {
+        return desktopSettingsFixture;
+      }
+
+      if (command === "load_device_status_snapshot") {
+        deviceStatusReads += 1;
+        return {
+          ...deviceStatusFixture,
+          pollIntervalMs: 20,
+        };
+      }
+
+      throw new Error(`Unexpected command: ${command}`);
+    });
+
+    render(<App />);
+
+    expect(await screen.findByText("Board connection looks ready.")).toBeInTheDocument();
+    expect(deviceStatusReads).toBeGreaterThanOrEqual(1);
+
+    await waitFor(() => {
+      expect(deviceStatusReads).toBeGreaterThanOrEqual(2);
+    });
   });
 
   it("shows a friendly host failure message", async () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,10 @@
+import { getCurrentWindow } from "@tauri-apps/api/window";
 import { open } from "@tauri-apps/plugin-dialog";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useEffectEvent, useMemo, useState } from "react";
 import {
   acquireBdbTool,
   loadDesktopSettings,
+  loadDeviceStatusSnapshot,
   loadSetupGateState,
   saveDesktopSettings,
 } from "./desktop/client";
@@ -10,6 +12,7 @@ import type {
   BdbAcquisitionResult,
   DesktopSettings,
   DesktopSettingsInput,
+  DeviceStatusSnapshot,
   ManagedStorageLocation,
   SetupGateState,
 } from "./desktop/types";
@@ -25,6 +28,8 @@ interface WorkspaceSection {
   summary: string;
   bullets: string[];
 }
+
+const DEFAULT_DEVICE_POLL_INTERVAL_MS = 5_000;
 
 const workspaceSections: WorkspaceSection[] = [
   {
@@ -107,6 +112,21 @@ function App() {
     message: null,
     detail: null,
   });
+  const [deviceStatusState, setDeviceStatusState] = useState<{
+    loading: boolean;
+    snapshot: DeviceStatusSnapshot | null;
+    errorMessage: string | null;
+    errorDetail: string | null;
+  }>({
+    loading: false,
+    snapshot: null,
+    errorMessage: null,
+    errorDetail: null,
+  });
+  const [windowFocused, setWindowFocused] = useState(true);
+  const [documentVisible, setDocumentVisible] = useState(
+    typeof document === "undefined" ? true : document.visibilityState !== "hidden",
+  );
   const [activeWorkspaceSection, setActiveWorkspaceSection] =
     useState<WorkspaceSectionId>("device");
 
@@ -132,6 +152,102 @@ function App() {
       workspaceSections[0],
     [activeWorkspaceSection],
   );
+  const devicePollIntervalMs =
+    deviceStatusState.snapshot?.pollIntervalMs ?? DEFAULT_DEVICE_POLL_INTERVAL_MS;
+  const devicePollingActive = setupGateState?.status === "ready" && documentVisible && windowFocused;
+
+  const refreshDeviceStatus = useEffectEvent(
+    async (source: "initial" | "poll" | "manual" = "manual"): Promise<void> => {
+      if (setupGateState?.status !== "ready") {
+        return;
+      }
+
+      if (source !== "poll") {
+        setDeviceStatusState((previous) => ({
+          ...previous,
+          loading: true,
+          errorMessage: null,
+          errorDetail: null,
+        }));
+      }
+
+      try {
+        const snapshot = await loadDeviceStatusSnapshot();
+        setDeviceStatusState({
+          loading: false,
+          snapshot,
+          errorMessage: null,
+          errorDetail: null,
+        });
+      } catch {
+        setDeviceStatusState((previous) => ({
+          loading: false,
+          snapshot: previous.snapshot,
+          errorMessage: "BE Home couldn't refresh the latest Board connection check.",
+          errorDetail:
+            source === "poll"
+              ? "We'll keep trying again while the desktop window stays visible."
+              : "Please try refreshing the device check again in a moment.",
+        }));
+      }
+    },
+  );
+
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      setDocumentVisible(document.visibilityState !== "hidden");
+    };
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+
+    let removeFocusListener: (() => void) | null = null;
+    void getCurrentWindow()
+      .onFocusChanged(({ payload }) => {
+        setWindowFocused(payload);
+      })
+      .then((unlisten) => {
+        removeFocusListener = unlisten;
+      })
+      .catch(() => {
+        setWindowFocused(true);
+      });
+
+    return () => {
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      if (removeFocusListener !== null) {
+        removeFocusListener();
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    if (setupGateState?.status !== "ready") {
+      setDeviceStatusState({
+        loading: false,
+        snapshot: null,
+        errorMessage: null,
+        errorDetail: null,
+      });
+      return;
+    }
+
+    if (!documentVisible || !windowFocused) {
+      return;
+    }
+
+    void refreshDeviceStatus("initial");
+    const timer = window.setInterval(() => {
+      void refreshDeviceStatus("poll");
+    }, devicePollIntervalMs);
+
+    return () => {
+      window.clearInterval(timer);
+    };
+  }, [
+    devicePollIntervalMs,
+    documentVisible,
+    setupGateState?.status,
+    windowFocused,
+  ]);
 
   async function refreshSetupGateState(options?: {
     showReviewDefaultsOnReady?: boolean;
@@ -501,6 +617,13 @@ function App() {
                   onResetApkLibraryLocation={() => void handleResetApkLibraryLocation()}
                   onRepairBdb={() => void handleRepairFromSettings()}
                 />
+              ) : activeWorkspaceSection === "device" ? (
+                <DeviceWorkspacePanel
+                  deviceStatusState={deviceStatusState}
+                  pollingActive={devicePollingActive}
+                  setupGateState={setupGateState}
+                  onRefresh={() => void refreshDeviceStatus("manual")}
+                />
               ) : (
                 <>
                   <article className="panel desktop-workspace-panel">
@@ -540,6 +663,137 @@ function App() {
         )}
       </section>
     </main>
+  );
+}
+
+interface DeviceWorkspacePanelProps {
+  deviceStatusState: {
+    loading: boolean;
+    snapshot: DeviceStatusSnapshot | null;
+    errorMessage: string | null;
+    errorDetail: string | null;
+  };
+  pollingActive: boolean;
+  setupGateState: SetupGateState;
+  onRefresh: () => void;
+}
+
+function DeviceWorkspacePanel({
+  deviceStatusState,
+  pollingActive,
+  setupGateState,
+  onRefresh,
+}: DeviceWorkspacePanelProps) {
+  const snapshot = deviceStatusState.snapshot;
+
+  return (
+    <>
+      <article className="panel desktop-workspace-panel">
+        <div className="eyebrow">Board connection</div>
+        <h2>Keep the latest device check easy to trust.</h2>
+        <p className="panel-description">
+          BE Home uses the managed Board install tool to confirm whether your Board is nearby,
+          ready, and worth keeping in view while the app is open.
+        </p>
+
+        {snapshot !== null ? (
+          <article
+            className={`desktop-status-band desktop-status-band--${deviceStatusTone(snapshot.status)}`}
+          >
+            <span className="desktop-status-band-label">
+              {deviceStatusLabel(snapshot.status)}
+            </span>
+            <h3>{snapshot.summary}</h3>
+            <p>{snapshot.guidance}</p>
+          </article>
+        ) : null}
+
+        {deviceStatusState.errorMessage !== null ? (
+          <article className="desktop-inline-message desktop-inline-message--warning">
+            <h3>{deviceStatusState.errorMessage}</h3>
+            {deviceStatusState.errorDetail !== null ? (
+              <p>{deviceStatusState.errorDetail}</p>
+            ) : null}
+          </article>
+        ) : null}
+
+        {snapshot === null ? (
+          <article className="desktop-inline-card">
+            <h3>Loading the latest Board connection check.</h3>
+            <p>
+              BE Home is asking the managed install tool for its current version and Board
+              connection state.
+            </p>
+          </article>
+        ) : (
+          <>
+            <dl className="desktop-detail-grid">
+              <DetailRow
+                label="Connection state"
+                value={deviceStatusLabel(snapshot.status)}
+              />
+              <DetailRow
+                label="bdb version"
+                value={snapshot.bdbVersion.value ?? "Version not available yet"}
+              />
+              <DetailRow
+                label="Live refresh"
+                value={
+                  pollingActive
+                    ? `Every ${Math.floor(snapshot.pollIntervalMs / 1000)} seconds while this window stays visible`
+                    : "Paused until the desktop window is visible and focused again"
+                }
+              />
+              <DetailRow
+                label="Managed bdb location"
+                value={setupGateState.toolState.executablePath}
+              />
+            </dl>
+
+            <StatusSummaryCard
+              title="Current bdb version check"
+              summary={snapshot.bdbVersion.summary}
+              guidance={snapshot.detail ?? snapshot.guidance}
+            />
+          </>
+        )}
+
+        <div className="desktop-action-row">
+          <button
+            className="secondary-button"
+            disabled={deviceStatusState.loading}
+            onClick={onRefresh}
+            type="button"
+          >
+            {deviceStatusState.loading ? "Refreshing..." : "Refresh device check"}
+          </button>
+        </div>
+      </article>
+
+      <article className="panel desktop-workspace-panel">
+        <div className="eyebrow">Managed tool</div>
+        <h2>Keep the session details and fallback path nearby.</h2>
+        <p className="panel-description">
+          The desktop app keeps the Board install tool in a managed location so connection checks,
+          installs, and repairs all point to the same trusted copy.
+        </p>
+        <dl className="desktop-detail-grid">
+          <DetailRow label="Tool state" value={setupGateState.toolState.summary} />
+          <DetailRow
+            label="Runnable check"
+            value={setupGateState.toolState.validation.summary}
+          />
+          <DetailRow
+            label="Source manifest"
+            value={setupGateState.toolState.sourcePlan.manifestSource}
+          />
+          <DetailRow
+            label="Managed tool folder"
+            value={setupGateState.toolState.storage.effectivePath}
+          />
+        </dl>
+      </article>
+    </>
   );
 }
 
@@ -1024,6 +1278,42 @@ function statusLabel(
 
 function locationSourceLabel(location: ManagedStorageLocation): string {
   return location.source === "override" ? "Custom location" : "App default";
+}
+
+function deviceStatusLabel(value: DeviceStatusSnapshot["status"]): string {
+  switch (value) {
+    case "toolMissing":
+      return "Tool missing";
+    case "toolBroken":
+      return "Tool needs repair";
+    case "unsupportedHost":
+      return "Unsupported host";
+    case "boardDisconnected":
+      return "Board disconnected";
+    case "boardConnected":
+      return "Board connected";
+    case "executionError":
+      return "Needs retry";
+    default:
+      return value;
+  }
+}
+
+function deviceStatusTone(
+  value: DeviceStatusSnapshot["status"],
+): "success" | "warning" | "neutral" {
+  switch (value) {
+    case "boardConnected":
+      return "success";
+    case "toolMissing":
+    case "toolBroken":
+    case "boardDisconnected":
+    case "executionError":
+      return "warning";
+    case "unsupportedHost":
+    default:
+      return "neutral";
+  }
 }
 
 async function pickSinglePath(

--- a/src/desktop/client.ts
+++ b/src/desktop/client.ts
@@ -5,6 +5,7 @@ import type {
   BdbToolState,
   DesktopSettings,
   DesktopSettingsInput,
+  DeviceStatusSnapshot,
   ManagedStorageOverridesInput,
   ManagedStorageSettings,
   SetupGateState,
@@ -36,6 +37,13 @@ export function loadBdbToolState(): Promise<BdbToolState> {
  */
 export function acquireBdbTool(repair = false): Promise<BdbAcquisitionResult> {
   return invoke<BdbAcquisitionResult>("acquire_bdb_tool", { repair });
+}
+
+/**
+ * Loads the current Board connection snapshot and `bdb` version details.
+ */
+export function loadDeviceStatusSnapshot(): Promise<DeviceStatusSnapshot> {
+  return invoke<DeviceStatusSnapshot>("load_device_status_snapshot");
 }
 
 /**

--- a/src/desktop/types.ts
+++ b/src/desktop/types.ts
@@ -25,6 +25,46 @@ export interface SetupGateState {
 }
 
 /**
+ * Describes the normalized device-connection state for the current `bdb` session.
+ */
+export type DeviceStatusKind =
+  | "toolMissing"
+  | "toolBroken"
+  | "unsupportedHost"
+  | "boardDisconnected"
+  | "boardConnected"
+  | "executionError";
+
+/**
+ * Describes whether BE Home could read a friendly `bdb version` string.
+ */
+export type BdbVersionStatus = "available" | "unavailable";
+
+/**
+ * Describes the latest `bdb version` check for the current session.
+ */
+export interface BdbVersionDetails {
+  status: BdbVersionStatus;
+  command: string;
+  value: string | null;
+  exitCode: number | null;
+  summary: string;
+  detail: string | null;
+}
+
+/**
+ * Describes the current Board connection state plus related `bdb` diagnostics.
+ */
+export interface DeviceStatusSnapshot {
+  status: DeviceStatusKind;
+  summary: string;
+  guidance: string;
+  detail: string | null;
+  pollIntervalMs: number;
+  bdbVersion: BdbVersionDetails;
+}
+
+/**
  * Describes whether the current machine matches a supported Board `bdb` target.
  */
 export type BdbSupportStatus = "supported" | "unsupported";


### PR DESCRIPTION
## Summary
- add a host-side device status snapshot that normalizes `bdb version` and `bdb status`
- poll Board connection state while the desktop window stays visible and surface it in the Device workspace
- keep the renderer on a typed, player-friendly status model instead of raw CLI parsing

## Testing
- `npm run build`
- `npm run test`

Closes #17