### PR TITLE
Add APK discovery and manual pick pipeline

### DIFF
--- a/src-tauri/src/apk.rs
+++ b/src-tauri/src/apk.rs
@@ -1,0 +1,319 @@
+use crate::storage;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Describes whether a candidate came from configured scan folders or a manual file pick.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) enum ApkCandidateSource {
+    ScanFolder,
+    ManualSelection,
+}
+
+/// Describes whether the current APK discovery result has content to show.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) enum ApkDiscoveryStatus {
+    Ready,
+    Empty,
+}
+
+/// Describes one locally discovered APK candidate.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ApkCandidate {
+    pub(crate) stable_id: String,
+    pub(crate) file_name: String,
+    pub(crate) source_path: String,
+    pub(crate) discovery_source: ApkCandidateSource,
+    pub(crate) discovered_from_path: Option<String>,
+    pub(crate) file_size_bytes: u64,
+}
+
+/// Describes the current APK discovery snapshot built from configured scan folders.
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ApkDiscoverySnapshot {
+    pub(crate) status: ApkDiscoveryStatus,
+    pub(crate) summary: String,
+    pub(crate) guidance: String,
+    pub(crate) candidates: Vec<ApkCandidate>,
+}
+
+/// Represents the manual APK path request accepted by the desktop host.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ManualApkPathInput {
+    path: String,
+}
+
+/// Scan the configured folders for local APK candidates.
+pub(crate) fn load_current_apk_discovery_snapshot() -> Result<ApkDiscoverySnapshot, String> {
+    let settings = storage::load_desktop_settings()?;
+    Ok(build_apk_discovery_snapshot(
+        settings
+            .scan_folders
+            .iter()
+            .map(|folder| folder.path.clone())
+            .collect(),
+    ))
+}
+
+/// Inspect one manually selected APK path and normalize it into the shared candidate model.
+pub(crate) fn inspect_manual_apk_path(input: ManualApkPathInput) -> Result<ApkCandidate, String> {
+    let path = normalize_apk_path(&input.path)?;
+    build_apk_candidate(&path, ApkCandidateSource::ManualSelection, None)
+}
+
+fn build_apk_discovery_snapshot(scan_folder_paths: Vec<String>) -> ApkDiscoverySnapshot {
+    let mut candidates_by_key = BTreeMap::new();
+
+    for scan_folder_path in scan_folder_paths {
+        let folder_path = PathBuf::from(&scan_folder_path);
+        if !folder_path.exists() || !folder_path.is_dir() {
+            continue;
+        }
+
+        for apk_path in walk_apk_files(&folder_path) {
+            if let Ok(candidate) = build_apk_candidate(
+                &apk_path,
+                ApkCandidateSource::ScanFolder,
+                Some(scan_folder_path.clone()),
+            ) {
+                candidates_by_key.entry(candidate.stable_id.clone()).or_insert(candidate);
+            }
+        }
+    }
+
+    let mut candidates = candidates_by_key.into_values().collect::<Vec<_>>();
+    candidates.sort_by(|left, right| {
+        left.file_name
+            .to_ascii_lowercase()
+            .cmp(&right.file_name.to_ascii_lowercase())
+            .then_with(|| left.source_path.cmp(&right.source_path))
+    });
+
+    if candidates.is_empty() {
+        return ApkDiscoverySnapshot {
+            status: ApkDiscoveryStatus::Empty,
+            summary: "BE Home did not find any APK files in the current scan folders yet.".into(),
+            guidance:
+                "Choose a manual APK when you already know the file you want, or add another scan folder in settings."
+                    .into(),
+            candidates,
+        };
+    }
+
+    ApkDiscoverySnapshot {
+        status: ApkDiscoveryStatus::Ready,
+        summary: format!("BE Home found {} APK file(s) across the current scan folders.", candidates.len()),
+        guidance:
+            "Use rescan after you add new downloads to a watched folder, or choose a file manually when you already know where it lives."
+                .into(),
+        candidates,
+    }
+}
+
+fn walk_apk_files(root: &Path) -> Vec<PathBuf> {
+    let mut directories = vec![root.to_path_buf()];
+    let mut apk_paths = Vec::new();
+
+    while let Some(directory) = directories.pop() {
+        let Ok(entries) = fs::read_dir(&directory) else {
+            continue;
+        };
+
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                directories.push(path);
+                continue;
+            }
+
+            if is_apk_path(&path) {
+                apk_paths.push(path);
+            }
+        }
+    }
+
+    apk_paths
+}
+
+fn build_apk_candidate(
+    path: &Path,
+    discovery_source: ApkCandidateSource,
+    discovered_from_path: Option<String>,
+) -> Result<ApkCandidate, String> {
+    let metadata = fs::metadata(path).map_err(|error| {
+        format!(
+            "BE Home could not read the APK file at `{}`: {error}",
+            path.display()
+        )
+    })?;
+
+    let absolute_path = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .map_err(|error| format!("BE Home could not resolve the current working directory: {error}"))?
+            .join(path)
+    };
+
+    let source_path = path_to_string(&absolute_path);
+    let file_name = absolute_path
+        .file_name()
+        .and_then(|file_name| file_name.to_str())
+        .map(str::to_owned)
+        .ok_or_else(|| {
+            format!(
+                "BE Home could not read a usable file name from `{}`.",
+                absolute_path.display()
+            )
+        })?;
+
+    Ok(ApkCandidate {
+        stable_id: format!("apk:{}", path_identity_key(&source_path)),
+        file_name,
+        source_path,
+        discovery_source,
+        discovered_from_path,
+        file_size_bytes: metadata.len(),
+    })
+}
+
+fn normalize_apk_path(value: &str) -> Result<PathBuf, String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err("Choose an APK file before asking BE Home to inspect it.".into());
+    }
+
+    let path = PathBuf::from(trimmed);
+    if !path.is_absolute() {
+        return Err("BE Home expects an absolute APK path from the file picker.".into());
+    }
+
+    if !path.exists() {
+        return Err(format!(
+            "BE Home could not find the APK file at `{}` anymore.",
+            path.display()
+        ));
+    }
+
+    if !is_apk_path(&path) {
+        return Err("Choose an `.apk` file so BE Home can inspect it.".into());
+    }
+
+    Ok(path)
+}
+
+fn is_apk_path(path: &Path) -> bool {
+    path.extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| extension.eq_ignore_ascii_case("apk"))
+}
+
+fn path_identity_key(path: &str) -> String {
+    #[cfg(target_os = "windows")]
+    {
+        path.to_lowercase()
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        path.to_owned()
+    }
+}
+
+fn path_to_string(path: &Path) -> String {
+    path.to_string_lossy().into_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        build_apk_candidate, build_apk_discovery_snapshot, inspect_manual_apk_path,
+        ApkCandidateSource, ApkDiscoveryStatus, ManualApkPathInput,
+    };
+    use std::fs;
+    use std::path::PathBuf;
+
+    #[test]
+    fn discovery_snapshot_walks_nested_scan_folders_and_deduplicates_results() {
+        let temp_directory = tempfile::tempdir().expect("temporary directory should exist");
+        let root = temp_directory.path();
+        let downloads = root.join("Downloads");
+        let nested = downloads.join("nested");
+        fs::create_dir_all(&nested).expect("nested folder should exist");
+        fs::write(downloads.join("LuckyDice.apk"), "apk").expect("top-level apk should exist");
+        fs::write(nested.join("FamilyMatch.apk"), "apk").expect("nested apk should exist");
+
+        let snapshot = build_apk_discovery_snapshot(vec![
+            downloads.to_string_lossy().into_owned(),
+            nested.to_string_lossy().into_owned(),
+        ]);
+
+        assert_eq!(ApkDiscoveryStatus::Ready, snapshot.status);
+        assert_eq!(2, snapshot.candidates.len());
+    }
+
+    #[test]
+    fn discovery_snapshot_reports_empty_when_no_apks_are_found() {
+        let temp_directory = tempfile::tempdir().expect("temporary directory should exist");
+        let downloads = temp_directory.path().join("Downloads");
+        fs::create_dir_all(&downloads).expect("downloads should exist");
+        fs::write(downloads.join("notes.txt"), "not an apk").expect("text file should exist");
+
+        let snapshot = build_apk_discovery_snapshot(vec![downloads.to_string_lossy().into_owned()]);
+
+        assert_eq!(ApkDiscoveryStatus::Empty, snapshot.status);
+        assert!(snapshot.candidates.is_empty());
+    }
+
+    #[test]
+    fn manual_apk_inspection_requires_an_absolute_apk_path() {
+        let result = inspect_manual_apk_path(ManualApkPathInput {
+            path: "LuckyDice.apk".into(),
+        });
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn manual_apk_inspection_returns_a_manual_candidate() {
+        let temp_directory = tempfile::tempdir().expect("temporary directory should exist");
+        let apk_path = temp_directory.path().join("LuckyDice.apk");
+        fs::write(&apk_path, "apk").expect("apk should exist");
+
+        let candidate = inspect_manual_apk_path(ManualApkPathInput {
+            path: apk_path.to_string_lossy().into_owned(),
+        })
+        .expect("manual apk inspection should succeed");
+
+        assert_eq!(ApkCandidateSource::ManualSelection, candidate.discovery_source);
+        assert_eq!("LuckyDice.apk", candidate.file_name);
+        assert_eq!(None, candidate.discovered_from_path);
+    }
+
+    #[test]
+    fn scan_candidates_preserve_the_scan_folder_they_were_found_from() {
+        let temp_directory = tempfile::tempdir().expect("temporary directory should exist");
+        let scan_folder = temp_directory.path().join("Downloads");
+        let apk_path = scan_folder.join("LuckyDice.apk");
+        fs::create_dir_all(&scan_folder).expect("downloads should exist");
+        fs::write(&apk_path, "apk").expect("apk should exist");
+
+        let candidate = build_apk_candidate(
+            &PathBuf::from(&apk_path),
+            ApkCandidateSource::ScanFolder,
+            Some(scan_folder.to_string_lossy().into_owned()),
+        )
+        .expect("candidate should build");
+
+        assert_eq!(
+            Some(scan_folder.to_string_lossy().into_owned()),
+            candidate.discovered_from_path
+        );
+    }
+}

