### PR TITLE
Add Board APK confidence heuristics

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -9,6 +9,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -46,6 +57,15 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "atk"
@@ -105,6 +125,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-dialog",
  "tempfile",
+ "zip",
 ]
 
 [[package]]
@@ -204,6 +225,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "bzip2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47"
+dependencies = [
+ "bzip2-sys",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "cairo-rs"
 version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -277,6 +317,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -332,6 +374,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -340,6 +392,12 @@ dependencies = [
  "bytes",
  "memchr",
 ]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "convert_case"
@@ -405,6 +463,21 @@ checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
 name = "crc32fast"
@@ -525,6 +598,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "deflate64"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac6b926516df9c60bfa16e107b21086399f8285a44ca9711344b9e553c5146e2"
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -532,6 +611,17 @@ checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
  "serde_core",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -576,6 +666,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1277,6 +1368,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "html5ever"
 version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1578,6 +1678,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1664,6 +1773,16 @@ checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
 ]
 
 [[package]]
@@ -1810,6 +1929,27 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "lzma-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e"
+dependencies = [
+ "byteorder",
+ "crc",
+]
+
+[[package]]
+name = "lzma-sys"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
 
 [[package]]
 name = "mac"
@@ -2183,6 +2323,16 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
 ]
 
 [[package]]
