### PR TITLE
Add installed title inventory modeling

### DIFF
--- a/src-tauri/src/installed_titles.rs
+++ b/src-tauri/src/installed_titles.rs
@@ -1,0 +1,662 @@
+use crate::{bdb_tool, device};
+use serde::Serialize;
+use std::collections::BTreeSet;
+use std::io;
+use std::path::Path;
+use std::process::Command;
+
+const BDB_LIST_ARGUMENT: &str = "list";
+
+/// Describes whether the installed-title inventory is ready, empty, or temporarily unavailable.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) enum InstalledTitlesStatus {
+    Ready,
+    Empty,
+    Unavailable,
+}
+
+/// Describes one title currently reported by `bdb list`.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct InstalledTitle {
+    pub(crate) stable_id: String,
+    pub(crate) display_name: String,
+    pub(crate) package_name: Option<String>,
+    pub(crate) subtitle: Option<String>,
+    pub(crate) can_launch: bool,
+    pub(crate) can_uninstall: bool,
+}
+
+/// Describes the current installed-title inventory model for Board.
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct InstalledTitlesSnapshot {
+    pub(crate) status: InstalledTitlesStatus,
+    pub(crate) summary: String,
+    pub(crate) guidance: String,
+    pub(crate) titles: Vec<InstalledTitle>,
+}
+
+#[derive(Clone, Debug)]
+struct ProcessRunOutput {
+    exit_code: Option<i32>,
+    stdout: String,
+    stderr: String,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ProcessRunFailureKind {
+    PermissionDenied,
+    NotFound,
+    Other,
+}
+
+#[derive(Clone, Debug)]
+struct ProcessRunFailure {
+    kind: ProcessRunFailureKind,
+    _detail: String,
+}
+
+trait ProcessRunner {
+    fn run(
+        &self,
+        executable_path: &Path,
+        args: &[&str],
+    ) -> Result<ProcessRunOutput, ProcessRunFailure>;
+}
+
+struct CommandProcessRunner;
+
+impl ProcessRunner for CommandProcessRunner {
+    fn run(
+        &self,
+        executable_path: &Path,
+        args: &[&str],
+    ) -> Result<ProcessRunOutput, ProcessRunFailure> {
+        let output = Command::new(executable_path)
+            .args(args)
+            .output()
+            .map_err(classify_process_failure)?;
+
+        Ok(ProcessRunOutput {
+            exit_code: output.status.code(),
+            stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+            stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        })
+    }
+}
+
+/// Load the current installed-title snapshot reported by `bdb list`.
+pub(crate) fn load_current_installed_titles_snapshot() -> Result<InstalledTitlesSnapshot, String> {
+    let device_status = device::load_current_device_status_snapshot()?;
+    let tool_state = bdb_tool::load_current_bdb_tool_state()?;
+
+    Ok(load_installed_titles_snapshot_with_runner(
+        &device_status,
+        &tool_state,
+        &CommandProcessRunner,
+    ))
+}
+
+fn load_installed_titles_snapshot_with_runner<P: ProcessRunner>(
+    device_status: &device::DeviceStatusSnapshot,
+    tool_state: &bdb_tool::BdbToolState,
+    runner: &P,
+) -> InstalledTitlesSnapshot {
+    if device_status.status != device::DeviceStatusKind::BoardConnected {
+        return InstalledTitlesSnapshot {
+            status: InstalledTitlesStatus::Unavailable,
+            summary: unavailable_summary_for_device_status(device_status.status).into(),
+            guidance: device_status.guidance.clone(),
+            titles: Vec::new(),
+        };
+    }
+
+    if tool_state.status != bdb_tool::BdbToolStatus::Runnable {
+        return InstalledTitlesSnapshot {
+            status: InstalledTitlesStatus::Unavailable,
+            summary: "BE Home could not trust the managed Board tool enough to refresh the installed-title list."
+                .into(),
+            guidance: tool_state.guidance.clone(),
+            titles: Vec::new(),
+        };
+    }
+
+    match runner.run(Path::new(&tool_state.executable_path), &[BDB_LIST_ARGUMENT]) {
+        Ok(output) => normalize_list_output(output),
+        Err(failure) => {
+            let (summary, guidance) = match failure.kind {
+                ProcessRunFailureKind::PermissionDenied => (
+                    "BE Home could not reopen Board's install tool to refresh the installed-title list."
+                        .into(),
+                    "Repair bdb from settings, then refresh the installed titles again.".into(),
+                ),
+                ProcessRunFailureKind::NotFound => (
+                    "The managed Board install tool was missing when BE Home tried to refresh the installed-title list."
+                        .into(),
+                    "Repair or re-download bdb from settings, then refresh again.".into(),
+                ),
+                ProcessRunFailureKind::Other => (
+                    "BE Home could not finish reading the installed-title list from Board right now."
+                        .into(),
+                    "Reconnect Board if needed, then refresh the installed titles again.".into(),
+                ),
+            };
+
+            InstalledTitlesSnapshot {
+                status: InstalledTitlesStatus::Unavailable,
+                summary,
+                guidance,
+                titles: Vec::new(),
+            }
+        }
+    }
+}
+
+fn unavailable_summary_for_device_status(status: device::DeviceStatusKind) -> &'static str {
+    match status {
+        device::DeviceStatusKind::ToolMissing => {
+            "Board's install tool needs to be downloaded before the installed-title list can load."
+        }
+        device::DeviceStatusKind::ToolBroken => {
+            "Board's install tool needs repair before the installed-title list can load."
+        }
+        device::DeviceStatusKind::UnsupportedHost => {
+            "This computer is outside Board's current support for the installed-title workflow."
+        }
+        device::DeviceStatusKind::BoardDisconnected => {
+            "Connect Board before refreshing what is already installed."
+        }
+        device::DeviceStatusKind::ExecutionError => {
+            "BE Home needs a clean Board connection check before it can trust the installed-title list."
+        }
+        device::DeviceStatusKind::BoardConnected => {
+            "The installed-title list is temporarily unavailable."
+        }
+    }
+}
+
+fn normalize_list_output(output: ProcessRunOutput) -> InstalledTitlesSnapshot {
+    let combined_output = combined_output_text(&output);
+    let titles = parse_installed_titles(&combined_output);
+
+    if output.exit_code != Some(0) && titles.is_empty() {
+        return InstalledTitlesSnapshot {
+            status: InstalledTitlesStatus::Unavailable,
+            summary: "BE Home could not finish reading the installed-title list from Board yet."
+                .into(),
+            guidance:
+                "Reconnect Board if needed, then refresh the installed titles again.".into(),
+            titles,
+        };
+    }
+
+    if titles.is_empty() {
+        if combined_output.trim().is_empty() {
+            return InstalledTitlesSnapshot {
+                status: InstalledTitlesStatus::Empty,
+                summary: "Board did not report any installed titles yet.".into(),
+                guidance: "Once you install something, it will show up here so uninstall and launch actions can stay close by.".into(),
+                titles,
+            };
+        }
+
+        return InstalledTitlesSnapshot {
+            status: InstalledTitlesStatus::Unavailable,
+            summary: "BE Home could not turn the latest installed-title response into a reliable list yet."
+                .into(),
+            guidance:
+                "Refresh the installed titles again. If this keeps happening, reconnect Board and try once more."
+                    .into(),
+            titles,
+        };
+    }
+
+    InstalledTitlesSnapshot {
+        status: InstalledTitlesStatus::Ready,
+        summary: format!("Board reported {} installed title(s).", titles.len()),
+        guidance:
+            "This list is ready for the later uninstall and launch actions that stay tied to package identity."
+                .into(),
+        titles,
+    }
+}
+
+fn parse_installed_titles(output_text: &str) -> Vec<InstalledTitle> {
+    let mut titles = Vec::new();
+    let mut seen_ids = BTreeSet::new();
+
+    for (index, line) in output_text.lines().enumerate() {
+        let Some(title) = parse_installed_title_line(index, line) else {
+            continue;
+        };
+
+        if seen_ids.insert(title.stable_id.clone()) {
+            titles.push(title);
+        }
+    }
+
+    titles
+}
+
+fn parse_installed_title_line(index: usize, line: &str) -> Option<InstalledTitle> {
+    let normalized_line = trim_inventory_prefix(line.trim());
+    if normalized_line.is_empty() {
+        return None;
+    }
+
+    let package_name = extract_package_name(normalized_line);
+    let display_name = normalize_display_name(normalized_line, package_name.as_deref());
+    if package_name.is_none() && !display_name.chars().any(|character| character.is_ascii_alphanumeric()) {
+        return None;
+    }
+    let stable_id = build_stable_id(&display_name, package_name.as_deref(), index);
+    let subtitle = package_name
+        .as_ref()
+        .filter(|package_name| *package_name != &display_name)
+        .cloned();
+    let can_launch = package_name.is_some();
+    let can_uninstall = package_name.is_some();
+
+    Some(InstalledTitle {
+        stable_id,
+        display_name,
+        package_name,
+        subtitle,
+        can_launch,
+        can_uninstall,
+    })
+}
+
+fn extract_package_name(line: &str) -> Option<String> {
+    extract_parenthetical_package(line).or_else(|| {
+        line.split(|character: char| {
+            character.is_whitespace()
+                || matches!(character, ',' | ';' | '|' | '(' | ')' | '[' | ']')
+        })
+        .filter_map(normalize_package_candidate)
+        .find(|candidate| looks_like_package_name(candidate))
+    })
+}
+
+fn extract_parenthetical_package(line: &str) -> Option<String> {
+    let open_index = line.rfind('(')?;
+    let close_index = line.rfind(')')?;
+    if close_index <= open_index {
+        return None;
+    }
+
+    let candidate = line[(open_index + 1)..close_index].trim();
+    if looks_like_package_name(candidate) {
+        Some(candidate.to_owned())
+    } else {
+        None
+    }
+}
+
+fn normalize_package_candidate(token: &str) -> Option<String> {
+    let trimmed = token.trim_matches(|character: char| {
+        matches!(character, ',' | ';' | '|' | '(' | ')' | '[' | ']' | '"' | '\'')
+    });
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let candidate = trimmed
+        .split(['=', ':'])
+        .next_back()
+        .unwrap_or(trimmed)
+        .trim();
+    if candidate.is_empty() {
+        return None;
+    }
+
+    Some(candidate.to_owned())
+}
+
+fn normalize_display_name(line: &str, package_name: Option<&str>) -> String {
+    let mut cleaned = line.to_owned();
+    if let Some(package_name) = package_name {
+        cleaned = cleaned.replace(package_name, " ");
+    }
+
+    for pattern in [
+        "package=",
+        "package =",
+        "package:",
+        "package :",
+        "title=",
+        "title =",
+        "title:",
+        "title :",
+        "name=",
+        "name =",
+        "name:",
+        "name :",
+        "app=",
+        "app =",
+        "app:",
+        "app :",
+        "bundle=",
+        "bundle =",
+        "bundle:",
+        "bundle :",
+        "identifier=",
+        "identifier =",
+        "identifier:",
+        "identifier :",
+        "appId=",
+        "appId =",
+        "appId:",
+        "appId :",
+        "|",
+        " - ",
+        ",",
+        ";",
+        "(",
+        ")",
+        "[",
+        "]",
+    ] {
+        cleaned = cleaned.replace(pattern, " ");
+    }
+
+    let display_name = cleaned
+        .split_whitespace()
+        .filter(|segment| {
+            let lowered = segment.to_ascii_lowercase();
+            !matches!(
+                lowered.as_str(),
+                "package" | "title" | "name" | "app" | "bundle" | "identifier" | "appid"
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    if display_name.is_empty() {
+        package_name.unwrap_or(line).to_owned()
+    } else {
+        display_name
+    }
+}
+
+fn build_stable_id(display_name: &str, package_name: Option<&str>, index: usize) -> String {
+    package_name
+        .map(|package_name| format!("package:{package_name}"))
+        .unwrap_or_else(|| format!("title:{}:{index}", slugify(display_name)))
+}
+
+fn slugify(value: &str) -> String {
+    let slug = value
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() {
+                character.to_ascii_lowercase()
+            } else {
+                '-'
+            }
+        })
+        .collect::<String>()
+        .trim_matches('-')
+        .to_owned();
+
+    if slug.is_empty() {
+        "installed-title".into()
+    } else {
+        slug
+    }
+}
+
+fn looks_like_package_name(value: &str) -> bool {
+    if value.contains(' ') || !value.contains('.') {
+        return false;
+    }
+
+    let segments = value.split('.').collect::<Vec<_>>();
+    if segments.len() < 2 || segments.iter().any(|segment| segment.is_empty()) {
+        return false;
+    }
+
+    value.chars().all(|character| {
+        character.is_ascii_alphanumeric() || matches!(character, '.' | '_' | '-')
+    }) && value.chars().any(|character| character.is_ascii_lowercase())
+}
+
+fn trim_inventory_prefix(line: &str) -> &str {
+    let digits = line.chars().take_while(|character| character.is_ascii_digit()).count();
+    if digits == 0 {
+        return line;
+    }
+
+    let remainder = &line[digits..];
+    if let Some(stripped) = remainder
+        .strip_prefix('.')
+        .or_else(|| remainder.strip_prefix(')'))
+    {
+        stripped.trim_start()
+    } else {
+        line
+    }
+}
+
+fn combined_output_text(output: &ProcessRunOutput) -> String {
+    [output.stdout.trim(), output.stderr.trim()]
+        .into_iter()
+        .filter(|segment| !segment.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn classify_process_failure(error: io::Error) -> ProcessRunFailure {
+    let kind = match error.kind() {
+        io::ErrorKind::PermissionDenied => ProcessRunFailureKind::PermissionDenied,
+        io::ErrorKind::NotFound => ProcessRunFailureKind::NotFound,
+        _ => ProcessRunFailureKind::Other,
+    };
+
+    ProcessRunFailure {
+        kind,
+        _detail: error.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        load_installed_titles_snapshot_with_runner, parse_installed_titles, InstalledTitlesStatus,
+        ProcessRunFailure, ProcessRunOutput, ProcessRunner,
+    };
+    use crate::{
+        bdb::{
+            BdbArchitecture, BdbDownloadSource, BdbOperatingSystem, BdbPlatformSupport,
+            BdbSourcePlan, BdbSupportStatus,
+        },
+        bdb_tool::{BdbRunnableStatus, BdbRunnableValidation, BdbToolState, BdbToolStatus},
+        device::{BdbVersionDetails, BdbVersionStatus, DeviceStatusKind, DeviceStatusSnapshot},
+        storage::{ManagedStorageLocation, ManagedStoragePathSource},
+    };
+    use std::path::Path;
+
+    struct StaticRunner {
+        result: Result<ProcessRunOutput, ProcessRunFailure>,
+    }
+
+    impl ProcessRunner for StaticRunner {
+        fn run(
+            &self,
+            _executable_path: &Path,
+            _args: &[&str],
+        ) -> Result<ProcessRunOutput, ProcessRunFailure> {
+            self.result.clone()
+        }
+    }
+
+    #[test]
+    fn parser_handles_package_only_lines() {
+        let titles = parse_installed_titles("co.board.luckydice\ncom.example.familymatch");
+
+        assert_eq!(2, titles.len());
+        assert_eq!(Some("co.board.luckydice"), titles[0].package_name.as_deref());
+        assert_eq!("co.board.luckydice", titles[0].display_name);
+    }
+
+    #[test]
+    fn parser_handles_titles_with_parenthetical_packages() {
+        let titles = parse_installed_titles("1. Lucky Dice (co.board.luckydice)");
+
+        assert_eq!(1, titles.len());
+        assert_eq!("Lucky Dice", titles[0].display_name);
+        assert_eq!(Some("co.board.luckydice"), titles[0].package_name.as_deref());
+        assert!(titles[0].can_launch);
+    }
+
+    #[test]
+    fn parser_handles_labelled_package_lines() {
+        let titles = parse_installed_titles("title=Family Match package=fun.board.familymatch");
+
+        assert_eq!(1, titles.len());
+        assert_eq!("Family Match", titles[0].display_name);
+        assert_eq!(
+            Some("fun.board.familymatch"),
+            titles[0].package_name.as_deref()
+        );
+    }
+
+    #[test]
+    fn connected_device_loads_a_ready_inventory_snapshot() {
+        let snapshot = load_installed_titles_snapshot_with_runner(
+            &connected_device_status(),
+            &runnable_tool_state(),
+            &StaticRunner {
+                result: Ok(ProcessRunOutput {
+                    exit_code: Some(0),
+                    stdout: "Lucky Dice (co.board.luckydice)\nFamily Match | fun.board.familymatch".into(),
+                    stderr: String::new(),
+                }),
+            },
+        );
+
+        assert_eq!(InstalledTitlesStatus::Ready, snapshot.status);
+        assert_eq!(2, snapshot.titles.len());
+        assert_eq!(Some("co.board.luckydice"), snapshot.titles[0].package_name.as_deref());
+    }
+
+    #[test]
+    fn disconnected_device_keeps_inventory_unavailable() {
+        let snapshot = load_installed_titles_snapshot_with_runner(
+            &device_status(DeviceStatusKind::BoardDisconnected),
+            &runnable_tool_state(),
+            &StaticRunner {
+                result: Ok(ProcessRunOutput {
+                    exit_code: Some(0),
+                    stdout: String::new(),
+                    stderr: String::new(),
+                }),
+            },
+        );
+
+        assert_eq!(InstalledTitlesStatus::Unavailable, snapshot.status);
+        assert!(snapshot.summary.contains("Connect Board"));
+    }
+
+    #[test]
+    fn empty_output_becomes_an_explicit_empty_state() {
+        let snapshot = load_installed_titles_snapshot_with_runner(
+            &connected_device_status(),
+            &runnable_tool_state(),
+            &StaticRunner {
+                result: Ok(ProcessRunOutput {
+                    exit_code: Some(0),
+                    stdout: String::new(),
+                    stderr: String::new(),
+                }),
+            },
+        );
+
+        assert_eq!(InstalledTitlesStatus::Empty, snapshot.status);
+        assert!(snapshot.titles.is_empty());
+    }
+
+    #[test]
+    fn malformed_output_becomes_an_unavailable_state() {
+        let snapshot = load_installed_titles_snapshot_with_runner(
+            &connected_device_status(),
+            &runnable_tool_state(),
+            &StaticRunner {
+                result: Ok(ProcessRunOutput {
+                    exit_code: Some(0),
+                    stdout: "::::\n====".into(),
+                    stderr: String::new(),
+                }),
+            },
+        );
+
+        assert_eq!(InstalledTitlesStatus::Unavailable, snapshot.status);
+        assert!(snapshot.titles.is_empty());
+    }
+
+    fn connected_device_status() -> DeviceStatusSnapshot {
+        device_status(DeviceStatusKind::BoardConnected)
+    }
+
+    fn device_status(status: DeviceStatusKind) -> DeviceStatusSnapshot {
+        DeviceStatusSnapshot {
+            status,
+            summary: "sample device summary".into(),
+            guidance: "sample device guidance".into(),
+            detail: None,
+            poll_interval_ms: 5_000,
+            bdb_version: BdbVersionDetails {
+                status: BdbVersionStatus::Available,
+                command: "bdb version".into(),
+                value: Some("bdb 0.19.0".into()),
+                exit_code: Some(0),
+                summary: "version summary".into(),
+                detail: None,
+            },
+        }
+    }
+
+    fn runnable_tool_state() -> BdbToolState {
+        BdbToolState {
+            status: BdbToolStatus::Runnable,
+            summary: "sample summary".into(),
+            guidance: "sample guidance".into(),
+            executable_path: "/tmp/bdb".into(),
+            executable_exists: true,
+            storage: ManagedStorageLocation {
+                default_path: "/tmp/tools".into(),
+                override_path: None,
+                effective_path: "/tmp/tools".into(),
+                source: ManagedStoragePathSource::Default,
+            },
+            source_plan: BdbSourcePlan {
+                manifest_source: "bundled".into(),
+                remote_manifest_url: "https://example.com/bdb-sources.json".into(),
+                manifest_cache_path: None,
+                manifest_schema_version: 1,
+                support: BdbPlatformSupport {
+                    status: BdbSupportStatus::Supported,
+                    operating_system: BdbOperatingSystem::Linux,
+                    architecture: BdbArchitecture::X86_64,
+                    windows_build: None,
+                    platform_key: Some("linux-x86_64".into()),
+                    reason: None,
+                    guidance: "This machine matches a Board-published bdb target.".into(),
+                },
+                source: Some(BdbDownloadSource {
+                    platform_key: "linux-x86_64".into(),
+                    download_url: "https://example.com/bdb".into(),
+                }),
+            },
+            validation: BdbRunnableValidation {
+                status: BdbRunnableStatus::Runnable,
+                command: "/tmp/bdb help".into(),
+                exit_code: Some(0),
+                summary: "validation summary".into(),
+                detail: None,
+            },
+        }
+    }
+}

--- a/src-tauri/src/installed_titles.rs
+++ b/src-tauri/src/installed_titles.rs
@@ -181,14 +181,14 @@ fn normalize_list_output(output: ProcessRunOutput) -> InstalledTitlesSnapshot {
     let combined_output = combined_output_text(&output);
     let titles = parse_installed_titles(&combined_output);
 
-    if output.exit_code != Some(0) && titles.is_empty() {
+    if output.exit_code != Some(0) {
         return InstalledTitlesSnapshot {
             status: InstalledTitlesStatus::Unavailable,
             summary: "BE Home could not finish reading the installed-title list from Board yet."
                 .into(),
             guidance:
                 "Reconnect Board if needed, then refresh the installed titles again.".into(),
-            titles,
+            titles: Vec::new(),
         };
     }
 
@@ -197,7 +197,9 @@ fn normalize_list_output(output: ProcessRunOutput) -> InstalledTitlesSnapshot {
             return InstalledTitlesSnapshot {
                 status: InstalledTitlesStatus::Empty,
                 summary: "Board did not report any installed titles yet.".into(),
-                guidance: "Once you install something, it will show up here so uninstall and launch actions can stay close by.".into(),
+                guidance:
+                    "Once you install something on Board, it will show up here so you can find it again quickly."
+                        .into(),
                 titles,
             };
         }
@@ -217,7 +219,7 @@ fn normalize_list_output(output: ProcessRunOutput) -> InstalledTitlesSnapshot {
         status: InstalledTitlesStatus::Ready,
         summary: format!("Board reported {} installed title(s).", titles.len()),
         guidance:
-            "This list is ready for the later uninstall and launch actions that stay tied to package identity."
+            "When Board shares package details, BE Home keeps them with each title so this list stays specific and easy to trust."
                 .into(),
         titles,
     }
@@ -588,6 +590,24 @@ mod tests {
                     exit_code: Some(0),
                     stdout: "::::\n====".into(),
                     stderr: String::new(),
+                }),
+            },
+        );
+
+        assert_eq!(InstalledTitlesStatus::Unavailable, snapshot.status);
+        assert!(snapshot.titles.is_empty());
+    }
+
+    #[test]
+    fn non_zero_exit_discards_partially_parsed_titles() {
+        let snapshot = load_installed_titles_snapshot_with_runner(
+            &connected_device_status(),
+            &runnable_tool_state(),
+            &StaticRunner {
+                result: Ok(ProcessRunOutput {
+                    exit_code: Some(1),
+                    stdout: "Lucky Dice (co.board.luckydice)".into(),
+                    stderr: "connection dropped".into(),
                 }),
             },
         );

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,7 @@
 mod bdb;
 mod bdb_tool;
 mod device;
+mod installed_titles;
 mod setup;
 mod storage;
 
@@ -27,6 +28,12 @@ fn acquire_bdb_tool(repair: bool) -> Result<bdb_tool::BdbAcquisitionResult, Stri
 #[tauri::command]
 fn load_device_status_snapshot() -> Result<device::DeviceStatusSnapshot, String> {
     device::load_current_device_status_snapshot()
+}
+
+#[tauri::command]
+fn load_installed_titles_snapshot(
+) -> Result<installed_titles::InstalledTitlesSnapshot, String> {
+    installed_titles::load_current_installed_titles_snapshot()
 }
 
 #[tauri::command]
@@ -64,6 +71,7 @@ pub fn run() {
             load_bdb_tool_state,
             acquire_bdb_tool,
             load_device_status_snapshot,
+            load_installed_titles_snapshot,
             load_managed_storage_settings,
             load_desktop_settings,
             save_managed_storage_settings,
@@ -164,5 +172,17 @@ mod tests {
             .get("bdbVersion")
             .and_then(|value| value.get("status"))
             .is_some());
+    }
+
+    #[test]
+    fn installed_titles_snapshot_serializes_the_inventory_contract() {
+        let snapshot = super::load_installed_titles_snapshot()
+            .expect("installed titles snapshot should load");
+        let serialized =
+            serde_json::to_value(snapshot).expect("installed titles snapshot should serialize");
+
+        assert!(serialized.get("status").is_some());
+        assert!(serialized.get("guidance").is_some());
+        assert!(serialized.get("titles").is_some());
     }
 }

--- a/src/App.css
+++ b/src/App.css
@@ -327,6 +327,64 @@
   line-height: 1.7;
 }
 