--- a/src-tauri/src/apk.rs
+++ b/src-tauri/src/apk.rs
@@ -1,6 +1,6 @@
 use crate::storage;
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -118,17 +118,35 @@ fn build_apk_discovery_snapshot(scan_folder_paths: Vec<String>) -> ApkDiscoveryS
 
 fn walk_apk_files(root: &Path) -> Vec<PathBuf> {
     let mut directories = vec![root.to_path_buf()];
+    let mut visited_directories = HashSet::new();
     let mut apk_paths = Vec::new();
 
     while let Some(directory) = directories.pop() {
+        let canonical_directory =
+            fs::canonicalize(&directory).unwrap_or_else(|_| directory.clone());
+        if !visited_directories.insert(canonical_directory) {
+            continue;
+        }
+
         let Ok(entries) = fs::read_dir(&directory) else {
             continue;
         };
 
         for entry in entries.flatten() {
             let path = entry.path();
-            if path.is_dir() {
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+
+            if file_type.is_dir() {
                 directories.push(path);
+                continue;
+            }
+
+            if file_type.is_symlink() {
+                if path.is_file() && is_apk_path(&path) {
+                    apk_paths.push(path);
+                }
                 continue;
             }
 
@@ -201,6 +219,10 @@ fn normalize_apk_path(value: &str) -> Result<PathBuf, String> {
         ));
     }
 
+    if !path.is_file() {
+        return Err("Choose an APK file, not a folder, so BE Home can inspect it.".into());
+    }
+
     if !is_apk_path(&path) {
         return Err("Choose an `.apk` file so BE Home can inspect it.".into());
     }
@@ -238,6 +260,8 @@ mod tests {
     };
     use std::fs;
     use std::path::PathBuf;
+    #[cfg(unix)]
+    use std::os::unix::fs::symlink;
 
     #[test]
     fn discovery_snapshot_walks_nested_scan_folders_and_deduplicates_results() {
@@ -271,6 +295,22 @@ mod tests {
         assert!(snapshot.candidates.is_empty());
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn discovery_snapshot_skips_symlinked_directory_cycles() {
+        let temp_directory = tempfile::tempdir().expect("temporary directory should exist");
+        let downloads = temp_directory.path().join("Downloads");
+        let nested = downloads.join("nested");
+        fs::create_dir_all(&nested).expect("nested folder should exist");
+        fs::write(nested.join("LuckyDice.apk"), "apk").expect("apk should exist");
+        symlink(&downloads, nested.join("loop")).expect("directory symlink should exist");
+
+        let snapshot = build_apk_discovery_snapshot(vec![downloads.to_string_lossy().into_owned()]);
+
+        assert_eq!(ApkDiscoveryStatus::Ready, snapshot.status);
+        assert_eq!(1, snapshot.candidates.len());
+    }
+
     #[test]
     fn manual_apk_inspection_requires_an_absolute_apk_path() {
         let result = inspect_manual_apk_path(ManualApkPathInput {
@@ -294,6 +334,21 @@ mod tests {
         assert_eq!(ApkCandidateSource::ManualSelection, candidate.discovery_source);
         assert_eq!("LuckyDice.apk", candidate.file_name);
         assert_eq!(None, candidate.discovered_from_path);
+    }
+
+    #[test]
+    fn manual_apk_inspection_rejects_directories_named_like_apks() {
+        let temp_directory = tempfile::tempdir().expect("temporary directory should exist");
+        let directory_path = temp_directory.path().join("LuckyDice.apk");
+        fs::create_dir_all(&directory_path).expect("directory should exist");
+
+        let result = inspect_manual_apk_path(ManualApkPathInput {
+            path: directory_path.to_string_lossy().into_owned(),
+        });
+
+        assert!(result
+            .expect_err("directory paths should be rejected")
+            .contains("not a folder"));
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+mod apk;
 mod bdb;
 mod bdb_tool;
 mod device;
@@ -8,6 +9,16 @@ mod storage;
 #[tauri::command]
 fn load_setup_gate_state() -> Result<setup::SetupGateState, String> {
     setup::load_setup_gate_state()
+}
+
+#[tauri::command]
+fn load_apk_discovery_snapshot() -> Result<apk::ApkDiscoverySnapshot, String> {
+    apk::load_current_apk_discovery_snapshot()
+}
+
+#[tauri::command]
+fn inspect_manual_apk_path(input: apk::ManualApkPathInput) -> Result<apk::ApkCandidate, String> {
+    apk::inspect_manual_apk_path(input)
 }
 
 #[tauri::command]
@@ -67,6 +78,8 @@ pub fn run() {
         .plugin(tauri_plugin_dialog::init())
         .invoke_handler(tauri::generate_handler![
             load_setup_gate_state,
+            load_apk_discovery_snapshot,
+            inspect_manual_apk_path,
             load_bdb_source_plan,
             load_bdb_tool_state,
             acquire_bdb_tool,
@@ -95,6 +108,18 @@ mod tests {
         assert!(serialized.get("toolState").is_some());
         assert!(serialized.get("storage").is_some());
         assert!(serialized.get("defaultScanFolders").is_some());
+    }
+
+    #[test]
+    fn apk_discovery_snapshot_serializes_the_discovery_contract() {
+        let snapshot = super::load_apk_discovery_snapshot()
+            .expect("apk discovery snapshot should load successfully");
+        let serialized =
+            serde_json::to_value(snapshot).expect("apk discovery snapshot should serialize");
+
+        assert!(serialized.get("status").is_some());
+        assert!(serialized.get("guidance").is_some());
+        assert!(serialized.get("candidates").is_some());
     }
 
     #[test]

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -5,6 +5,8 @@ import { open } from "@tauri-apps/plugin-dialog";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import App from "./App";
 import type {
+  ApkCandidate,
+  ApkDiscoverySnapshot,
   DesktopSettings,
   DeviceStatusSnapshot,
   InstalledTitlesSnapshot,
@@ -197,6 +199,40 @@ const installedTitlesFixture: InstalledTitlesSnapshot = {
   ],
 };
 
+const apkDiscoveryFixture: ApkDiscoverySnapshot = {
+  status: "ready",
+  summary: "BE Home found 2 APK file(s) across the current scan folders.",
+  guidance:
+    "Use rescan after you add new downloads to a watched folder, or choose a file manually when you already know where it lives.",
+  candidates: [
+    {
+      stableId: "apk:c:\\users\\matt\\downloads\\luckydice.apk",
+      fileName: "LuckyDice.apk",
+      sourcePath: "C:\\Users\\Matt\\Downloads\\LuckyDice.apk",
+      discoverySource: "scanFolder",
+      discoveredFromPath: "C:\\Users\\Matt\\Downloads",
+      fileSizeBytes: 2048000,
+    },
+    {
+      stableId: "apk:c:\\users\\matt\\games\\familymatch.apk",
+      fileName: "FamilyMatch.apk",
+      sourcePath: "C:\\Users\\Matt\\Games\\FamilyMatch.apk",
+      discoverySource: "scanFolder",
+      discoveredFromPath: "C:\\Users\\Matt\\Games",
+      fileSizeBytes: 1024000,
+    },
+  ],
+};
+
+const manualApkCandidateFixture: ApkCandidate = {
+  stableId: "apk:c:\\users\\matt\\downloads\\manualchoice.apk",
+  fileName: "ManualChoice.apk",
+  sourcePath: "C:\\Users\\Matt\\Downloads\\ManualChoice.apk",
+  discoverySource: "manualSelection",
+  discoveredFromPath: null,
+  fileSizeBytes: 3072000,
+};
+
 const unsupportedSetupFixture: SetupGateState = {
   ...missingToolFixture,
   status: "unsupported",
@@ -273,6 +309,10 @@ describe("App", () => {
         return installedTitlesFixture;
       }
 
+      if (command === "load_apk_discovery_snapshot") {
+        return apkDiscoveryFixture;
+      }
+
       throw new Error(`Unexpected command: ${command}`);
     });
 
@@ -302,6 +342,10 @@ describe("App", () => {
 
       if (command === "load_installed_titles_snapshot") {
         return installedTitlesFixture;
+      }
+
+      if (command === "load_apk_discovery_snapshot") {
+        return apkDiscoveryFixture;
       }
 
       if (command === "acquire_bdb_tool") {
@@ -342,6 +386,10 @@ describe("App", () => {
 
       if (command === "load_installed_titles_snapshot") {
         return installedTitlesFixture;
+      }
+
+      if (command === "load_apk_discovery_snapshot") {
+        return apkDiscoveryFixture;
       }
 
       if (command === "save_desktop_settings") {
@@ -401,6 +449,10 @@ describe("App", () => {
         return installedTitlesFixture;
       }
 
+      if (command === "load_apk_discovery_snapshot") {
+        return apkDiscoveryFixture;
+      }
+
       throw new Error(`Unexpected command: ${command}`);
     });
 
@@ -432,6 +484,10 @@ describe("App", () => {
         return installedTitlesFixture;
       }
 
+      if (command === "load_apk_discovery_snapshot") {
+        return apkDiscoveryFixture;
+      }
+
       throw new Error(`Unexpected command: ${command}`);
     });
 
@@ -460,6 +516,10 @@ describe("App", () => {
 
       if (command === "load_installed_titles_snapshot") {
         return installedTitlesFixture;
+      }
+
+      if (command === "load_apk_discovery_snapshot") {
+        return apkDiscoveryFixture;
       }
 
       throw new Error(`Unexpected command: ${command}`);
@@ -517,6 +577,10 @@ describe("App", () => {
         return installedTitlesFixture;
       }
 
+      if (command === "load_apk_discovery_snapshot") {
+        return apkDiscoveryFixture;
+      }
+
       throw new Error(`Unexpected command: ${command}`);
     });
 
@@ -528,6 +592,50 @@ describe("App", () => {
     expect(await screen.findByText("Lucky Dice")).toBeInTheDocument();
     expect(screen.getByText("Family Match")).toBeInTheDocument();
     expect(screen.getAllByText("Launch ready")).toHaveLength(2);
+  });
+
+  it("shows scanned APK candidates and lets players choose a manual APK", async () => {
+    openMock.mockResolvedValue("C:\\Users\\Matt\\Downloads\\ManualChoice.apk");
+    invokeMock.mockImplementation(async (command) => {
+      if (command === "load_setup_gate_state") {
+        return runnableFixture;
+      }
+
+      if (command === "load_desktop_settings") {
+        return desktopSettingsFixture;
+      }
+
+      if (command === "load_device_status_snapshot") {
+        return deviceStatusFixture;
+      }
+
+      if (command === "load_installed_titles_snapshot") {
+        return installedTitlesFixture;
+      }
+
+      if (command === "load_apk_discovery_snapshot") {
+        return apkDiscoveryFixture;
+      }
+
+      if (command === "inspect_manual_apk_path") {
+        return manualApkCandidateFixture;
+      }
+
+      throw new Error(`Unexpected command: ${command}`);
+    });
+
+    render(<App />);
+
+    expect(await screen.findByText("Your desktop install space is ready")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /APK Library/ }));
+
+    expect(await screen.findByText("LuckyDice.apk")).toBeInTheDocument();
+    expect(screen.getByText("FamilyMatch.apk")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Choose APK" }));
+
+    expect(await screen.findByText("Latest manual APK pick")).toBeInTheDocument();
+    expect(screen.getAllByText("ManualChoice.apk").length).toBeGreaterThanOrEqual(1);
   });
 
   it("shows a friendly host failure message", async () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,8 @@ import { open } from "@tauri-apps/plugin-dialog";
 import { useEffect, useEffectEvent, useMemo, useState } from "react";
 import {
   acquireBdbTool,
+  inspectManualApkPath,
+  loadApkDiscoverySnapshot,
   loadDesktopSettings,
   loadDeviceStatusSnapshot,
   loadInstalledTitlesSnapshot,
@@ -10,6 +12,8 @@ import {
   saveDesktopSettings,
 } from "./desktop/client";
 import type {
+  ApkCandidate,
+  ApkDiscoverySnapshot,
   BdbAcquisitionResult,
   DesktopSettings,
   DesktopSettingsInput,
@@ -150,6 +154,19 @@ function App() {
     errorMessage: null,
     errorDetail: null,
   });
+  const [apkDiscoveryState, setApkDiscoveryState] = useState<{
+    loading: boolean;
+    snapshot: ApkDiscoverySnapshot | null;
+    manualCandidate: ApkCandidate | null;
+    errorMessage: string | null;
+    errorDetail: string | null;
+  }>({
+    loading: false,
+    snapshot: null,
+    manualCandidate: null,
+    errorMessage: null,
+    errorDetail: null,
+  });
   const [windowFocused, setWindowFocused] = useState(true);
   const [documentVisible, setDocumentVisible] = useState(
     typeof document === "undefined" ? true : document.visibilityState !== "hidden",
@@ -255,6 +272,42 @@ function App() {
     },
   );
 
+  const refreshApkDiscovery = useEffectEvent(
+    async (source: "initial" | "manual" = "manual"): Promise<void> => {
+      if (setupGateState?.status !== "ready") {
+        return;
+      }
+
+      setApkDiscoveryState((previous) => ({
+        ...previous,
+        loading: true,
+        errorMessage: null,
+        errorDetail: null,
+      }));
+
+      try {
+        const snapshot = await loadApkDiscoverySnapshot();
+        setApkDiscoveryState((previous) => ({
+          ...previous,
+          loading: false,
+          snapshot,
+          errorMessage: null,
+          errorDetail: null,
+        }));
+      } catch {
+        setApkDiscoveryState((previous) => ({
+          ...previous,
+          loading: false,
+          errorMessage: "BE Home couldn't refresh the current APK scan just yet.",
+          errorDetail:
+            source === "initial"
+              ? "You can try again from the APK Library section once the workspace finishes loading."
+              : "Please try rescanning the current folders again in a moment.",
+        }));
+      }
+    },
+  );
+
   useEffect(() => {
     const handleVisibilityChange = () => {
       setDocumentVisible(document.visibilityState !== "hidden");
@@ -323,6 +376,21 @@ function App() {
     }
 
     void refreshInstalledTitles("initial");
+  }, [setupGateState?.status]);
+
+  useEffect(() => {
+    if (setupGateState?.status !== "ready") {
+      setApkDiscoveryState({
+        loading: false,
+        snapshot: null,
+        manualCandidate: null,
+        errorMessage: null,
+        errorDetail: null,
+      });
+      return;
+    }
+
+    void refreshApkDiscovery("initial");
   }, [setupGateState?.status]);
 
   async function refreshSetupGateState(options?: {
@@ -541,6 +609,51 @@ function App() {
     });
   }
 
+  async function handleChooseManualApk(): Promise<void> {
+    const selectedPath = await pickSinglePath(
+      await open({
+        directory: false,
+        filters: [
+          {
+            name: "Android Packages",
+            extensions: ["apk"],
+          },
+        ],
+        multiple: false,
+        defaultPath:
+          desktopSettings?.scanFolders[0]?.path ?? desktopSettings?.apkLibrary.effectivePath,
+      }),
+    );
+    if (selectedPath === null) {
+      return;
+    }
+
+    setApkDiscoveryState((previous) => ({
+      ...previous,
+      loading: true,
+      errorMessage: null,
+      errorDetail: null,
+    }));
+
+    try {
+      const manualCandidate = await inspectManualApkPath(selectedPath);
+      setApkDiscoveryState((previous) => ({
+        ...previous,
+        loading: false,
+        manualCandidate,
+        errorMessage: null,
+        errorDetail: null,
+      }));
+    } catch {
+      setApkDiscoveryState((previous) => ({
+        ...previous,
+        loading: false,
+        errorMessage: "BE Home couldn't inspect that APK just yet.",
+        errorDetail: "Choose another `.apk` file or try the same file again in a moment.",
+      }));
+    }
+  }
+
   if (errorMessage !== null) {
     return (
       <main className="page-shell desktop-shell">
@@ -706,6 +819,13 @@ function App() {
                   installedTitlesState={installedTitlesState}
                   onRefresh={() => void refreshInstalledTitles("manual")}
                 />
+              ) : activeWorkspaceSection === "apkLibrary" ? (
+                <ApkLibraryWorkspacePanel
+                  apkDiscoveryState={apkDiscoveryState}
+                  desktopSettings={desktopSettings}
+                  onChooseManualApk={() => void handleChooseManualApk()}
+                  onRefresh={() => void refreshApkDiscovery("manual")}
+                />
               ) : (
                 <>
                   <article className="panel desktop-workspace-panel">
@@ -745,6 +865,151 @@ function App() {
         )}
       </section>
     </main>
+  );
+}
+
+interface ApkLibraryWorkspacePanelProps {
+  apkDiscoveryState: {
+    loading: boolean;
+    snapshot: ApkDiscoverySnapshot | null;
+    manualCandidate: ApkCandidate | null;
+    errorMessage: string | null;
+    errorDetail: string | null;
+  };
+  desktopSettings: DesktopSettings | null;
+  onChooseManualApk: () => void;
+  onRefresh: () => void;
+}
+
+function ApkLibraryWorkspacePanel({
+  apkDiscoveryState,
+  desktopSettings,
+  onChooseManualApk,
+  onRefresh,
+}: ApkLibraryWorkspacePanelProps) {
+  const snapshot = apkDiscoveryState.snapshot;
+  const scanFolderCount = desktopSettings?.scanFolders.length ?? 0;
+
+  return (
+    <>
+      <article className="panel desktop-workspace-panel">
+        <div className="eyebrow">APK Library</div>
+        <h2>Keep local APK discovery simple and repeatable.</h2>
+        <p className="panel-description">
+          BE Home can walk your configured scan folders for `.apk` files, then keep manual file
+          picks on the same discovery model so the later heuristic and library steps have one place
+          to build from.
+        </p>
+
+        {snapshot !== null ? (
+          <article
+            className={`desktop-status-band desktop-status-band--${apkDiscoveryStatusTone(snapshot.status)}`}
+          >
+            <span className="desktop-status-band-label">
+              {apkDiscoveryStatusLabel(snapshot.status)}
+            </span>
+            <h3>{snapshot.summary}</h3>
+            <p>{snapshot.guidance}</p>
+          </article>
+        ) : null}
+
+        {apkDiscoveryState.errorMessage !== null ? (
+          <article className="desktop-inline-message desktop-inline-message--warning">
+            <h3>{apkDiscoveryState.errorMessage}</h3>
+            {apkDiscoveryState.errorDetail !== null ? (
+              <p>{apkDiscoveryState.errorDetail}</p>
+            ) : null}
+          </article>
+        ) : null}
+
+        <dl className="desktop-detail-grid">
+          <DetailRow
+            label="Scan folders"
+            value={scanFolderCount === 0 ? "No folders configured yet" : String(scanFolderCount)}
+          />
+          <DetailRow
+            label="Scanned APKs"
+            value={snapshot ? String(snapshot.candidates.length) : "Loading..."}
+          />
+          <DetailRow
+            label="Manual pick"
+            value={
+              apkDiscoveryState.manualCandidate?.fileName ??
+              "Choose an `.apk` when you already know the file you want."
+            }
+          />
+        </dl>
+
+        <div className="desktop-action-row">
+          <button
+            className="primary-button"
+            disabled={apkDiscoveryState.loading}
+            onClick={onChooseManualApk}
+            type="button"
+          >
+            Choose APK
+          </button>
+          <button
+            className="secondary-button"
+            disabled={apkDiscoveryState.loading}
+            onClick={onRefresh}
+            type="button"
+          >
+            {apkDiscoveryState.loading ? "Scanning..." : "Rescan folders"}
+          </button>
+        </div>
+      </article>
+
+      <article className="panel desktop-workspace-panel">
+        <div className="eyebrow">Current candidates</div>
+        <h2>See what BE Home has already discovered.</h2>
+        <p className="panel-description">
+          Duplicate scan results stay collapsed to a stable path-based identity, so rescans do not
+          fill this list with repeat entries.
+        </p>
+
+        {apkDiscoveryState.manualCandidate !== null ? (
+          <article className="desktop-inline-card">
+            <h3>Latest manual APK pick</h3>
+            <p>{apkDiscoveryState.manualCandidate.fileName}</p>
+            <p>{apkDiscoveryState.manualCandidate.sourcePath}</p>
+          </article>
+        ) : null}
+
+        {snapshot === null ? (
+          <article className="desktop-inline-card">
+            <h3>Scanning the current APK folders.</h3>
+            <p>BE Home is walking the configured folders for `.apk` files now.</p>
+          </article>
+        ) : snapshot.candidates.length === 0 ? (
+          <article className="desktop-inline-card">
+            <h3>{snapshot.summary}</h3>
+            <p>{snapshot.guidance}</p>
+          </article>
+        ) : (
+          <ul className="desktop-inventory-list">
+            {snapshot.candidates.map((candidate) => (
+              <li className="desktop-inventory-item" key={candidate.stableId}>
+                <div className="desktop-inventory-copy">
+                  <h3>{candidate.fileName}</h3>
+                  <p>{candidate.sourcePath}</p>
+                </div>
+                <div className="desktop-inventory-meta">
+                  <span className="desktop-inventory-pill">
+                    {candidate.discoverySource === "manualSelection"
+                      ? "Manual pick"
+                      : "Scan result"}
+                  </span>
+                  <span className="desktop-inventory-pill">
+                    {formatFileSize(candidate.fileSizeBytes)}
+                  </span>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </article>
+    </>
   );
 }
 
@@ -1599,6 +1864,29 @@ function installedTitlesStatusTone(
   }
 }
 
+function apkDiscoveryStatusLabel(value: ApkDiscoverySnapshot["status"]): string {
+  switch (value) {
+    case "ready":
+      return "Candidates found";
+    case "empty":
+      return "Nothing found yet";
+    default:
+      return value;
+  }
+}
+
+function apkDiscoveryStatusTone(
+  value: ApkDiscoverySnapshot["status"],
+): "success" | "warning" | "neutral" {
+  switch (value) {
+    case "ready":
+      return "success";
+    case "empty":
+    default:
+      return "neutral";
+  }
+}
+
 function buildDeviceGuidanceContent(
   snapshot: DeviceStatusSnapshot,
   setupGateState: SetupGateState,
@@ -1700,6 +1988,18 @@ function buildDeviceGuidanceContent(
         primaryActionLabel: "Refresh device check",
       };
   }
+}
+
+function formatFileSize(value: number): string {
+  if (value >= 1024 * 1024) {
+    return `${(value / (1024 * 1024)).toFixed(1)} MB`;
+  }
+
+  if (value >= 1024) {
+    return `${Math.round(value / 1024)} KB`;
+  }
+
+  return `${value} bytes`;
 }
 
 async function pickSinglePath(

--- a/src/desktop/client.ts
+++ b/src/desktop/client.ts
@@ -1,5 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import type {
+  ApkCandidate,
+  ApkDiscoverySnapshot,
   BdbAcquisitionResult,
   BdbSourcePlan,
   BdbToolState,
@@ -17,6 +19,22 @@ import type {
  */
 export function loadSetupGateState(): Promise<SetupGateState> {
   return invoke<SetupGateState>("load_setup_gate_state");
+}
+
+/**
+ * Loads the current APK discovery snapshot built from configured scan folders.
+ */
+export function loadApkDiscoverySnapshot(): Promise<ApkDiscoverySnapshot> {
+  return invoke<ApkDiscoverySnapshot>("load_apk_discovery_snapshot");
+}
+
+/**
+ * Inspects one manually selected APK path and returns a normalized candidate model.
+ */
+export function inspectManualApkPath(path: string): Promise<ApkCandidate> {
+  return invoke<ApkCandidate>("inspect_manual_apk_path", {
+    input: { path },
+  });
 }
 
 /**

--- a/src/desktop/types.ts
+++ b/src/desktop/types.ts
@@ -25,6 +25,38 @@ export interface SetupGateState {
 }
 
 /**
+ * Describes whether a candidate came from configured scan folders or a manual file pick.
+ */
+export type ApkCandidateSource = "scanFolder" | "manualSelection";
+
+/**
+ * Describes whether the current APK discovery result has content to show.
+ */
+export type ApkDiscoveryStatus = "ready" | "empty";
+
+/**
+ * Describes one locally discovered APK candidate.
+ */
+export interface ApkCandidate {
+  stableId: string;
+  fileName: string;
+  sourcePath: string;
+  discoverySource: ApkCandidateSource;
+  discoveredFromPath: string | null;
+  fileSizeBytes: number;
+}
+
+/**
+ * Describes the current APK discovery snapshot built from configured scan folders.
+ */
+export interface ApkDiscoverySnapshot {
+  status: ApkDiscoveryStatus;
+  summary: string;
+  guidance: string;
+  candidates: ApkCandidate[];
+}
+
+/**
  * Describes the normalized device-connection state for the current `bdb` session.
  */
 export type DeviceStatusKind =


### PR DESCRIPTION
## Summary
- add a host-side APK discovery snapshot that walks configured scan folders and deduplicates rescan results
- support manual APK file picks through the same candidate model used for scanned files
- replace the placeholder APK Library section with a real discovery view and explicit rescan flow

## Testing
- `npm run build`
- `npm run test`

Closes #21