@@ -3271,6 +3421,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930"
 dependencies = [
  "stable_deref_trait",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -5267,6 +5428,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "xz2"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
+dependencies = [
+ "lzma-sys",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5335,6 +5505,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "zerotrie"
@@ -5370,7 +5554,77 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "aes",
+ "arbitrary",
+ "bzip2",
+ "constant_time_eq",
+ "crc32fast",
+ "crossbeam-utils",
+ "deflate64",
+ "displaydoc",
+ "flate2",
+ "getrandom 0.3.4",
+ "hmac",
+ "indexmap 2.14.0",
+ "lzma-rs",
+ "memchr",
+ "pbkdf2",
+ "sha1",
+ "thiserror 2.0.18",
+ "time",
+ "xz2",
+ "zeroize",
+ "zopfli",
+ "zstd",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,6 +18,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tauri = { version = "2", features = [] }
 tauri-plugin-dialog = "2"
+zip = "2"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src-tauri/src/apk.rs
+++ b/src-tauri/src/apk.rs
@@ -522,7 +522,7 @@ mod tests {
         let downloads = temp_directory.path().join("Downloads");
         let nested = downloads.join("nested");
         fs::create_dir_all(&nested).expect("nested folder should exist");
-        fs::write(nested.join("LuckyDice.apk"), "apk").expect("apk should exist");
+        write_apk(&nested.join("LuckyDice.apk"), true, "fun.board.luckydice");
         symlink(&downloads, nested.join("loop")).expect("directory symlink should exist");
 
         let snapshot = build_apk_discovery_snapshot(vec![downloads.to_string_lossy().into_owned()]);

--- a/src-tauri/src/apk.rs
+++ b/src-tauri/src/apk.rs
@@ -1,8 +1,12 @@
 use crate::storage;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
-use std::fs;
+use std::fs::{self, File};
+use std::io::Read;
 use std::path::{Path, PathBuf};
+use zip::ZipArchive;
+
+const BOARD_STRONG_MARKER: &str = "libnativeBoardSDK.so";
 
 /// Describes whether a candidate came from configured scan folders or a manual file pick.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
@@ -20,6 +24,15 @@ pub(crate) enum ApkDiscoveryStatus {
     Empty,
 }
 
+/// Describes the Board-confidence level detected for one APK candidate.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) enum ApkConfidence {
+    StrongMatch,
+    PossibleMatch,
+    Unknown,
+}
+
 /// Describes one locally discovered APK candidate.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -30,6 +43,9 @@ pub(crate) struct ApkCandidate {
     pub(crate) discovery_source: ApkCandidateSource,
     pub(crate) discovered_from_path: Option<String>,
     pub(crate) file_size_bytes: u64,
+    pub(crate) package_name: Option<String>,
+    pub(crate) confidence: ApkConfidence,
+    pub(crate) confidence_summary: String,
 }
 
 /// Describes the current APK discovery snapshot built from configured scan folders.
@@ -47,6 +63,12 @@ pub(crate) struct ApkDiscoverySnapshot {
 #[serde(rename_all = "camelCase")]
 pub(crate) struct ManualApkPathInput {
     path: String,
+}
+
+#[derive(Clone, Debug)]
+struct ApkInspection {
+    package_name: Option<String>,
+    confidence: ApkConfidence,
 }
 
 /// Scan the configured folders for local APK candidates.
@@ -69,6 +91,7 @@ pub(crate) fn inspect_manual_apk_path(input: ManualApkPathInput) -> Result<ApkCa
 
 fn build_apk_discovery_snapshot(scan_folder_paths: Vec<String>) -> ApkDiscoverySnapshot {
     let mut candidates_by_key = BTreeMap::new();
+    let mut scanned_apk_count = 0usize;
 
     for scan_folder_path in scan_folder_paths {
         let folder_path = PathBuf::from(&scan_folder_path);
@@ -77,12 +100,15 @@ fn build_apk_discovery_snapshot(scan_folder_paths: Vec<String>) -> ApkDiscoveryS
         }
 
         for apk_path in walk_apk_files(&folder_path) {
+            scanned_apk_count += 1;
             if let Ok(candidate) = build_apk_candidate(
                 &apk_path,
                 ApkCandidateSource::ScanFolder,
                 Some(scan_folder_path.clone()),
             ) {
-                candidates_by_key.entry(candidate.stable_id.clone()).or_insert(candidate);
+                if candidate.confidence == ApkConfidence::StrongMatch {
+                    candidates_by_key.entry(candidate.stable_id.clone()).or_insert(candidate);
+                }
             }
         }
     }
@@ -98,7 +124,12 @@ fn build_apk_discovery_snapshot(scan_folder_paths: Vec<String>) -> ApkDiscoveryS
     if candidates.is_empty() {
         return ApkDiscoverySnapshot {
             status: ApkDiscoveryStatus::Empty,
-            summary: "BE Home did not find any APK files in the current scan folders yet.".into(),
+            summary: if scanned_apk_count == 0 {
+                "BE Home did not find any APK files in the current scan folders yet.".into()
+            } else {
+                "BE Home found APK files, but none of them showed the strongest Board marker yet."
+                    .into()
+            },
             guidance:
                 "Choose a manual APK when you already know the file you want, or add another scan folder in settings."
                     .into(),
@@ -108,7 +139,10 @@ fn build_apk_discovery_snapshot(scan_folder_paths: Vec<String>) -> ApkDiscoveryS
 
     ApkDiscoverySnapshot {
         status: ApkDiscoveryStatus::Ready,
-        summary: format!("BE Home found {} APK file(s) across the current scan folders.", candidates.len()),
+        summary: format!(
+            "BE Home found {} strong Board APK match(es) across the current scan folders.",
+            candidates.len()
+        ),
         guidance:
             "Use rescan after you add new downloads to a watched folder, or choose a file manually when you already know where it lives."
                 .into(),
@@ -157,7 +191,9 @@ fn build_apk_candidate(
         path.to_path_buf()
     } else {
         std::env::current_dir()
-            .map_err(|error| format!("BE Home could not resolve the current working directory: {error}"))?
+            .map_err(|error| {
+                format!("BE Home could not resolve the current working directory: {error}")
+            })?
             .join(path)
     };
 
@@ -172,6 +208,7 @@ fn build_apk_candidate(
                 absolute_path.display()
             )
         })?;
+    let inspection = inspect_apk_contents(&absolute_path)?;
 
     Ok(ApkCandidate {
         stable_id: format!("apk:{}", path_identity_key(&source_path)),
@@ -180,7 +217,144 @@ fn build_apk_candidate(
         discovery_source,
         discovered_from_path,
         file_size_bytes: metadata.len(),
+        package_name: inspection.package_name,
+        confidence: inspection.confidence,
+        confidence_summary: confidence_summary(inspection.confidence).into(),
     })
+}
+
+fn inspect_apk_contents(path: &Path) -> Result<ApkInspection, String> {
+    let file = File::open(path).map_err(|error| {
+        format!(
+            "BE Home could not open the APK archive at `{}`: {error}",
+            path.display()
+        )
+    })?;
+    let mut archive = ZipArchive::new(file).map_err(|error| {
+        format!(
+            "BE Home could not read `{}` as an APK archive: {error}",
+            path.display()
+        )
+    })?;
+
+    let mut found_strong_marker = false;
+    let mut found_possible_marker = false;
+    for name in archive.file_names() {
+        if name.ends_with(BOARD_STRONG_MARKER) {
+            found_strong_marker = true;
+        }
+
+        if (name.starts_with("lib/") && name.ends_with(".so")) || name == "AndroidManifest.xml" {
+            found_possible_marker = true;
+        }
+    }
+
+    let package_name = extract_package_name(&mut archive);
+    let confidence = if found_strong_marker {
+        ApkConfidence::StrongMatch
+    } else if found_possible_marker {
+        ApkConfidence::PossibleMatch
+    } else {
+        ApkConfidence::Unknown
+    };
+
+    Ok(ApkInspection {
+        package_name,
+        confidence,
+    })
+}
+
+fn extract_package_name(archive: &mut ZipArchive<File>) -> Option<String> {
+    let mut manifest = archive.by_name("AndroidManifest.xml").ok()?;
+    let mut bytes = Vec::new();
+    manifest.read_to_end(&mut bytes).ok()?;
+
+    let mut candidates = extract_ascii_strings(&bytes);
+    candidates.extend(extract_utf16le_strings(&bytes));
+    candidates
+        .into_iter()
+        .filter(|candidate| looks_like_package_name(candidate))
+        .filter(|candidate| !is_common_non_app_package(candidate))
+        .max_by_key(package_name_score)
+}
+
+fn extract_ascii_strings(bytes: &[u8]) -> Vec<String> {
+    let mut strings = Vec::new();
+    let mut current = String::new();
+
+    for byte in bytes {
+        let character = *byte as char;
+        if character.is_ascii_alphanumeric() || matches!(character, '.' | '_' | '-') {
+            current.push(character);
+        } else {
+            if current.len() >= 6 {
+                strings.push(current.clone());
+            }
+            current.clear();
+        }
+    }
+
+    if current.len() >= 6 {
+        strings.push(current);
+    }
+
+    strings
+}
+
+fn extract_utf16le_strings(bytes: &[u8]) -> Vec<String> {
+    let mut strings = Vec::new();
+    let mut current = String::new();
+
+    for chunk in bytes.chunks_exact(2) {
+        let low = chunk[0] as char;
+        let high = chunk[1];
+        if high == 0
+            && (low.is_ascii_alphanumeric() || matches!(low, '.' | '_' | '-'))
+        {
+            current.push(low);
+        } else {
+            if current.len() >= 6 {
+                strings.push(current.clone());
+            }
+            current.clear();
+        }
+    }
+
+    if current.len() >= 6 {
+        strings.push(current);
+    }
+
+    strings
+}
+
+fn package_name_score(value: &String) -> usize {
+    value.split('.').count() * 10 + value.len()
+}
+
+fn is_common_non_app_package(value: &str) -> bool {
+    let lowered = value.to_ascii_lowercase();
+    matches!(
+        lowered.as_str(),
+        value if value.starts_with("android.")
+            || value.starts_with("com.unity3d")
+            || value.starts_with("com.google.")
+            || value.starts_with("org.apache.")
+            || value.starts_with("kotlin.")
+    )
+}
+
+fn confidence_summary(confidence: ApkConfidence) -> &'static str {
+    match confidence {
+        ApkConfidence::StrongMatch => {
+            "BE Home found a strong Board SDK marker in this APK."
+        }
+        ApkConfidence::PossibleMatch => {
+            "BE Home found some Android packaging signals, but not the strongest Board marker yet."
+        }
+        ApkConfidence::Unknown => {
+            "BE Home did not find a clear Board marker in this APK yet."
+        }
+    }
 }
 
 fn normalize_apk_path(value: &str) -> Result<PathBuf, String> {
@@ -214,6 +388,21 @@ fn is_apk_path(path: &Path) -> bool {
         .is_some_and(|extension| extension.eq_ignore_ascii_case("apk"))
 }
 
+fn looks_like_package_name(value: &str) -> bool {
+    if value.contains(' ') || !value.contains('.') {
+        return false;
+    }
+
+    let segments = value.split('.').collect::<Vec<_>>();
+    if segments.len() < 2 || segments.iter().any(|segment| segment.is_empty()) {
+        return false;
+    }
+
+    value.chars().all(|character| {
+        character.is_ascii_alphanumeric() || matches!(character, '.' | '_' | '-')
+    }) && value.chars().any(|character| character.is_ascii_lowercase())
+}
+
 fn path_identity_key(path: &str) -> String {
     #[cfg(target_os = "windows")]
     {
@@ -234,10 +423,13 @@ fn path_to_string(path: &Path) -> String {
 mod tests {
     use super::{
         build_apk_candidate, build_apk_discovery_snapshot, inspect_manual_apk_path,
-        ApkCandidateSource, ApkDiscoveryStatus, ManualApkPathInput,
+        ApkCandidateSource, ApkConfidence, ApkDiscoveryStatus, ManualApkPathInput,
     };
-    use std::fs;
-    use std::path::PathBuf;
+    use std::fs::{self, File};
+    use std::io::Write;
+    use std::path::{Path, PathBuf};
+    use zip::write::SimpleFileOptions;
+    use zip::{CompressionMethod, ZipWriter};
 
     #[test]
     fn discovery_snapshot_walks_nested_scan_folders_and_deduplicates_results() {
@@ -246,8 +438,16 @@ mod tests {
         let downloads = root.join("Downloads");
         let nested = downloads.join("nested");
         fs::create_dir_all(&nested).expect("nested folder should exist");
-        fs::write(downloads.join("LuckyDice.apk"), "apk").expect("top-level apk should exist");
-        fs::write(nested.join("FamilyMatch.apk"), "apk").expect("nested apk should exist");
+        write_apk(
+            &downloads.join("LuckyDice.apk"),
+            true,
+            "fun.board.luckydice",
+        );
+        write_apk(
+            &nested.join("FamilyMatch.apk"),
+            false,
+            "fun.board.familymatch",
+        );
 
         let snapshot = build_apk_discovery_snapshot(vec![
             downloads.to_string_lossy().into_owned(),
@@ -255,15 +455,16 @@ mod tests {
         ]);
 
         assert_eq!(ApkDiscoveryStatus::Ready, snapshot.status);
-        assert_eq!(2, snapshot.candidates.len());
+        assert_eq!(1, snapshot.candidates.len());
+        assert_eq!(ApkConfidence::StrongMatch, snapshot.candidates[0].confidence);
     }
 
     #[test]
-    fn discovery_snapshot_reports_empty_when_no_apks_are_found() {
+    fn discovery_snapshot_reports_empty_when_no_strong_board_matches_are_found() {
         let temp_directory = tempfile::tempdir().expect("temporary directory should exist");
         let downloads = temp_directory.path().join("Downloads");
         fs::create_dir_all(&downloads).expect("downloads should exist");
-        fs::write(downloads.join("notes.txt"), "not an apk").expect("text file should exist");
+        write_apk(&downloads.join("notes.apk"), false, "fun.board.notes");
 
         let snapshot = build_apk_discovery_snapshot(vec![downloads.to_string_lossy().into_owned()]);
 
@@ -281,10 +482,10 @@ mod tests {
     }
 
     #[test]
-    fn manual_apk_inspection_returns_a_manual_candidate() {
+    fn manual_apk_inspection_returns_a_manual_candidate_with_strong_confidence() {
         let temp_directory = tempfile::tempdir().expect("temporary directory should exist");
         let apk_path = temp_directory.path().join("LuckyDice.apk");
-        fs::write(&apk_path, "apk").expect("apk should exist");
+        write_apk(&apk_path, true, "fun.board.luckydice");
 
         let candidate = inspect_manual_apk_path(ManualApkPathInput {
             path: apk_path.to_string_lossy().into_owned(),
@@ -292,8 +493,22 @@ mod tests {
         .expect("manual apk inspection should succeed");
 
         assert_eq!(ApkCandidateSource::ManualSelection, candidate.discovery_source);
-        assert_eq!("LuckyDice.apk", candidate.file_name);
-        assert_eq!(None, candidate.discovered_from_path);
+        assert_eq!(ApkConfidence::StrongMatch, candidate.confidence);
+        assert_eq!(Some("fun.board.luckydice"), candidate.package_name.as_deref());
+    }
+
+    #[test]
+    fn manual_apk_inspection_can_surface_possible_matches() {
+        let temp_directory = tempfile::tempdir().expect("temporary directory should exist");
+        let apk_path = temp_directory.path().join("PossibleMatch.apk");
+        write_apk(&apk_path, false, "fun.board.possible");
+
+        let candidate = inspect_manual_apk_path(ManualApkPathInput {
+            path: apk_path.to_string_lossy().into_owned(),
+        })
+        .expect("manual apk inspection should succeed");
+
+        assert_eq!(ApkConfidence::PossibleMatch, candidate.confidence);
     }
 
     #[test]
@@ -302,7 +517,7 @@ mod tests {
         let scan_folder = temp_directory.path().join("Downloads");
         let apk_path = scan_folder.join("LuckyDice.apk");
         fs::create_dir_all(&scan_folder).expect("downloads should exist");
-        fs::write(&apk_path, "apk").expect("apk should exist");
+        write_apk(&apk_path, true, "fun.board.luckydice");
 
         let candidate = build_apk_candidate(
             &PathBuf::from(&apk_path),
@@ -315,5 +530,33 @@ mod tests {
             Some(scan_folder.to_string_lossy().into_owned()),
             candidate.discovered_from_path
         );
+    }
+
+    fn write_apk(path: &Path, include_strong_marker: bool, package_name: &str) {
+        let file = File::create(path).expect("apk file should create");
+        let mut writer = ZipWriter::new(file);
+        let options = SimpleFileOptions::default()
+            .compression_method(CompressionMethod::Stored);
+
+        writer
+            .start_file("AndroidManifest.xml", options)
+            .expect("manifest should start");
+        writer
+            .write_all(format!(r#"<manifest package="{package_name}"></manifest>"#).as_bytes())
+            .expect("manifest should write");
+
+        if include_strong_marker {
+            writer
+                .start_file("lib/arm64-v8a/libnativeBoardSDK.so", options)
+                .expect("strong marker should start");
+            writer.write_all(b"board-sdk").expect("strong marker should write");
+        } else {
+            writer
+                .start_file("lib/arm64-v8a/libunity.so", options)
+                .expect("possible marker should start");
+            writer.write_all(b"unity").expect("possible marker should write");
+        }
+
+        writer.finish().expect("apk archive should finish");
     }
 }

--- a/src-tauri/src/apk.rs
+++ b/src-tauri/src/apk.rs
@@ -269,13 +269,32 @@ fn extract_package_name(archive: &mut ZipArchive<File>) -> Option<String> {
     let mut bytes = Vec::new();
     manifest.read_to_end(&mut bytes).ok()?;
 
-    let mut candidates = extract_ascii_strings(&bytes);
-    candidates.extend(extract_utf16le_strings(&bytes));
-    candidates
+    let mut ascii_strings = extract_ascii_strings(&bytes);
+    if let Some(package_name) = extract_manifest_package_candidate(&ascii_strings) {
+        return Some(package_name);
+    }
+
+    let utf16_strings = extract_utf16le_strings(&bytes);
+    if let Some(package_name) = extract_manifest_package_candidate(&utf16_strings) {
+        return Some(package_name);
+    }
+
+    ascii_strings.extend(utf16_strings);
+    ascii_strings
         .into_iter()
         .filter(|candidate| looks_like_package_name(candidate))
         .filter(|candidate| !is_common_non_app_package(candidate))
         .max_by_key(package_name_score)
+}
+
+fn extract_manifest_package_candidate(strings: &[String]) -> Option<String> {
+    strings
+        .windows(2)
+        .find(|window| window[0].eq_ignore_ascii_case("package"))
+        .and_then(|window| window.get(1))
+        .filter(|candidate| looks_like_package_name(candidate))
+        .filter(|candidate| !is_common_non_app_package(candidate))
+        .cloned()
 }
 
 fn extract_ascii_strings(bytes: &[u8]) -> Vec<String> {
@@ -512,6 +531,24 @@ mod tests {
     }
 
     #[test]
+    fn manual_apk_inspection_prefers_the_manifest_package_over_class_names() {
+        let temp_directory = tempfile::tempdir().expect("temporary directory should exist");
+        let apk_path = temp_directory.path().join("LuckyDice.apk");
+        write_apk_with_manifest(
+            &apk_path,
+            true,
+            r#"<manifest package="fun.board.luckydice"><application><activity android:name="fun.board.luckydice.MainActivity" /></application></manifest>"#,
+        );
+
+        let candidate = inspect_manual_apk_path(ManualApkPathInput {
+            path: apk_path.to_string_lossy().into_owned(),
+        })
+        .expect("manual apk inspection should succeed");
+
+        assert_eq!(Some("fun.board.luckydice"), candidate.package_name.as_deref());
+    }
+
+    #[test]
     fn scan_candidates_preserve_the_scan_folder_they_were_found_from() {
         let temp_directory = tempfile::tempdir().expect("temporary directory should exist");
         let scan_folder = temp_directory.path().join("Downloads");
@@ -533,6 +570,14 @@ mod tests {
     }
 
     fn write_apk(path: &Path, include_strong_marker: bool, package_name: &str) {
+        write_apk_with_manifest(
+            path,
+            include_strong_marker,
+            &format!(r#"<manifest package="{package_name}"></manifest>"#),
+        );
+    }
+
+    fn write_apk_with_manifest(path: &Path, include_strong_marker: bool, manifest: &str) {
         let file = File::create(path).expect("apk file should create");
         let mut writer = ZipWriter::new(file);
         let options = SimpleFileOptions::default()
@@ -542,7 +587,7 @@ mod tests {
             .start_file("AndroidManifest.xml", options)
             .expect("manifest should start");
         writer
-            .write_all(format!(r#"<manifest package="{package_name}"></manifest>"#).as_bytes())
+            .write_all(manifest.as_bytes())
             .expect("manifest should write");
 
         if include_strong_marker {

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -201,7 +201,7 @@ const installedTitlesFixture: InstalledTitlesSnapshot = {
 
 const apkDiscoveryFixture: ApkDiscoverySnapshot = {
   status: "ready",
-  summary: "BE Home found 2 APK file(s) across the current scan folders.",
+  summary: "BE Home found 2 strong Board APK match(es) across the current scan folders.",
   guidance:
     "Use rescan after you add new downloads to a watched folder, or choose a file manually when you already know where it lives.",
   candidates: [
@@ -212,6 +212,9 @@ const apkDiscoveryFixture: ApkDiscoverySnapshot = {
       discoverySource: "scanFolder",
       discoveredFromPath: "C:\\Users\\Matt\\Downloads",
       fileSizeBytes: 2048000,
+      packageName: "fun.board.luckydice",
+      confidence: "strongMatch",
+      confidenceSummary: "BE Home found a strong Board SDK marker in this APK.",
     },
     {
       stableId: "apk:c:\\users\\matt\\games\\familymatch.apk",
@@ -220,6 +223,9 @@ const apkDiscoveryFixture: ApkDiscoverySnapshot = {
       discoverySource: "scanFolder",
       discoveredFromPath: "C:\\Users\\Matt\\Games",
       fileSizeBytes: 1024000,
+      packageName: "fun.board.familymatch",
+      confidence: "strongMatch",
+      confidenceSummary: "BE Home found a strong Board SDK marker in this APK.",
     },
   ],
 };
@@ -231,6 +237,10 @@ const manualApkCandidateFixture: ApkCandidate = {
   discoverySource: "manualSelection",
   discoveredFromPath: null,
   fileSizeBytes: 3072000,
+  packageName: "fun.board.manualchoice",
+  confidence: "possibleMatch",
+  confidenceSummary:
+    "BE Home found some Android packaging signals, but not the strongest Board marker yet.",
 };
 
 const unsupportedSetupFixture: SetupGateState = {
@@ -636,6 +646,12 @@ describe("App", () => {
 
     expect(await screen.findByText("Latest manual APK pick")).toBeInTheDocument();
     expect(screen.getAllByText("ManualChoice.apk").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("Possible Board match")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "BE Home found some Android packaging signals, but not the strongest Board marker yet.",
+      ),
+    ).toBeInTheDocument();
   });
 
   it("shows a friendly host failure message", async () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -969,10 +969,20 @@ function ApkLibraryWorkspacePanel({
         </p>
 
         {apkDiscoveryState.manualCandidate !== null ? (
-          <article className="desktop-inline-card">
+          <article
+            className={
+              apkDiscoveryState.manualCandidate.confidence === "strongMatch"
+                ? "desktop-inline-card"
+                : "desktop-inline-message desktop-inline-message--warning"
+            }
+          >
             <h3>Latest manual APK pick</h3>
             <p>{apkDiscoveryState.manualCandidate.fileName}</p>
-            <p>{apkDiscoveryState.manualCandidate.sourcePath}</p>
+            <p>{apkConfidenceLabel(apkDiscoveryState.manualCandidate.confidence)}</p>
+            <p>{apkDiscoveryState.manualCandidate.confidenceSummary}</p>
+            {apkDiscoveryState.manualCandidate.packageName !== null ? (
+              <p>{apkDiscoveryState.manualCandidate.packageName}</p>
+            ) : null}
           </article>
         ) : null}
 
@@ -996,9 +1006,7 @@ function ApkLibraryWorkspacePanel({
                 </div>
                 <div className="desktop-inventory-meta">
                   <span className="desktop-inventory-pill">
-                    {candidate.discoverySource === "manualSelection"
-                      ? "Manual pick"
-                      : "Scan result"}
+                    {apkConfidenceLabel(candidate.confidence)}
                   </span>
                   <span className="desktop-inventory-pill">
                     {formatFileSize(candidate.fileSizeBytes)}
@@ -1884,6 +1892,18 @@ function apkDiscoveryStatusTone(
     case "empty":
     default:
       return "neutral";
+  }
+}
+
+function apkConfidenceLabel(value: ApkCandidate["confidence"]): string {
+  switch (value) {
+    case "strongMatch":
+      return "Strong Board match";
+    case "possibleMatch":
+      return "Possible Board match";
+    case "unknown":
+    default:
+      return "Board match unknown";
   }
 }
 

--- a/src/desktop/types.ts
+++ b/src/desktop/types.ts
@@ -35,6 +35,11 @@ export type ApkCandidateSource = "scanFolder" | "manualSelection";
 export type ApkDiscoveryStatus = "ready" | "empty";
 
 /**
+ * Describes the current Board-confidence level for one APK candidate.
+ */
+export type ApkConfidence = "strongMatch" | "possibleMatch" | "unknown";
+
+/**
  * Describes one locally discovered APK candidate.
  */
 export interface ApkCandidate {
@@ -44,6 +49,9 @@ export interface ApkCandidate {
   discoverySource: ApkCandidateSource;
   discoveredFromPath: string | null;
   fileSizeBytes: number;
+  packageName: string | null;
+  confidence: ApkConfidence;
+  confidenceSummary: string;
 }
 
 /**


### PR DESCRIPTION
## Summary
- inspect APK archives for strong and possible Board markers
- extract package metadata when available and surface stable confidence messaging to the UI
- filter automatic scan results to strong Board matches while keeping manual low-confidence picks visible

## Validation
- npm run build
- npm run test

## Issue
- refs #22