+.desktop-inventory-list {
+  display: grid;
+  gap: 0.9rem;
+  margin: 1.5rem 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.desktop-inventory-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem;
+  border-radius: 1rem;
+  background: rgba(18, 17, 23, 0.55);
+  border: 1px solid rgba(118, 255, 170, 0.12);
+}
+
+.desktop-inventory-copy {
+  display: grid;
+  gap: 0.25rem;
+  min-width: 0;
+}
+
+.desktop-inventory-copy h3 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 700;
+  color: #ffffff;
+}
+
+.desktop-inventory-copy p {
+  margin: 0;
+  color: rgb(203 213 225 / 1);
+  line-height: 1.7;
+  overflow-wrap: anywhere;
+}
+
+.desktop-inventory-meta {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.55rem;
+}
+
+.desktop-inventory-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  border: 1px solid rgba(118, 255, 170, 0.18);
+  background: rgba(255, 255, 255, 0.03);
+  color: rgba(220, 247, 234, 0.78);
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+
 .desktop-inline-button {
   min-height: auto;
   padding-block: 0.65rem;
@@ -490,5 +548,14 @@
   .desktop-folder-item {
     align-items: stretch;
     flex-direction: column;
+  }
+
+  .desktop-inventory-item {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .desktop-inventory-meta {
+    justify-content: flex-start;
   }
 }

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -7,6 +7,7 @@ import App from "./App";
 import type {
   DesktopSettings,
   DeviceStatusSnapshot,
+  InstalledTitlesSnapshot,
   SetupGateState,
 } from "./desktop/types";
 
@@ -171,6 +172,31 @@ const brokenToolDeviceStatusFixture: DeviceStatusSnapshot = {
   detail: "Choose repair in settings to fetch a fresh copy of bdb.",
 };
 
+const installedTitlesFixture: InstalledTitlesSnapshot = {
+  status: "ready",
+  summary: "Board reported 2 installed title(s).",
+  guidance:
+    "This list is ready for the later uninstall and launch actions that stay tied to package identity.",
+  titles: [
+    {
+      stableId: "package:co.board.luckydice",
+      displayName: "Lucky Dice",
+      packageName: "co.board.luckydice",
+      subtitle: "co.board.luckydice",
+      canLaunch: true,
+      canUninstall: true,
+    },
+    {
+      stableId: "package:fun.board.familymatch",
+      displayName: "Family Match",
+      packageName: "fun.board.familymatch",
+      subtitle: "fun.board.familymatch",
+      canLaunch: true,
+      canUninstall: true,
+    },
+  ],
+};
+
 const unsupportedSetupFixture: SetupGateState = {
   ...missingToolFixture,
   status: "unsupported",
@@ -243,6 +269,10 @@ describe("App", () => {
         return deviceStatusFixture;
       }
 
+      if (command === "load_installed_titles_snapshot") {
+        return installedTitlesFixture;
+      }
+
       throw new Error(`Unexpected command: ${command}`);
     });
 
@@ -268,6 +298,10 @@ describe("App", () => {
 
       if (command === "load_device_status_snapshot") {
         return deviceStatusFixture;
+      }
+
+      if (command === "load_installed_titles_snapshot") {
+        return installedTitlesFixture;
       }
 
       if (command === "acquire_bdb_tool") {
@@ -304,6 +338,10 @@ describe("App", () => {
 
       if (command === "load_device_status_snapshot") {
         return deviceStatusFixture;
+      }
+
+      if (command === "load_installed_titles_snapshot") {
+        return installedTitlesFixture;
       }
 
       if (command === "save_desktop_settings") {
@@ -359,6 +397,10 @@ describe("App", () => {
         };
       }
 
+      if (command === "load_installed_titles_snapshot") {
+        return installedTitlesFixture;
+      }
+
       throw new Error(`Unexpected command: ${command}`);
     });
 
@@ -386,6 +428,10 @@ describe("App", () => {
         return disconnectedDeviceStatusFixture;
       }
 
+      if (command === "load_installed_titles_snapshot") {
+        return installedTitlesFixture;
+      }
+
       throw new Error(`Unexpected command: ${command}`);
     });
 
@@ -410,6 +456,10 @@ describe("App", () => {
 
       if (command === "load_device_status_snapshot") {
         return brokenToolDeviceStatusFixture;
+      }
+
+      if (command === "load_installed_titles_snapshot") {
+        return installedTitlesFixture;
       }
 
       throw new Error(`Unexpected command: ${command}`);
@@ -447,6 +497,37 @@ describe("App", () => {
         "If Board expands desktop support later, you can come back and refresh this check again from here.",
       ),
     ).toBeInTheDocument();
+  });
+
+  it("shows installed titles from the normalized inventory model", async () => {
+    invokeMock.mockImplementation(async (command) => {
+      if (command === "load_setup_gate_state") {
+        return runnableFixture;
+      }
+
+      if (command === "load_desktop_settings") {
+        return desktopSettingsFixture;
+      }
+
+      if (command === "load_device_status_snapshot") {
+        return deviceStatusFixture;
+      }
+
+      if (command === "load_installed_titles_snapshot") {
+        return installedTitlesFixture;
+      }
+
+      throw new Error(`Unexpected command: ${command}`);
+    });
+
+    render(<App />);
+
+    expect(await screen.findByText("Your desktop install space is ready")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Installed on Board/ }));
+
+    expect(await screen.findByText("Lucky Dice")).toBeInTheDocument();
+    expect(screen.getByText("Family Match")).toBeInTheDocument();
+    expect(screen.getAllByText("Launch ready")).toHaveLength(2);
   });
 
   it("shows a friendly host failure message", async () => {

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -176,7 +176,7 @@ const installedTitlesFixture: InstalledTitlesSnapshot = {
   status: "ready",
   summary: "Board reported 2 installed title(s).",
   guidance:
-    "This list is ready for the later uninstall and launch actions that stay tied to package identity.",
+    "When Board shares package details, BE Home keeps them with each title so this list stays specific and easy to trust.",
   titles: [
     {
       stableId: "package:co.board.luckydice",
@@ -654,6 +654,11 @@ describe("App", () => {
     expect(await screen.findByText("Your desktop install space is ready")).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: /Installed on Board/ }));
 
+    expect(
+      await screen.findByText(
+        "This view keeps the titles Board is already reporting in one easy place, so you can confirm what is on the device before you reach for another install.",
+      ),
+    ).toBeInTheDocument();
     expect(await screen.findByText("Lucky Dice")).toBeInTheDocument();
     expect(screen.getByText("Family Match")).toBeInTheDocument();
     expect(screen.getAllByText("Launch ready")).toHaveLength(2);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -793,8 +793,8 @@ function InstalledTitlesWorkspacePanel({
         <div className="eyebrow">Installed on Board</div>
         <h2>Keep the current Board inventory in one stable place.</h2>
         <p className="panel-description">
-          This view turns `bdb list` into a title model the later uninstall and launch work can
-          reuse, without asking the renderer to parse command output on its own.
+          This view keeps the titles Board is already reporting in one easy place, so you can
+          confirm what is on the device before you reach for another install.
         </p>
 
         {snapshot !== null ? (
@@ -849,8 +849,8 @@ function InstalledTitlesWorkspacePanel({
         <div className="eyebrow">Current inventory</div>
         <h2>See the titles Board is already reporting.</h2>
         <p className="panel-description">
-          Package identity stays with each entry when BE Home can read it, so later launch and
-          uninstall actions have a stable place to start.
+          When Board shares package details, BE Home keeps them with each entry so the list stays
+          specific and dependable.
         </p>
 
         {snapshot === null ? (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import {
   acquireBdbTool,
   loadDesktopSettings,
   loadDeviceStatusSnapshot,
+  loadInstalledTitlesSnapshot,
   loadSetupGateState,
   saveDesktopSettings,
 } from "./desktop/client";
@@ -13,6 +14,7 @@ import type {
   DesktopSettings,
   DesktopSettingsInput,
   DeviceStatusSnapshot,
+  InstalledTitlesSnapshot,
   ManagedStorageLocation,
   SetupGateState,
 } from "./desktop/types";
@@ -137,6 +139,17 @@ function App() {
     errorMessage: null,
     errorDetail: null,
   });
+  const [installedTitlesState, setInstalledTitlesState] = useState<{
+    loading: boolean;
+    snapshot: InstalledTitlesSnapshot | null;
+    errorMessage: string | null;
+    errorDetail: string | null;
+  }>({
+    loading: false,
+    snapshot: null,
+    errorMessage: null,
+    errorDetail: null,
+  });
   const [windowFocused, setWindowFocused] = useState(true);
   const [documentVisible, setDocumentVisible] = useState(
     typeof document === "undefined" ? true : document.visibilityState !== "hidden",
@@ -207,6 +220,41 @@ function App() {
     },
   );
 
+  const refreshInstalledTitles = useEffectEvent(
+    async (source: "initial" | "manual" = "manual"): Promise<void> => {
+      if (setupGateState?.status !== "ready") {
+        return;
+      }
+
+      setInstalledTitlesState((previous) => ({
+        ...previous,
+        loading: true,
+        errorMessage: null,
+        errorDetail: null,
+      }));
+
+      try {
+        const snapshot = await loadInstalledTitlesSnapshot();
+        setInstalledTitlesState({
+          loading: false,
+          snapshot,
+          errorMessage: null,
+          errorDetail: null,
+        });
+      } catch {
+        setInstalledTitlesState((previous) => ({
+          loading: false,
+          snapshot: previous.snapshot,
+          errorMessage: "BE Home couldn't refresh the installed titles right now.",
+          errorDetail:
+            source === "initial"
+              ? "The first installed-title read did not finish cleanly. You can try again from the Installed on Board section."
+              : "Please try refreshing the installed titles again in a moment.",
+        }));
+      }
+    },
+  );
+
   useEffect(() => {
     const handleVisibilityChange = () => {
       setDocumentVisible(document.visibilityState !== "hidden");
@@ -262,6 +310,20 @@ function App() {
     setupGateState?.status,
     windowFocused,
   ]);
+
+  useEffect(() => {
+    if (setupGateState?.status !== "ready") {
+      setInstalledTitlesState({
+        loading: false,
+        snapshot: null,
+        errorMessage: null,
+        errorDetail: null,
+      });
+      return;
+    }
+
+    void refreshInstalledTitles("initial");
+  }, [setupGateState?.status]);
 
   async function refreshSetupGateState(options?: {
     showReviewDefaultsOnReady?: boolean;
@@ -639,6 +701,11 @@ function App() {
                   onOpenSettings={() => setActiveWorkspaceSection("settings")}
                   onRefresh={() => void refreshDeviceStatus("manual")}
                 />
+              ) : activeWorkspaceSection === "installed" ? (
+                <InstalledTitlesWorkspacePanel
+                  installedTitlesState={installedTitlesState}
+                  onRefresh={() => void refreshInstalledTitles("manual")}
+                />
               ) : (
                 <>
                   <article className="panel desktop-workspace-panel">
@@ -678,6 +745,128 @@ function App() {
         )}
       </section>
     </main>
+  );
+}
+
+interface InstalledTitlesWorkspacePanelProps {
+  installedTitlesState: {
+    loading: boolean;
+    snapshot: InstalledTitlesSnapshot | null;
+    errorMessage: string | null;
+    errorDetail: string | null;
+  };
+  onRefresh: () => void;
+}
+
+function InstalledTitlesWorkspacePanel({
+  installedTitlesState,
+  onRefresh,
+}: InstalledTitlesWorkspacePanelProps) {
+  const snapshot = installedTitlesState.snapshot;
+  const launchReadyCount =
+    snapshot?.titles.filter((title) => title.canLaunch).length ?? 0;
+
+  return (
+    <>
+      <article className="panel desktop-workspace-panel">
+        <div className="eyebrow">Installed on Board</div>
+        <h2>Keep the current Board inventory in one stable place.</h2>
+        <p className="panel-description">
+          This view turns `bdb list` into a title model the later uninstall and launch work can
+          reuse, without asking the renderer to parse command output on its own.
+        </p>
+
+        {snapshot !== null ? (
+          <article
+            className={`desktop-status-band desktop-status-band--${installedTitlesStatusTone(snapshot.status)}`}
+          >
+            <span className="desktop-status-band-label">
+              {installedTitlesStatusLabel(snapshot.status)}
+            </span>
+            <h3>{snapshot.summary}</h3>
+            <p>{snapshot.guidance}</p>
+          </article>
+        ) : null}
+
+        {installedTitlesState.errorMessage !== null ? (
+          <article className="desktop-inline-message desktop-inline-message--warning">
+            <h3>{installedTitlesState.errorMessage}</h3>
+            {installedTitlesState.errorDetail !== null ? (
+              <p>{installedTitlesState.errorDetail}</p>
+            ) : null}
+          </article>
+        ) : null}
+
+        <dl className="desktop-detail-grid">
+          <DetailRow
+            label="Installed titles"
+            value={snapshot ? String(snapshot.titles.length) : "Loading..."}
+          />
+          <DetailRow
+            label="Launch-ready titles"
+            value={snapshot ? String(launchReadyCount) : "Loading..."}
+          />
+          <DetailRow
+            label="Inventory state"
+            value={snapshot ? installedTitlesStatusLabel(snapshot.status) : "Loading..."}
+          />
+        </dl>
+
+        <div className="desktop-action-row">
+          <button
+            className="secondary-button"
+            disabled={installedTitlesState.loading}
+            onClick={onRefresh}
+            type="button"
+          >
+            {installedTitlesState.loading ? "Refreshing..." : "Refresh installed titles"}
+          </button>
+        </div>
+      </article>
+
+      <article className="panel desktop-workspace-panel">
+        <div className="eyebrow">Current inventory</div>
+        <h2>See the titles Board is already reporting.</h2>
+        <p className="panel-description">
+          Package identity stays with each entry when BE Home can read it, so later launch and
+          uninstall actions have a stable place to start.
+        </p>
+
+        {snapshot === null ? (
+          <article className="desktop-inline-card">
+            <h3>Loading the installed-title inventory.</h3>
+            <p>BE Home is reading the current `bdb list` response from Board.</p>
+          </article>
+        ) : snapshot.status === "ready" ? (
+          <ul className="desktop-inventory-list">
+            {snapshot.titles.map((title) => (
+              <li className="desktop-inventory-item" key={title.stableId}>
+                <div className="desktop-inventory-copy">
+                  <h3>{title.displayName}</h3>
+                  <p>
+                    {title.subtitle ??
+                      "Package identity is not available yet for this installed title."}
+                  </p>
+                </div>
+                <div className="desktop-inventory-meta">
+                  <span className="desktop-inventory-pill">
+                    {title.canLaunch ? "Launch ready" : "Package needed"}
+                  </span>
+                  <span className="desktop-inventory-pill">
+                    {title.canUninstall ? "Uninstall ready" : "Read only"}
+                  </span>
+                </div>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <article className="desktop-inline-card">
+            <h3>{snapshot.summary}</h3>
+            <p>{snapshot.guidance}</p>
+          </article>
+        )}
+      </article>
+    </>
   );
 }
 
@@ -1380,6 +1569,33 @@ function deviceStatusTone(
     case "unsupportedHost":
     default:
       return "neutral";
+  }
+}
+
+function installedTitlesStatusLabel(value: InstalledTitlesSnapshot["status"]): string {
+  switch (value) {
+    case "ready":
+      return "Inventory ready";
+    case "empty":
+      return "Nothing installed yet";
+    case "unavailable":
+      return "Temporarily unavailable";
+    default:
+      return value;
+  }
+}
+
+function installedTitlesStatusTone(
+  value: InstalledTitlesSnapshot["status"],
+): "success" | "warning" | "neutral" {
+  switch (value) {
+    case "ready":
+      return "success";
+    case "empty":
+      return "neutral";
+    case "unavailable":
+    default:
+      return "warning";
   }
 }
 

--- a/src/desktop/client.ts
+++ b/src/desktop/client.ts
@@ -6,6 +6,7 @@ import type {
   DesktopSettings,
   DesktopSettingsInput,
   DeviceStatusSnapshot,
+  InstalledTitlesSnapshot,
   ManagedStorageOverridesInput,
   ManagedStorageSettings,
   SetupGateState,
@@ -44,6 +45,13 @@ export function acquireBdbTool(repair = false): Promise<BdbAcquisitionResult> {
  */
 export function loadDeviceStatusSnapshot(): Promise<DeviceStatusSnapshot> {
   return invoke<DeviceStatusSnapshot>("load_device_status_snapshot");
+}
+
+/**
+ * Loads the current installed-title inventory from the desktop host.
+ */
+export function loadInstalledTitlesSnapshot(): Promise<InstalledTitlesSnapshot> {
+  return invoke<InstalledTitlesSnapshot>("load_installed_titles_snapshot");
 }
 
 /**

--- a/src/desktop/types.ts
+++ b/src/desktop/types.ts
@@ -65,6 +65,33 @@ export interface DeviceStatusSnapshot {
 }
 
 /**
+ * Describes whether the installed-title inventory is ready, empty, or temporarily unavailable.
+ */
+export type InstalledTitlesStatus = "ready" | "empty" | "unavailable";
+
+/**
+ * Describes one title currently reported by `bdb list`.
+ */
+export interface InstalledTitle {
+  stableId: string;
+  displayName: string;
+  packageName: string | null;
+  subtitle: string | null;
+  canLaunch: boolean;
+  canUninstall: boolean;
+}
+
+/**
+ * Describes the current installed-title inventory model for Board.
+ */
+export interface InstalledTitlesSnapshot {
+  status: InstalledTitlesStatus;
+  summary: string;
+  guidance: string;
+  titles: InstalledTitle[];
+}
+
+/**
  * Describes whether the current machine matches a supported Board `bdb` target.
  */
 export type BdbSupportStatus = "supported" | "unsupported";


### PR DESCRIPTION
## Summary
- add a host-side installed-title snapshot that normalizes `bdb list` into a stable inventory model
- load installed inventory when the workspace opens and surface it in the Installed on Board section
- keep empty and unavailable inventory states explicit so later uninstall and launch flows can build on the same contract

## Testing
- `npm run build`
- `npm run test`

Closes #19