### PR TITLE
Rewrite desktop setup and settings windows (#60)

### DIFF
--- a/config/bdb-sources.json
+++ b/config/bdb-sources.json
@@ -1,8 +1,17 @@
 {
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "platforms": {
-    "linux-x86_64": "https://dev.board.fun/downloads/bdb/linux/bdb",
-    "macos-universal": "https://dev.board.fun/downloads/bdb/macos-universal/bdb",
-    "windows-x86_64": "https://dev.board.fun/downloads/bdb/windows/bdb.exe"
+    "linux-x86_64": {
+      "downloadUrl": "https://dev.board.fun/downloads/bdb/linux/bdb",
+      "version": "Board OS Version: 1.8.1"
+    },
+    "macos-universal": {
+      "downloadUrl": "https://dev.board.fun/downloads/bdb/macos-universal/bdb",
+      "version": "Board OS Version: 1.8.1"
+    },
+    "windows-x86_64": {
+      "downloadUrl": "https://dev.board.fun/downloads/bdb/windows/bdb.exe",
+      "version": "Board OS Version: 1.8.1"
+    }
   }
 }

--- a/src-tauri/src/actions.rs
+++ b/src-tauri/src/actions.rs
@@ -1138,8 +1138,26 @@ mod tests {
                 source: Some(bdb::BdbDownloadSource {
                     platform_key: "windows-x86_64".into(),
                     download_url: "https://example.com/bdb.exe".into(),
+                    version: None,
                 }),
             },
+            version_check: bdb_tool::BdbToolVersionCheck {
+                status: bdb_tool::BdbToolVersionStatus::Available,
+                command: "bdb version".into(),
+                value: Some("Board OS Version: 1.8.1".into()),
+                exit_code: Some(0),
+                summary: "Installed version: Board OS Version: 1.8.1".into(),
+                detail: None,
+            },
+            update_status: bdb_tool::BdbUpdateStatus {
+                status: bdb_tool::BdbUpdateStatusKind::UpToDate,
+                current_version: Some("Board OS Version: 1.8.1".into()),
+                available_version: Some("Board OS Version: 1.8.1".into()),
+                guidance:
+                    "This Board Install Tool matches the latest version in BE Home's source list."
+                        .into(),
+            },
+            support_request_draft: None,
             validation: bdb_tool::BdbRunnableValidation {
                 status: bdb_tool::BdbRunnableStatus::Runnable,
                 command: "bdb help".into(),
@@ -1156,6 +1174,7 @@ mod tests {
             summary: "Board connection looks ready.".into(),
             guidance: "Refresh the connection when you need to.".into(),
             detail: None,
+            board_os_version: Some("1.8.1".into()),
             poll_interval_ms: 5_000,
             bdb_version: device::BdbVersionDetails {
                 status: device::BdbVersionStatus::Available,

--- a/src-tauri/src/bdb.rs
+++ b/src-tauri/src/bdb.rs
@@ -67,7 +67,37 @@ pub(crate) enum BdbArchitecture {
 #[serde(rename_all = "camelCase")]
 struct BdbSourceManifest {
     schema_version: u32,
-    platforms: BTreeMap<String, String>,
+    platforms: BTreeMap<String, BdbSourceManifestPlatform>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(untagged)]
+enum BdbSourceManifestPlatform {
+    SchemaV1(String),
+    SchemaV2(BdbSourceManifestPlatformV2),
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct BdbSourceManifestPlatformV2 {
+    download_url: String,
+    version: Option<String>,
+}
+
+impl BdbSourceManifestPlatform {
+    fn download_url(&self) -> &str {
+        match self {
+            Self::SchemaV1(download_url) => download_url,
+            Self::SchemaV2(platform) => &platform.download_url,
+        }
+    }
+
+    fn version(&self) -> Option<&str> {
+        match self {
+            Self::SchemaV1(_) => None,
+            Self::SchemaV2(platform) => platform.version.as_deref(),
+        }
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -103,6 +133,7 @@ pub(crate) struct BdbPlatformSupport {
 pub(crate) struct BdbDownloadSource {
     pub(crate) platform_key: String,
     pub(crate) download_url: String,
+    pub(crate) version: Option<String>,
 }
 
 /// Describes the maintained source-resolution plan for `bdb` on the current machine.
@@ -188,9 +219,10 @@ fn resolve_bdb_source_plan_for_platform(
             .manifest
             .platforms
             .get(platform_key)
-            .map(|download_url| BdbDownloadSource {
+            .map(|platform| BdbDownloadSource {
                 platform_key: platform_key.clone(),
-                download_url: download_url.clone(),
+                download_url: platform.download_url().to_owned(),
+                version: platform.version().map(str::to_owned),
             })
     });
 
@@ -352,7 +384,7 @@ fn save_cached_manifest(cache_path: &Path, manifest_text: &str) -> Result<(), St
 fn parse_manifest(manifest_text: &str) -> Result<BdbSourceManifest, String> {
     let manifest: BdbSourceManifest = serde_json::from_str(manifest_text)
         .map_err(|error| format!("The bdb manifest JSON was invalid: {error}"))?;
-    if manifest.schema_version != 1 {
+    if manifest.schema_version != 1 && manifest.schema_version != 2 {
         return Err(format!(
             "The bdb manifest used unsupported schema version {}.",
             manifest.schema_version
@@ -433,7 +465,7 @@ mod tests {
     use super::{
         bundled_manifest, load_manifest_with_fallbacks, parse_manifest, parse_windows_build_number,
         resolve_bdb_source_plan_for_platform, BdbArchitecture, BdbOperatingSystem,
-        BdbSupportStatus, BdbUnsupportedReason, DetectedPlatform, LoadedManifest,
+        BdbSourceManifestPlatform, BdbSupportStatus, BdbUnsupportedReason, DetectedPlatform, LoadedManifest,
         LINUX_X86_64_PLATFORM_KEY, MACOS_UNIVERSAL_PLATFORM_KEY, WINDOWS_X86_64_PLATFORM_KEY,
     };
     use std::cell::Cell;
@@ -443,18 +475,27 @@ mod tests {
     fn bundled_manifest_tracks_current_board_download_urls() {
         let manifest = bundled_manifest();
 
-        assert_eq!(1, manifest.schema_version);
+        assert_eq!(2, manifest.schema_version);
         assert_eq!(
-            Some(&"https://dev.board.fun/downloads/bdb/macos-universal/bdb".to_string()),
-            manifest.platforms.get(MACOS_UNIVERSAL_PLATFORM_KEY)
+            Some("https://dev.board.fun/downloads/bdb/macos-universal/bdb"),
+            manifest
+                .platforms
+                .get(MACOS_UNIVERSAL_PLATFORM_KEY)
+                .map(BdbSourceManifestPlatform::download_url)
         );
         assert_eq!(
-            Some(&"https://dev.board.fun/downloads/bdb/linux/bdb".to_string()),
-            manifest.platforms.get(LINUX_X86_64_PLATFORM_KEY)
+            Some("https://dev.board.fun/downloads/bdb/linux/bdb"),
+            manifest
+                .platforms
+                .get(LINUX_X86_64_PLATFORM_KEY)
+                .map(BdbSourceManifestPlatform::download_url)
         );
         assert_eq!(
-            Some(&"https://dev.board.fun/downloads/bdb/windows/bdb.exe".to_string()),
-            manifest.platforms.get(WINDOWS_X86_64_PLATFORM_KEY)
+            Some("https://dev.board.fun/downloads/bdb/windows/bdb.exe"),
+            manifest
+                .platforms
+                .get(WINDOWS_X86_64_PLATFORM_KEY)
+                .map(BdbSourceManifestPlatform::download_url)
         );
     }
 
@@ -475,8 +516,12 @@ mod tests {
 
         assert_eq!("remote", loaded.source);
         assert_eq!(
-            Some(&"https://example.com/linux/bdb".to_string()),
-            loaded.manifest.platforms.get(LINUX_X86_64_PLATFORM_KEY)
+            Some("https://example.com/linux/bdb"),
+            loaded
+                .manifest
+                .platforms
+                .get(LINUX_X86_64_PLATFORM_KEY)
+                .map(BdbSourceManifestPlatform::download_url)
         );
         assert!(fs::read_to_string(cache_path)
             .expect("cache file should be written")
@@ -507,8 +552,12 @@ mod tests {
 
         assert_eq!("cached", loaded.source);
         assert_eq!(
-            Some(&"https://cached.example/bdb".to_string()),
-            loaded.manifest.platforms.get(LINUX_X86_64_PLATFORM_KEY)
+            Some("https://cached.example/bdb"),
+            loaded
+                .manifest
+                .platforms
+                .get(LINUX_X86_64_PLATFORM_KEY)
+                .map(BdbSourceManifestPlatform::download_url)
         );
     }
 
@@ -540,8 +589,12 @@ mod tests {
         assert_eq!("cached", loaded.source);
         assert!(!remote_fetch_attempted.get());
         assert_eq!(
-            Some(&"https://cached.example/bdb".to_string()),
-            loaded.manifest.platforms.get(LINUX_X86_64_PLATFORM_KEY)
+            Some("https://cached.example/bdb"),
+            loaded
+                .manifest
+                .platforms
+                .get(LINUX_X86_64_PLATFORM_KEY)
+                .map(BdbSourceManifestPlatform::download_url)
         );
     }
 
@@ -558,14 +611,18 @@ mod tests {
 
         assert_eq!("bundled", loaded.source);
         assert_eq!(
-            Some(&"https://dev.board.fun/downloads/bdb/linux/bdb".to_string()),
-            loaded.manifest.platforms.get(LINUX_X86_64_PLATFORM_KEY)
+            Some("https://dev.board.fun/downloads/bdb/linux/bdb"),
+            loaded
+                .manifest
+                .platforms
+                .get(LINUX_X86_64_PLATFORM_KEY)
+                .map(BdbSourceManifestPlatform::download_url)
         );
     }
 
     #[test]
     fn manifest_parser_rejects_unknown_schema_versions() {
-        let result = parse_manifest(r#"{"schemaVersion":2,"platforms":{}}"#);
+        let result = parse_manifest(r#"{"schemaVersion":3,"platforms":{}}"#);
 
         assert!(result.is_err());
     }

--- a/src-tauri/src/bdb_tool.rs
+++ b/src-tauri/src/bdb_tool.rs
@@ -10,7 +10,10 @@ use std::process::Command;
 use std::time::Duration;
 
 const BDB_HELP_ARGUMENT: &str = "help";
+const BDB_VERSION_ARGUMENT: &str = "version";
 const BDB_DOWNLOAD_TIMEOUT_SECONDS: u64 = 30;
+const BOARD_SUPPORT_EMAIL: &str = "hello@board.fun";
+const BOARD_SUPPORT_SUBJECT: &str = "OS Support Request for bdb";
 
 /// Describes the local `bdb` readiness state the renderer can consume.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
@@ -30,6 +33,57 @@ pub(crate) enum BdbRunnableStatus {
     Missing,
     Blocked,
     Runnable,
+}
+
+/// Describes whether BE Home could read a friendly Board Install Tool version line.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) enum BdbToolVersionStatus {
+    Available,
+    Unavailable,
+}
+
+/// Describes the latest `bdb version` check for the managed Board Install Tool.
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct BdbToolVersionCheck {
+    pub(crate) status: BdbToolVersionStatus,
+    pub(crate) command: String,
+    pub(crate) value: Option<String>,
+    pub(crate) exit_code: Option<i32>,
+    pub(crate) summary: String,
+    pub(crate) detail: Option<String>,
+}
+
+/// Describes the latest manual update-check result for the managed Board Install Tool.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) enum BdbUpdateStatusKind {
+    UpToDate,
+    UpdateAvailable,
+    Unknown,
+    Unsupported,
+    Error,
+}
+
+/// Describes whether the managed Board Install Tool matches the latest manifest version.
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct BdbUpdateStatus {
+    pub(crate) status: BdbUpdateStatusKind,
+    pub(crate) current_version: Option<String>,
+    pub(crate) available_version: Option<String>,
+    pub(crate) guidance: String,
+}
+
+/// Describes a prefilled Board support request for unsupported-OS cases.
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct SupportRequestDraft {
+    pub(crate) to: String,
+    pub(crate) subject: String,
+    pub(crate) body: String,
+    pub(crate) mailto_url: String,
 }
 
 /// Describes the latest runnable-validation result for the stored `bdb` binary.
@@ -54,6 +108,9 @@ pub(crate) struct BdbToolState {
     pub(crate) executable_exists: bool,
     pub(crate) storage: storage::ManagedStorageLocation,
     pub(crate) source_plan: bdb::BdbSourcePlan,
+    pub(crate) version_check: BdbToolVersionCheck,
+    pub(crate) update_status: BdbUpdateStatus,
+    pub(crate) support_request_draft: Option<SupportRequestDraft>,
     pub(crate) validation: BdbRunnableValidation,
 }
 
@@ -87,6 +144,8 @@ struct UserFacingError {
 #[derive(Clone, Debug)]
 struct ProcessRunOutput {
     exit_code: Option<i32>,
+    stdout: String,
+    stderr: String,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -192,13 +251,26 @@ impl ProcessRunner for CommandProcessRunner {
 
         Ok(ProcessRunOutput {
             exit_code: output.status.code(),
+            stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+            stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
         })
     }
 }
 
 /// Load the current `bdb` tool state for the local machine.
 pub(crate) fn load_current_bdb_tool_state() -> Result<BdbToolState, String> {
-    let source_plan = bdb::resolve_current_bdb_source_plan();
+    load_current_bdb_tool_state_with_remote_refresh(false)
+}
+
+/// Load the current `bdb` tool state, optionally refreshing the remote source manifest first.
+pub(crate) fn load_current_bdb_tool_state_with_remote_refresh(
+    refresh_manifest: bool,
+) -> Result<BdbToolState, String> {
+    let source_plan = if refresh_manifest {
+        bdb::refresh_current_bdb_source_plan()
+    } else {
+        bdb::resolve_current_bdb_source_plan()
+    };
     let storage_settings = storage::load_managed_storage_settings()?;
     Ok(inspect_bdb_tool_state_with_plan_and_runner(
         source_plan,
@@ -232,6 +304,10 @@ fn inspect_bdb_tool_state_with_plan_and_runner<P: ProcessRunner>(
     let validation_command = build_validation_command(&executable_path);
 
     if source_plan.support.status == bdb::BdbSupportStatus::Unsupported {
+        let version_check = unavailable_version_check(
+            &executable_path,
+            "BE Home cannot read a Board Install Tool version for this computer yet.".into(),
+        );
         return BdbToolState {
             status: BdbToolStatus::Unsupported,
             summary: "This computer is outside Board's current bdb support matrix.".into(),
@@ -239,7 +315,10 @@ fn inspect_bdb_tool_state_with_plan_and_runner<P: ProcessRunner>(
             executable_path: path_to_string(&executable_path),
             executable_exists,
             storage: storage_location,
-            source_plan,
+            source_plan: source_plan.clone(),
+            version_check: version_check.clone(),
+            update_status: build_update_status(&source_plan, executable_exists, &version_check),
+            support_request_draft: None,
             validation: BdbRunnableValidation {
                 status: BdbRunnableStatus::Unsupported,
                 command: validation_command,
@@ -251,6 +330,10 @@ fn inspect_bdb_tool_state_with_plan_and_runner<P: ProcessRunner>(
     }
 
     if !executable_exists {
+        let version_check = unavailable_version_check(
+            &executable_path,
+            "BE Home has not downloaded the Board Install Tool yet.".into(),
+        );
         return BdbToolState {
             status: BdbToolStatus::Missing,
             summary: "BE Home has not downloaded bdb into the managed tools folder yet.".into(),
@@ -258,7 +341,10 @@ fn inspect_bdb_tool_state_with_plan_and_runner<P: ProcessRunner>(
             executable_path: path_to_string(&executable_path),
             executable_exists: false,
             storage: storage_location,
-            source_plan,
+            source_plan: source_plan.clone(),
+            version_check: version_check.clone(),
+            update_status: build_update_status(&source_plan, false, &version_check),
+            support_request_draft: None,
             validation: BdbRunnableValidation {
                 status: BdbRunnableStatus::Missing,
                 command: validation_command,
@@ -269,12 +355,21 @@ fn inspect_bdb_tool_state_with_plan_and_runner<P: ProcessRunner>(
         };
     }
 
+    let version_check = load_bdb_tool_version_check(&executable_path, runner);
     let validation = validate_runnable(&executable_path, runner);
+    let support_request_draft =
+        build_support_request_draft(&source_plan, &version_check, &validation);
+    let update_status = build_update_status(&source_plan, executable_exists, &version_check);
     let (status, summary, guidance) = match validation.status {
         BdbRunnableStatus::Runnable => (
             BdbToolStatus::Runnable,
             "Board's install tool is ready to use.".into(),
             "BE Home confirmed that bdb can open from its managed tools folder.".into(),
+        ),
+        BdbRunnableStatus::Blocked if support_request_draft.is_some() => (
+            BdbToolStatus::Downloaded,
+            "BE Home downloaded the Board Install Tool, but this computer is not supported by this build yet.".into(),
+            "You can ask Board about OS support from this step, or switch to another supported computer.".into(),
         ),
         BdbRunnableStatus::Blocked => (
             BdbToolStatus::Downloaded,
@@ -301,6 +396,9 @@ fn inspect_bdb_tool_state_with_plan_and_runner<P: ProcessRunner>(
         executable_exists,
         storage: storage_location,
         source_plan,
+        version_check,
+        update_status,
+        support_request_draft,
         validation,
     }
 }
@@ -519,6 +617,225 @@ fn validate_runnable<P: ProcessRunner>(
     }
 }
 
+fn load_bdb_tool_version_check<P: ProcessRunner>(
+    executable_path: &Path,
+    runner: &P,
+) -> BdbToolVersionCheck {
+    let command = build_version_command(executable_path);
+
+    match runner.run(executable_path, &[BDB_VERSION_ARGUMENT]) {
+        Ok(output) => {
+            let combined_text = combined_output_text(&output);
+            if output.exit_code == Some(0) {
+                match first_non_empty_line(&combined_text) {
+                    Some(version_value) => BdbToolVersionCheck {
+                        status: BdbToolVersionStatus::Available,
+                        command,
+                        value: Some(version_value.clone()),
+                        exit_code: output.exit_code,
+                        summary: format!("Installed version: {version_value}"),
+                        detail: None,
+                    },
+                    None => BdbToolVersionCheck {
+                        status: BdbToolVersionStatus::Unavailable,
+                        command,
+                        value: None,
+                        exit_code: output.exit_code,
+                        summary: "BE Home could not read a version number from the Board Install Tool.".into(),
+                        detail: Some(
+                            "The tool opened, but it did not return a readable version line.".into(),
+                        ),
+                    },
+                }
+            } else {
+                BdbToolVersionCheck {
+                    status: BdbToolVersionStatus::Unavailable,
+                    command,
+                    value: None,
+                    exit_code: output.exit_code,
+                    summary: "BE Home could not confirm which Board Install Tool version is stored here.".into(),
+                    detail: Some(if combined_text.is_empty() {
+                        "The Board Install Tool exited before it returned a readable version line."
+                            .into()
+                    } else {
+                        combined_text
+                    }),
+                }
+            }
+        }
+        Err(failure) => BdbToolVersionCheck {
+            status: BdbToolVersionStatus::Unavailable,
+            command,
+            value: None,
+            exit_code: None,
+            summary: "BE Home could not confirm which Board Install Tool version is stored here."
+                .into(),
+            detail: Some(failure.detail),
+        },
+    }
+}
+
+fn unavailable_version_check(executable_path: &Path, summary: String) -> BdbToolVersionCheck {
+    BdbToolVersionCheck {
+        status: BdbToolVersionStatus::Unavailable,
+        command: build_version_command(executable_path),
+        value: None,
+        exit_code: None,
+        summary,
+        detail: None,
+    }
+}
+
+fn build_update_status(
+    source_plan: &bdb::BdbSourcePlan,
+    executable_exists: bool,
+    version_check: &BdbToolVersionCheck,
+) -> BdbUpdateStatus {
+    let available_version = source_plan.source.as_ref().and_then(|source| source.version.clone());
+    let current_version = version_check.value.clone();
+
+    if source_plan.support.status == bdb::BdbSupportStatus::Unsupported {
+        return BdbUpdateStatus {
+            status: BdbUpdateStatusKind::Unsupported,
+            current_version,
+            available_version,
+            guidance: "Board does not currently publish a supported Board Install Tool download for this computer.".into(),
+        };
+    }
+
+    if !executable_exists {
+        return BdbUpdateStatus {
+            status: BdbUpdateStatusKind::Unknown,
+            current_version,
+            available_version,
+            guidance:
+                "Download the Board Install Tool first, then use Check for Update whenever you want to compare it with Board's latest download."
+                    .into(),
+        };
+    }
+
+    match (&current_version, &available_version, version_check.status) {
+        (Some(current), Some(available), BdbToolVersionStatus::Available) => {
+            if normalized_version(current) == normalized_version(available) {
+                BdbUpdateStatus {
+                    status: BdbUpdateStatusKind::UpToDate,
+                    current_version,
+                    available_version,
+                    guidance: "This Board Install Tool matches the latest version in BE Home's source list.".into(),
+                }
+            } else {
+                BdbUpdateStatus {
+                    status: BdbUpdateStatusKind::UpdateAvailable,
+                    current_version,
+                    available_version,
+                    guidance:
+                        "Board has a newer Board Install Tool version available. You can download it from this window."
+                            .into(),
+                }
+            }
+        }
+        (_, Some(_), BdbToolVersionStatus::Unavailable) => BdbUpdateStatus {
+            status: BdbUpdateStatusKind::Error,
+            current_version,
+            available_version,
+            guidance:
+                "BE Home could not compare the stored Board Install Tool with the latest source version just yet."
+                    .into(),
+        },
+        _ => BdbUpdateStatus {
+            status: BdbUpdateStatusKind::Unknown,
+            current_version,
+            available_version,
+            guidance:
+                "BE Home could not compare versions yet, but you can still repair or reinstall the Board Install Tool from here."
+                    .into(),
+        },
+    }
+}
+
+fn build_support_request_draft(
+    source_plan: &bdb::BdbSourcePlan,
+    version_check: &BdbToolVersionCheck,
+    validation: &BdbRunnableValidation,
+) -> Option<SupportRequestDraft> {
+    let error_text = version_check
+        .detail
+        .as_deref()
+        .or(validation.detail.as_deref())?;
+    if !looks_like_os_incompatibility(error_text) {
+        return None;
+    }
+
+    let subject = BOARD_SUPPORT_SUBJECT.to_string();
+    let body = format!(
+        "Hello.\nI tried to use your 'bdb' application on my {} and got this error:\n\n`{}`\n\nCould you please add support for my OS?\nThank you for your help!",
+        describe_host_platform(source_plan),
+        error_text.trim(),
+    );
+
+    Some(SupportRequestDraft {
+        to: BOARD_SUPPORT_EMAIL.into(),
+        subject: subject.clone(),
+        mailto_url: format!(
+            "mailto:{}?subject={}&body={}",
+            BOARD_SUPPORT_EMAIL,
+            percent_encode_component(&subject),
+            percent_encode_component(&body)
+        ),
+        body,
+    })
+}
+
+fn looks_like_os_incompatibility(detail: &str) -> bool {
+    let normalized = detail.to_ascii_lowercase();
+    [
+        "not compatible",
+        "not a valid win32 application",
+        "this app can't run on your pc",
+        "bad cpu type in executable",
+        "exec format error",
+        "wrong architecture",
+    ]
+    .iter()
+    .any(|marker| normalized.contains(marker))
+}
+
+fn describe_host_platform(source_plan: &bdb::BdbSourcePlan) -> String {
+    let operating_system = match source_plan.support.operating_system {
+        bdb::BdbOperatingSystem::Windows => "Windows",
+        bdb::BdbOperatingSystem::Macos => "macOS",
+        bdb::BdbOperatingSystem::Linux => "Linux",
+        bdb::BdbOperatingSystem::Unknown => "Unknown OS",
+    };
+    let architecture = match source_plan.support.architecture {
+        bdb::BdbArchitecture::X86_64 => "x86_64",
+        bdb::BdbArchitecture::Aarch64 => "aarch64",
+        bdb::BdbArchitecture::X86 => "x86",
+        bdb::BdbArchitecture::Arm => "arm",
+        bdb::BdbArchitecture::Unknown => "unknown architecture",
+    };
+
+    match source_plan.support.windows_build {
+        Some(build) => format!("{operating_system} {architecture} (build {build})"),
+        None => format!("{operating_system} {architecture}"),
+    }
+}
+
+fn combined_output_text(output: &ProcessRunOutput) -> String {
+    [output.stdout.trim(), output.stderr.trim()]
+        .into_iter()
+        .filter(|segment| !segment.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn first_non_empty_line(value: &str) -> Option<String> {
+    value.lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .map(str::to_owned)
+}
+
 fn classify_process_failure(error: io::Error) -> ProcessRunFailure {
     let detail = error.to_string();
     let kind = match error.kind() {
@@ -553,8 +870,33 @@ fn resolve_bdb_executable_path(storage_location: &storage::ManagedStorageLocatio
     PathBuf::from(&storage_location.effective_path).join(bdb_executable_file_name())
 }
 
+fn build_version_command(executable_path: &Path) -> String {
+    format!("{} {}", executable_path.display(), BDB_VERSION_ARGUMENT)
+}
+
 fn build_validation_command(executable_path: &Path) -> String {
     format!("{} {}", executable_path.display(), BDB_HELP_ARGUMENT)
+}
+
+fn normalized_version(value: &str) -> String {
+    value.trim().to_ascii_lowercase()
+}
+
+fn percent_encode_component(value: &str) -> String {
+    value
+        .bytes()
+        .flat_map(|byte| match byte {
+            b'A'..=b'Z'
+            | b'a'..=b'z'
+            | b'0'..=b'9'
+            | b'-'
+            | b'.'
+            | b'_'
+            | b'~' => vec![byte as char].into_iter().collect::<Vec<_>>(),
+            b' ' => vec!['%','2','0'],
+            _ => format!("%{byte:02X}").chars().collect::<Vec<_>>(),
+        })
+        .collect()
 }
 
 fn bdb_executable_file_name() -> &'static str {
@@ -612,8 +954,16 @@ mod tests {
         ) -> Result<ProcessRunOutput, ProcessRunFailure> {
             let content = fs::read_to_string(executable_path).unwrap_or_default();
             match content.as_str() {
-                "fresh-bdb" => Ok(ProcessRunOutput { exit_code: Some(0) }),
-                "odd-but-runnable" => Ok(ProcessRunOutput { exit_code: Some(1) }),
+                "fresh-bdb" => Ok(ProcessRunOutput {
+                    exit_code: Some(0),
+                    stdout: "Board OS Version: 1.8.1".into(),
+                    stderr: String::new(),
+                }),
+                "odd-but-runnable" => Ok(ProcessRunOutput {
+                    exit_code: Some(1),
+                    stdout: String::new(),
+                    stderr: "unexpected exit".into(),
+                }),
                 "blocked-bdb" => Err(ProcessRunFailure {
                     kind: ProcessRunFailureKind::PermissionDenied,
                     detail: "The operating system denied access to the file.".into(),
@@ -796,6 +1146,7 @@ mod tests {
             source: Some(BdbDownloadSource {
                 platform_key: "linux-x86_64".into(),
                 download_url: "https://example.com/bdb".into(),
+                version: None,
             }),
         }
     }

--- a/src-tauri/src/device.rs
+++ b/src-tauri/src/device.rs
@@ -1,4 +1,4 @@
-use crate::bdb_tool;
+use crate::{bdb_tool, storage};
 use serde::Serialize;
 use std::io;
 use std::path::Path;
@@ -6,7 +6,7 @@ use std::process::Command;
 
 const BDB_STATUS_ARGUMENT: &str = "status";
 const BDB_VERSION_ARGUMENT: &str = "version";
-const DEVICE_STATUS_POLL_INTERVAL_MS: u32 = 5_000;
+const DEFAULT_DEVICE_STATUS_POLL_INTERVAL_MS: u32 = 5_000;
 
 /// Describes the normalized connection state that the device workspace can consume.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
@@ -48,6 +48,7 @@ pub(crate) struct DeviceStatusSnapshot {
     pub(crate) summary: String,
     pub(crate) guidance: String,
     pub(crate) detail: Option<String>,
+    pub(crate) board_os_version: Option<String>,
     pub(crate) poll_interval_ms: u32,
     pub(crate) bdb_version: BdbVersionDetails,
 }
@@ -114,6 +115,7 @@ fn load_device_status_snapshot_with_runner<P: ProcessRunner>(
     tool_state: &bdb_tool::BdbToolState,
     runner: &P,
 ) -> DeviceStatusSnapshot {
+    let poll_interval_ms = current_poll_interval_ms();
     match tool_state.status {
         bdb_tool::BdbToolStatus::Unsupported => DeviceStatusSnapshot {
             status: DeviceStatusKind::UnsupportedHost,
@@ -121,7 +123,8 @@ fn load_device_status_snapshot_with_runner<P: ProcessRunner>(
                 .into(),
             guidance: tool_state.guidance.clone(),
             detail: None,
-            poll_interval_ms: DEVICE_STATUS_POLL_INTERVAL_MS,
+            board_os_version: None,
+            poll_interval_ms,
             bdb_version: unavailable_version_details(&tool_state.executable_path, tool_state.summary.clone()),
         },
         bdb_tool::BdbToolStatus::Missing => DeviceStatusSnapshot {
@@ -130,7 +133,8 @@ fn load_device_status_snapshot_with_runner<P: ProcessRunner>(
                 .into(),
             guidance: tool_state.guidance.clone(),
             detail: None,
-            poll_interval_ms: DEVICE_STATUS_POLL_INTERVAL_MS,
+            board_os_version: None,
+            poll_interval_ms,
             bdb_version: unavailable_version_details(
                 &tool_state.executable_path,
                 "BE Home has not downloaded bdb yet.".into(),
@@ -142,7 +146,8 @@ fn load_device_status_snapshot_with_runner<P: ProcessRunner>(
                 .into(),
             guidance: tool_state.guidance.clone(),
             detail: Some("Choose repair in settings to fetch a fresh copy of bdb.".into()),
-            poll_interval_ms: DEVICE_STATUS_POLL_INTERVAL_MS,
+            board_os_version: None,
+            poll_interval_ms,
             bdb_version: unavailable_version_details(
                 &tool_state.executable_path,
                 "BE Home could not trust the stored bdb copy enough to read its version.".into(),
@@ -159,6 +164,7 @@ fn inspect_runnable_device_status<P: ProcessRunner>(
     let executable_path = Path::new(&tool_state.executable_path);
     let version = load_bdb_version(executable_path, runner);
     let status_command = build_command_string(&tool_state.executable_path, BDB_STATUS_ARGUMENT);
+    let poll_interval_ms = current_poll_interval_ms();
 
     match runner.run(executable_path, &[BDB_STATUS_ARGUMENT]) {
         Ok(output) => normalize_status_output(output, version),
@@ -191,7 +197,8 @@ fn inspect_runnable_device_status<P: ProcessRunner>(
                 summary,
                 guidance,
                 detail,
-                poll_interval_ms: DEVICE_STATUS_POLL_INTERVAL_MS,
+                board_os_version: None,
+                poll_interval_ms,
                 bdb_version: version,
             }
         }
@@ -204,6 +211,13 @@ fn normalize_status_output(
 ) -> DeviceStatusSnapshot {
     let combined_text = combined_output_text(&output);
     let normalized_text = combined_text.to_ascii_lowercase();
+    let board_os_version =
+        extract_board_os_version(&combined_text).or_else(|| {
+            version
+                .value
+                .as_deref()
+                .and_then(extract_board_os_version)
+        });
 
     let (status, summary, guidance, detail) = if contains_any(
         &normalized_text,
@@ -250,7 +264,8 @@ fn normalize_status_output(
         summary,
         guidance,
         detail,
-        poll_interval_ms: DEVICE_STATUS_POLL_INTERVAL_MS,
+        board_os_version,
+        poll_interval_ms: current_poll_interval_ms(),
         bdb_version: version,
     }
 }
@@ -333,6 +348,18 @@ fn combined_output_text(output: &ProcessRunOutput) -> String {
         .join("\n")
 }
 
+fn extract_board_os_version(value: &str) -> Option<String> {
+    value.lines()
+        .map(str::trim)
+        .find_map(|line| {
+            let lower = line.to_ascii_lowercase();
+            lower
+                .strip_prefix("board os version:")
+                .map(|_| line["Board OS Version:".len()..].trim().to_owned())
+        })
+        .filter(|version| !version.is_empty())
+}
+
 fn contains_any(value: &str, candidates: &[&str]) -> bool {
     candidates.iter().any(|candidate| value.contains(candidate))
 }
@@ -359,6 +386,12 @@ fn build_command_string(executable_path: &str, argument: &str) -> String {
     format!("{executable_path} {argument}")
 }
 
+fn current_poll_interval_ms() -> u32 {
+    storage::load_desktop_settings()
+        .map(|settings| settings.board_connection.poll_interval_seconds.saturating_mul(1000))
+        .unwrap_or(DEFAULT_DEVICE_STATUS_POLL_INTERVAL_MS)
+}
+
 fn path_to_string(path: &Path) -> String {
     path.to_string_lossy().into_owned()
 }
@@ -375,7 +408,10 @@ mod tests {
             BdbArchitecture, BdbDownloadSource, BdbOperatingSystem, BdbPlatformSupport,
             BdbSourcePlan, BdbSupportStatus,
         },
-        bdb_tool::{BdbRunnableStatus, BdbRunnableValidation, BdbToolState, BdbToolStatus},
+        bdb_tool::{
+            BdbRunnableStatus, BdbRunnableValidation, BdbToolState, BdbToolStatus,
+            BdbToolVersionCheck, BdbToolVersionStatus, BdbUpdateStatus, BdbUpdateStatusKind,
+        },
         storage::{ManagedStorageLocation, ManagedStoragePathSource},
     };
     use std::path::Path;
@@ -564,8 +600,26 @@ mod tests {
                 source: Some(BdbDownloadSource {
                     platform_key: "linux-x86_64".into(),
                     download_url: "https://example.com/bdb".into(),
+                    version: None,
                 }),
             },
+            version_check: BdbToolVersionCheck {
+                status: BdbToolVersionStatus::Available,
+                command: "/tmp/bdb version".into(),
+                value: Some("Board OS Version: 1.8.1".into()),
+                exit_code: Some(0),
+                summary: "Installed version: Board OS Version: 1.8.1".into(),
+                detail: None,
+            },
+            update_status: BdbUpdateStatus {
+                status: BdbUpdateStatusKind::UpToDate,
+                current_version: Some("Board OS Version: 1.8.1".into()),
+                available_version: Some("Board OS Version: 1.8.1".into()),
+                guidance:
+                    "This Board Install Tool matches the latest version in BE Home's source list."
+                        .into(),
+            },
+            support_request_draft: None,
             validation: BdbRunnableValidation {
                 status: runnable_status,
                 command: "/tmp/bdb help".into(),

--- a/src-tauri/src/installed_titles.rs
+++ b/src-tauri/src/installed_titles.rs
@@ -474,7 +474,10 @@ mod tests {
             BdbArchitecture, BdbDownloadSource, BdbOperatingSystem, BdbPlatformSupport,
             BdbSourcePlan, BdbSupportStatus,
         },
-        bdb_tool::{BdbRunnableStatus, BdbRunnableValidation, BdbToolState, BdbToolStatus},
+        bdb_tool::{
+            BdbRunnableStatus, BdbRunnableValidation, BdbToolState, BdbToolStatus,
+            BdbToolVersionCheck, BdbToolVersionStatus, BdbUpdateStatus, BdbUpdateStatusKind,
+        },
         device::{BdbVersionDetails, BdbVersionStatus, DeviceStatusKind, DeviceStatusSnapshot},
         storage::{ManagedStorageLocation, ManagedStoragePathSource},
     };
@@ -626,6 +629,7 @@ mod tests {
             summary: "sample device summary".into(),
             guidance: "sample device guidance".into(),
             detail: None,
+            board_os_version: Some("1.8.1".into()),
             poll_interval_ms: 5_000,
             bdb_version: BdbVersionDetails {
                 status: BdbVersionStatus::Available,
@@ -668,8 +672,26 @@ mod tests {
                 source: Some(BdbDownloadSource {
                     platform_key: "linux-x86_64".into(),
                     download_url: "https://example.com/bdb".into(),
+                    version: None,
                 }),
             },
+            version_check: BdbToolVersionCheck {
+                status: BdbToolVersionStatus::Available,
+                command: "/tmp/bdb version".into(),
+                value: Some("Board OS Version: 1.8.1".into()),
+                exit_code: Some(0),
+                summary: "Installed version: Board OS Version: 1.8.1".into(),
+                detail: None,
+            },
+            update_status: BdbUpdateStatus {
+                status: BdbUpdateStatusKind::UpToDate,
+                current_version: Some("Board OS Version: 1.8.1".into()),
+                available_version: Some("Board OS Version: 1.8.1".into()),
+                guidance:
+                    "This Board Install Tool matches the latest version in BE Home's source list."
+                        .into(),
+            },
+            support_request_draft: None,
             validation: BdbRunnableValidation {
                 status: BdbRunnableStatus::Runnable,
                 command: "/tmp/bdb help".into(),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -69,6 +69,11 @@ fn load_bdb_tool_state() -> Result<bdb_tool::BdbToolState, String> {
 }
 
 #[tauri::command]
+fn refresh_bdb_tool_state() -> Result<bdb_tool::BdbToolState, String> {
+    bdb_tool::load_current_bdb_tool_state_with_remote_refresh(true)
+}
+
+#[tauri::command]
 fn acquire_bdb_tool(repair: bool) -> Result<bdb_tool::BdbAcquisitionResult, String> {
     bdb_tool::acquire_current_bdb_tool(repair)
 }
@@ -174,6 +179,7 @@ pub fn run() {
             launch_installed_title_on_board,
             load_bdb_source_plan,
             load_bdb_tool_state,
+            refresh_bdb_tool_state,
             acquire_bdb_tool,
             load_device_status_snapshot,
             load_installed_titles_snapshot,
@@ -234,7 +240,7 @@ mod tests {
     }
 
     #[test]
-    fn bdb_source_plan_uses_the_bundled_manifest_contract() {
+    fn bdb_source_plan_uses_the_supported_manifest_contract() {
         let plan = super::load_bdb_source_plan();
         let serialized = serde_json::to_value(plan).expect("bdb source plan should serialize");
 
@@ -242,12 +248,10 @@ mod tests {
             .get("manifestSource")
             .and_then(|value| value.as_str())
             .is_some_and(|value| matches!(value, "bundled" | "cached" | "remote")));
-        assert_eq!(
-            Some(1),
-            serialized
-                .get("manifestSchemaVersion")
-                .and_then(|value| value.as_u64())
-        );
+        assert!(serialized
+            .get("manifestSchemaVersion")
+            .and_then(|value| value.as_u64())
+            .is_some_and(|value| matches!(value, 1 | 2)));
         assert!(serialized
             .get("remoteManifestUrl")
             .and_then(|value| value.as_str())

--- a/src-tauri/src/setup.rs
+++ b/src-tauri/src/setup.rs
@@ -127,7 +127,10 @@ mod tests {
             BdbArchitecture, BdbDownloadSource, BdbOperatingSystem, BdbPlatformSupport,
             BdbSourcePlan, BdbSupportStatus,
         },
-        bdb_tool::{BdbRunnableStatus, BdbRunnableValidation, BdbToolState, BdbToolStatus},
+        bdb_tool::{
+            BdbRunnableStatus, BdbRunnableValidation, BdbToolState, BdbToolStatus,
+            BdbToolVersionCheck, BdbToolVersionStatus, BdbUpdateStatus, BdbUpdateStatusKind,
+        },
         storage::{
             ManagedStorageLocation, ManagedStoragePathSource, ManagedStorageSettings,
             StorageOperatingSystem,
@@ -205,8 +208,26 @@ mod tests {
                 source: Some(BdbDownloadSource {
                     platform_key: "linux-x86_64".into(),
                     download_url: "https://example.com/bdb".into(),
+                    version: None,
                 }),
             },
+            version_check: BdbToolVersionCheck {
+                status: BdbToolVersionStatus::Available,
+                command: "/tmp/bdb version".into(),
+                value: Some("Board OS Version: 1.8.1".into()),
+                exit_code: Some(0),
+                summary: "Installed version: Board OS Version: 1.8.1".into(),
+                detail: None,
+            },
+            update_status: BdbUpdateStatus {
+                status: BdbUpdateStatusKind::UpToDate,
+                current_version: Some("Board OS Version: 1.8.1".into()),
+                available_version: Some("Board OS Version: 1.8.1".into()),
+                guidance:
+                    "This Board Install Tool matches the latest version in BE Home's source list."
+                        .into(),
+            },
+            support_request_draft: None,
             validation: BdbRunnableValidation {
                 status: runnable_status,
                 command: "/tmp/bdb help".into(),

--- a/src-tauri/src/storage.rs
+++ b/src-tauri/src/storage.rs
@@ -11,6 +11,8 @@ const DOWNLOADS_DIRECTORY: &str = "Downloads";
 const SETTINGS_DIRECTORY: &str = "settings";
 const STORAGE_SETTINGS_FILE_NAME: &str = "managed-storage.json";
 const TOOLS_DIRECTORY: &str = "tools";
+const DEFAULT_BOARD_CONNECTION_POLL_INTERVAL_SECONDS: u32 = 5;
+const BOARD_CONNECTION_POLL_INTERVAL_OPTIONS: [u32; 3] = [5, 10, 30];
 
 /// Describes the normalized operating system used for managed-storage defaults.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
@@ -55,6 +57,13 @@ pub(crate) struct ConfiguredScanFolder {
     pub(crate) source: ConfiguredScanFolderSource,
 }
 
+/// Describes the persisted Board connection preferences for the desktop app.
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct BoardConnectionSettings {
+    pub(crate) poll_interval_seconds: u32,
+}
+
 /// Describes the current managed storage configuration for the desktop app.
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -74,6 +83,7 @@ pub(crate) struct DesktopSettings {
     pub(crate) bdb_tools: ManagedStorageLocation,
     pub(crate) apk_library: ManagedStorageLocation,
     pub(crate) bdb_executable_path: String,
+    pub(crate) board_connection: BoardConnectionSettings,
     pub(crate) scan_folders: Vec<ConfiguredScanFolder>,
 }
 
@@ -90,6 +100,7 @@ pub(crate) struct ManagedStorageOverridesInput {
 #[serde(rename_all = "camelCase")]
 pub(crate) struct DesktopSettingsInput {
     apk_library_override: Option<String>,
+    board_connection_poll_interval_seconds: Option<u32>,
     scan_folder_paths: Vec<String>,
 }
 
@@ -98,6 +109,7 @@ pub(crate) struct DesktopSettingsInput {
 struct PersistedDesktopSettings {
     bdb_tools_override: Option<String>,
     apk_library_override: Option<String>,
+    board_connection_poll_interval_seconds: Option<u32>,
     scan_folder_paths: Option<Vec<String>>,
 }
 
@@ -148,6 +160,11 @@ pub(crate) fn save_desktop_settings(
     let context = current_storage_context()?;
     let mut persisted = load_persisted_settings(&context.settings_file_path)?;
     persisted.apk_library_override = normalize_override(input.apk_library_override)?;
+    persisted.board_connection_poll_interval_seconds =
+        Some(normalize_board_connection_poll_interval(
+            input.board_connection_poll_interval_seconds,
+            persisted.board_connection_poll_interval_seconds,
+        )?);
     persisted.scan_folder_paths = Some(normalize_scan_folder_paths(input.scan_folder_paths)?);
 
     save_persisted_settings(&context.settings_file_path, &persisted)?;
@@ -176,12 +193,15 @@ fn build_desktop_settings(
     persisted: &PersistedDesktopSettings,
 ) -> DesktopSettings {
     let managed_storage = build_managed_storage_settings(context, persisted);
-    DesktopSettings {
+        DesktopSettings {
         operating_system: managed_storage.operating_system,
         settings_file_path: managed_storage.settings_file_path.clone(),
         bdb_tools: managed_storage.bdb_tools.clone(),
         apk_library: managed_storage.apk_library.clone(),
         bdb_executable_path: resolve_bdb_executable_path(&managed_storage.bdb_tools),
+        board_connection: BoardConnectionSettings {
+            poll_interval_seconds: resolve_board_connection_poll_interval_seconds(persisted),
+        },
         scan_folders: build_scan_folders(context, persisted),
     }
 }
@@ -261,6 +281,37 @@ fn normalize_loaded_scan_folder_paths(values: &[String]) -> Vec<String> {
     }
 
     normalized
+}
+
+fn resolve_board_connection_poll_interval_seconds(
+    persisted: &PersistedDesktopSettings,
+) -> u32 {
+    persisted
+        .board_connection_poll_interval_seconds
+        .filter(|value| BOARD_CONNECTION_POLL_INTERVAL_OPTIONS.contains(value))
+        .unwrap_or(DEFAULT_BOARD_CONNECTION_POLL_INTERVAL_SECONDS)
+}
+
+fn normalize_board_connection_poll_interval(
+    requested: Option<u32>,
+    current: Option<u32>,
+) -> Result<u32, String> {
+    let poll_interval = requested
+        .or(current)
+        .unwrap_or(DEFAULT_BOARD_CONNECTION_POLL_INTERVAL_SECONDS);
+
+    if BOARD_CONNECTION_POLL_INTERVAL_OPTIONS.contains(&poll_interval) {
+        return Ok(poll_interval);
+    }
+
+    Err(format!(
+        "The desktop app only supports Board connection refresh intervals of {} seconds.",
+        BOARD_CONNECTION_POLL_INTERVAL_OPTIONS
+            .iter()
+            .map(u32::to_string)
+            .collect::<Vec<_>>()
+            .join(", ")
+    ))
 }
 
 fn current_storage_context() -> Result<ManagedStorageContext, String> {
@@ -489,7 +540,8 @@ mod tests {
         build_desktop_settings, build_managed_storage_settings,
         current_storage_context_from_environment, load_persisted_settings, normalize_override,
         normalize_scan_folder_paths, save_desktop_settings, save_managed_storage_settings,
-        save_persisted_settings, DesktopSettingsInput, ManagedStorageContext,
+        save_persisted_settings, DesktopSettingsInput,
+        DEFAULT_BOARD_CONNECTION_POLL_INTERVAL_SECONDS, ManagedStorageContext,
         ManagedStorageOverridesInput, PersistedDesktopSettings, StorageOperatingSystem,
     };
     use std::collections::BTreeMap;
@@ -651,6 +703,7 @@ mod tests {
         let persisted = PersistedDesktopSettings {
             bdb_tools_override: Some(sample_tools_override_path()),
             apk_library_override: Some(sample_apk_library_override_path()),
+            board_connection_poll_interval_seconds: Some(30),
             scan_folder_paths: Some(vec![sample_scan_folder_path()]),
         };
 
@@ -685,6 +738,7 @@ mod tests {
         let persisted = PersistedDesktopSettings {
             bdb_tools_override: Some("relative/tools".into()),
             apk_library_override: Some(sample_apk_library_override_path()),
+            board_connection_poll_interval_seconds: Some(12),
             scan_folder_paths: Some(vec!["relative/Downloads".into()]),
         };
 
@@ -724,6 +778,7 @@ mod tests {
                 .and_then(|value| value.as_str())
                 .expect("source should serialize")
         );
+        assert_eq!(DEFAULT_BOARD_CONNECTION_POLL_INTERVAL_SECONDS, settings.board_connection.poll_interval_seconds);
     }
 
     #[test]
@@ -746,6 +801,7 @@ mod tests {
 
         let result = save_desktop_settings(DesktopSettingsInput {
             apk_library_override: Some(sample_apk_library_override_path()),
+            board_connection_poll_interval_seconds: Some(10),
             scan_folder_paths: vec![sample_scan_folder_path()],
         })
         .expect("desktop settings should save");
@@ -761,6 +817,7 @@ mod tests {
             Some(sample_apk_library_override_path().as_str()),
             result.apk_library.override_path.as_deref()
         );
+        assert_eq!(10, result.board_connection.poll_interval_seconds);
         assert!(PathBuf::from(&result.settings_file_path).exists());
     }
 
@@ -791,6 +848,7 @@ mod tests {
             &PersistedDesktopSettings {
                 bdb_tools_override: None,
                 apk_library_override: None,
+                board_connection_poll_interval_seconds: None,
                 scan_folder_paths: Some(vec![sample_scan_folder_path()]),
             },
         )

--- a/src/App.css
+++ b/src/App.css
@@ -1,453 +1,462 @@
 .desktop-shell {
-  padding: clamp(1.25rem, 2.5vw, 2.5rem);
+  padding: clamp(1rem, 2vw, 1.75rem);
+}
+
+.desktop-shell--workspace {
+  min-height: 100vh;
 }
 
 .desktop-grid {
-  max-width: 92rem;
+  max-width: 96rem;
   margin: 0 auto;
 }
 
 .desktop-state-card {
-  margin-top: clamp(1rem, 4vw, 3rem);
+  margin-top: clamp(1rem, 4vw, 4rem);
 }
 
-.desktop-banner {
-  overflow: hidden;
+.desktop-utility-window {
+  min-height: 100vh;
+  display: grid;
+  align-items: center;
 }
 
-.desktop-banner::after {
-  content: "";
-  position: absolute;
-  inset: auto -6rem -8rem auto;
-  width: 18rem;
-  height: 18rem;
-  border-radius: 999px;
-  background:
-    radial-gradient(circle, rgba(77, 117, 244, 0.24) 0%, rgba(77, 117, 244, 0.12) 38%, transparent 72%);
-  pointer-events: none;
+.desktop-utility-grid {
+  padding-block: 1rem;
 }
 
-.desktop-banner-copy {
+.desktop-utility-card {
+  display: grid;
+  gap: 1.5rem;
+  padding: 1.5rem;
+}
+
+.desktop-utility-header,
+.desktop-app-header {
   display: grid;
   gap: 1rem;
 }
 
-.desktop-platform-note {
-  margin: 0;
-  font-size: 0.92rem;
-  color: rgba(220, 247, 234, 0.78);
+.desktop-utility-heading,
+.desktop-app-heading {
+  display: grid;
+  gap: 0.35rem;
 }
 
-.desktop-highlight-row {
+.desktop-utility-body,
+.desktop-main-content,
+.desktop-section-stack {
+  display: grid;
+  gap: 1rem;
+}
+
+.desktop-utility-footer {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  border-top: 1px solid var(--desktop-border);
+  padding-top: 1rem;
+}
+
+.desktop-utility-footer-actions,
+.desktop-inline-button-row {
   display: flex;
   flex-wrap: wrap;
   gap: 0.75rem;
-  margin-top: 1.25rem;
 }
 
-.desktop-highlight {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.55rem;
-  padding: 0.72rem 1rem;
-  border-radius: 999px;
-  border: 1px solid rgba(118, 255, 170, 0.24);
-  background:
-    radial-gradient(circle at 50% 0%, rgba(95, 255, 164, 0.14), transparent 56%),
-    linear-gradient(180deg, rgba(26, 24, 32, 0.94), rgba(17, 16, 24, 0.94));
-  box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.03),
-    0 0 14px rgba(118, 255, 170, 0.14),
-    0 0 28px rgba(118, 255, 170, 0.05);
-}
-
-.desktop-highlight-label {
-  font-size: 0.72rem;
-  font-weight: 700;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-  color: rgba(220, 247, 234, 0.68);
-}
-
-.desktop-highlight-value {
-  font-size: 0.92rem;
-  font-weight: 700;
-  color: #f7fff8;
-}
-
-.desktop-setup-layout,
-.desktop-workspace-layout {
-  display: grid;
-  grid-template-columns: minmax(17rem, 23rem) minmax(0, 1fr);
-  gap: 1.5rem;
-}
-
-.desktop-stepper,
-.desktop-nav-panel,
-.desktop-setup-panel,
-.desktop-workspace-panel {
-  height: 100%;
-}
-
-.desktop-step-list {
-  display: grid;
-  gap: 1rem;
-  margin: 1.5rem 0 0;
+.desktop-wizard-step-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin: 0;
   padding: 0;
   list-style: none;
 }
 
-.desktop-step-card {
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr);
-  gap: 0.9rem;
-  align-items: start;
-  padding: 1rem;
-  border-radius: 1.25rem;
-  border: 1px solid rgba(118, 255, 170, 0.14);
-  background: rgba(18, 17, 23, 0.55);
+.desktop-wizard-step {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  padding: 0.55rem 0.8rem;
+  border-radius: 999px;
+  border: 1px solid var(--desktop-border);
+  background: var(--desktop-surface-muted);
+  color: var(--desktop-text-soft);
+  font-size: 0.92rem;
+  font-weight: 600;
 }
 
-.desktop-step-card--active {
-  border-color: rgba(118, 255, 170, 0.38);
-  box-shadow: 0 0 22px rgba(118, 255, 170, 0.08);
+.desktop-wizard-step--current {
+  border-color: var(--desktop-border-strong);
+  color: var(--desktop-text);
 }
 
-.desktop-step-card--complete {
-  border-color: rgba(77, 117, 244, 0.3);
+.desktop-wizard-step--complete {
+  color: var(--desktop-text-muted);
 }
 
-.desktop-step-number {
+.desktop-wizard-step-number {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 2rem;
-  height: 2rem;
+  width: 1.6rem;
+  height: 1.6rem;
   border-radius: 999px;
-  border: 1px solid rgba(118, 255, 170, 0.24);
-  background: rgba(64, 198, 141, 0.12);
-  font-size: 0.88rem;
-  font-weight: 700;
-  color: #f7fff8;
-}
-
-.desktop-step-copy {
-  display: grid;
-  gap: 0.45rem;
-}
-
-.desktop-step-copy h3,
-.desktop-inline-card h3,
-.desktop-inline-message h3 {
-  margin: 0;
-  font-size: 1rem;
-  font-weight: 700;
-  color: #ffffff;
-}
-
-.desktop-step-copy p,
-.desktop-inline-card p,
-.desktop-inline-message p,
-.desktop-detail-row dd,
-.desktop-nav-summary {
-  margin: 0;
-  color: rgb(203 213 225 / 1);
-  line-height: 1.7;
-}
-
-.desktop-setup-panel,
-.desktop-workspace-main {
-  display: grid;
-  gap: 1.5rem;
-}
-
-.desktop-detail-grid {
-  display: grid;
-  gap: 0.85rem;
-  margin: 1.5rem 0 0;
-}
-
-.desktop-status-band {
-  display: grid;
-  gap: 0.45rem;
-  margin-top: 1.5rem;
-  padding: 1rem 1.1rem;
-  border-radius: 1.25rem;
-  border: 1px solid rgba(118, 255, 170, 0.18);
-  background:
-    radial-gradient(circle at 0% 0%, rgba(96, 255, 164, 0.08), transparent 26%),
-    rgba(18, 17, 23, 0.72);
-}
-
-.desktop-status-band--success {
-  border-color: rgba(118, 255, 170, 0.3);
-  background:
-    radial-gradient(circle at 0% 0%, rgba(96, 255, 164, 0.12), transparent 28%),
-    rgba(18, 17, 23, 0.72);
-}
-
-.desktop-status-band--warning {
-  border-color: rgba(243, 177, 58, 0.28);
-  background:
-    radial-gradient(circle at 0% 0%, rgba(243, 177, 58, 0.1), transparent 28%),
-    rgba(18, 17, 23, 0.72);
-}
-
-.desktop-status-band--neutral {
-  border-color: rgba(118, 177, 255, 0.22);
-  background:
-    radial-gradient(circle at 0% 0%, rgba(118, 177, 255, 0.08), transparent 28%),
-    rgba(18, 17, 23, 0.72);
-}
-
-.desktop-status-band-label {
-  font-size: 0.72rem;
-  font-weight: 700;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-  color: rgba(220, 247, 234, 0.68);
-}
-
-.desktop-status-band h3 {
-  margin: 0;
-  font-size: 1.12rem;
-  font-weight: 700;
-  color: #ffffff;
-}
-
-.desktop-status-band p {
-  margin: 0;
-  color: rgb(203 213 225 / 1);
-  line-height: 1.7;
-}
-
-.desktop-detail-row {
-  display: grid;
-  gap: 0.25rem;
-  padding: 0.9rem 1rem;
-  border-radius: 1rem;
-  background: rgba(18, 17, 23, 0.55);
-  border: 1px solid rgba(118, 255, 170, 0.12);
-}
-
-.desktop-detail-row dt {
-  font-size: 0.72rem;
-  font-weight: 700;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-  color: rgba(220, 247, 234, 0.68);
-}
-
-.desktop-settings-group {
-  display: grid;
-  gap: 1rem;
-  margin-top: 1.75rem;
-}
-
-.desktop-settings-group-copy {
-  display: grid;
-  gap: 0.4rem;
-}
-
-.desktop-settings-group-copy h3 {
-  margin: 0;
-  font-size: 1.05rem;
-  font-weight: 700;
-  color: #ffffff;
-}
-
-.desktop-settings-group-copy p,
-.desktop-folder-meta,
-.desktop-folder-path {
-  margin: 0;
-  color: rgb(203 213 225 / 1);
-  line-height: 1.7;
-}
-
-.desktop-folder-list {
-  display: grid;
-  gap: 0.75rem;
-  padding: 0;
-  margin: 0;
-  list-style: none;
-}
-
-.desktop-folder-item {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  padding: 0.9rem 1rem;
-  border-radius: 1rem;
-  background: rgba(18, 17, 23, 0.55);
-  border: 1px solid rgba(118, 255, 170, 0.12);
-}
-
-.desktop-folder-copy {
-  display: grid;
-  gap: 0.2rem;
-  min-width: 0;
-}
-
-.desktop-folder-path {
-  font-weight: 700;
-  color: #f7fff8;
-  overflow-wrap: anywhere;
-}
-
-.desktop-folder-meta {
-  font-size: 0.88rem;
-}
-
-.desktop-guidance-panel {
-  border-color: rgba(118, 255, 170, 0.14);
-}
-
-.desktop-guidance-panel--success {
-  border-color: rgba(118, 255, 170, 0.28);
-}
-
-.desktop-guidance-panel--warning {
-  border-color: rgba(243, 177, 58, 0.22);
-}
-
-.desktop-guidance-panel--neutral {
-  border-color: rgba(118, 177, 255, 0.22);
-}
-
-.desktop-guidance-list {
-  display: grid;
-  gap: 0.95rem;
-  margin: 1.5rem 0 0;
-  padding-left: 1.35rem;
-  color: rgb(203 213 225 / 1);
-}
-
-.desktop-guidance-list li {
-  line-height: 1.7;
-}
-
-.desktop-inventory-list {
-  display: grid;
-  gap: 0.9rem;
-  margin: 1.5rem 0 0;
-  padding: 0;
-  list-style: none;
-}
-
-.desktop-inventory-item {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  padding: 1rem;
-  border-radius: 1rem;
-  background: rgba(18, 17, 23, 0.55);
-  border: 1px solid rgba(118, 255, 170, 0.12);
-}
-
-.desktop-inventory-copy {
-  display: grid;
-  gap: 0.25rem;
-  min-width: 0;
-}
-
-.desktop-inventory-copy h3 {
-  margin: 0;
-  font-size: 1rem;
-  font-weight: 700;
-  color: #ffffff;
-}
-
-.desktop-inventory-copy p {
-  margin: 0;
-  color: rgb(203 213 225 / 1);
-  line-height: 1.7;
-  overflow-wrap: anywhere;
-}
-
-.desktop-inventory-meta {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: flex-end;
-  gap: 0.55rem;
-}
-
-.desktop-inventory-side {
-  display: grid;
-  justify-items: end;
-  gap: 0.7rem;
-}
-
-.desktop-inventory-pill {
-  display: inline-flex;
-  align-items: center;
-  padding: 0.45rem 0.75rem;
-  border-radius: 999px;
-  border: 1px solid rgba(118, 255, 170, 0.18);
-  background: rgba(255, 255, 255, 0.03);
-  color: rgba(220, 247, 234, 0.78);
+  background: rgba(75, 224, 154, 0.16);
+  color: var(--desktop-text);
   font-size: 0.82rem;
   font-weight: 700;
 }
 
-.desktop-library-timestamp {
-  margin: 0;
-  color: rgb(203 213 225 / 1);
-  font-size: 0.88rem;
-  line-height: 1.7;
-  text-align: right;
+.desktop-wizard-page,
+.desktop-settings-page {
+  display: grid;
+  gap: 1rem;
 }
 
-.desktop-inline-button {
+.desktop-wizard-checklist,
+.desktop-entity-list {
+  display: grid;
+  gap: 0.85rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.desktop-wizard-checklist li {
+  padding: 0.95rem 1rem;
+  border-radius: var(--desktop-radius-md);
+  background: var(--desktop-surface-muted);
+  border: 1px solid var(--desktop-border);
+  color: var(--desktop-text-muted);
+  line-height: 1.7;
+}
+
+.desktop-form-grid,
+.desktop-summary-grid {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.desktop-field {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.desktop-field-label {
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--desktop-text-soft);
+}
+
+.desktop-readonly-field,
+.desktop-text-field,
+.desktop-text-area {
+  width: 100%;
+  border: 1px solid var(--desktop-border);
+  border-radius: var(--desktop-radius-sm);
+  background: var(--desktop-surface-strong);
+  color: var(--desktop-text);
+  padding: 0.85rem 0.95rem;
+  line-height: 1.55;
+}
+
+.desktop-readonly-field {
+  min-height: 3rem;
+  overflow-wrap: anywhere;
+}
+
+.desktop-text-field:focus,
+.desktop-text-area:focus {
+  outline: 2px solid rgba(75, 224, 154, 0.32);
+  outline-offset: 2px;
+}
+
+.desktop-text-area {
+  min-height: 10rem;
+}
+
+.desktop-input-with-button {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.desktop-recommended-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.desktop-recommended-badge,
+.desktop-entity-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.35rem 0.7rem;
+  border-radius: 999px;
+  border: 1px solid var(--desktop-border);
+  background: var(--desktop-surface-muted);
+  color: var(--desktop-text-soft);
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+
+.desktop-link-button {
   min-height: auto;
-  padding-block: 0.65rem;
+  padding: 0;
+  border: none;
+}
+
+.desktop-footnote,
+.desktop-section-copy,
+.desktop-folder-meta,
+.desktop-entity-meta,
+.desktop-sidebar-button-summary,
+.desktop-radio-copy {
+  margin: 0;
+  color: var(--desktop-text-soft);
+  line-height: 1.65;
+}
+
+.desktop-inline-card,
+.desktop-inline-message,
+.desktop-content-card,
+.desktop-manual-card {
+  display: grid;
+  gap: 0.6rem;
+  padding: 1rem 1.1rem;
+  border-radius: var(--desktop-radius-md);
+  border: 1px solid var(--desktop-border);
+  background: var(--desktop-surface-muted);
+}
+
+.desktop-inline-card h3,
+.desktop-inline-message h3,
+.desktop-content-card h3,
+.desktop-manual-card h4,
+.desktop-entity-copy h4 {
+  margin: 0;
+  color: var(--desktop-text);
+}
+
+.desktop-inline-card p,
+.desktop-inline-message p,
+.desktop-content-card p,
+.desktop-manual-card p,
+.desktop-entity-copy p {
+  margin: 0;
+}
+
+.desktop-inline-message--warning {
+  border-color: rgba(244, 187, 89, 0.32);
+  background: rgba(244, 187, 89, 0.08);
+}
+
+.desktop-inline-message--success {
+  border-color: rgba(75, 224, 154, 0.28);
+  background: rgba(75, 224, 154, 0.08);
+}
+
+.desktop-icon-button,
+.desktop-help-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.4rem;
+  height: 2.4rem;
+  border-radius: 999px;
+  border: 1px solid var(--desktop-border);
+  background: var(--desktop-surface-strong);
+  color: var(--desktop-text);
+  cursor: pointer;
+  transition:
+    transform 140ms ease,
+    border-color 140ms ease,
+    background-color 140ms ease;
+}
+
+.desktop-help-chip {
+  width: 1.9rem;
+  height: 1.9rem;
+  font-weight: 700;
+}
+
+.desktop-icon-button:hover,
+.desktop-help-chip:hover,
+.primary-button:hover,
+.secondary-button:hover,
+.tertiary-button:hover,
+.desktop-sidebar-button:hover,
+.desktop-tab-button:hover,
+.desktop-radio-card:hover {
+  transform: translateY(-1px);
+}
+
+.desktop-icon-button:disabled,
+.desktop-help-chip:disabled,
+.primary-button:disabled,
+.secondary-button:disabled,
+.tertiary-button:disabled,
+.desktop-sidebar-button:disabled,
+.desktop-tab-button:disabled,
+.desktop-radio-card:disabled {
+  cursor: not-allowed;
+  opacity: 0.62;
+  transform: none;
+}
+
+.desktop-list-editor,
+.desktop-settings-section {
+  display: grid;
+  gap: 0.8rem;
+}
+
+.desktop-list-editor-header {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 0.8rem;
+}
+
+.desktop-empty-note {
+  padding: 0.95rem 1rem;
+  border-radius: var(--desktop-radius-md);
+  border: 1px dashed var(--desktop-border);
+  color: var(--desktop-text-muted);
+  background: var(--desktop-surface-muted);
+  line-height: 1.6;
+}
+
+.desktop-folder-list {
+  display: grid;
+  gap: 0.7rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.desktop-folder-item,
+.desktop-entity-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.9rem 1rem;
+  border-radius: var(--desktop-radius-md);
+  border: 1px solid var(--desktop-border);
+  background: var(--desktop-surface-strong);
+}
+
+.desktop-folder-copy,
+.desktop-entity-copy,
+.desktop-entity-actions {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.desktop-folder-path {
+  margin: 0;
+  color: var(--desktop-text);
+  overflow-wrap: anywhere;
+}
+
+.desktop-entity-copy {
+  min-width: 0;
+}
+
+.desktop-entity-copy h4,
+.desktop-folder-path {
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.desktop-entity-actions {
+  justify-items: end;
 }
 
 .desktop-inline-action-stack {
   display: grid;
-  gap: 0.6rem;
+  gap: 0.55rem;
 }
 
-.desktop-inline-card,
-.desktop-inline-message {
-  display: grid;
-  gap: 0.5rem;
-  margin-top: 1.5rem;
-  padding: 1rem 1.1rem;
-  border-radius: 1.25rem;
-  border: 1px solid rgba(118, 255, 170, 0.18);
-  background:
-    radial-gradient(circle at 0% 0%, rgba(96, 255, 164, 0.08), transparent 26%),
-    rgba(18, 17, 23, 0.72);
+.desktop-inline-button {
+  min-height: auto;
+  padding-block: 0.7rem;
 }
 
-.desktop-inline-message--warning {
-  border-color: rgba(243, 177, 58, 0.28);
-  background:
-    radial-gradient(circle at 0% 0%, rgba(243, 177, 58, 0.1), transparent 26%),
-    rgba(18, 17, 23, 0.72);
-}
-
-.desktop-action-row {
+.desktop-tab-row,
+.desktop-summary-row {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.85rem;
-  margin-top: 1.5rem;
+  gap: 0.75rem;
 }
 
+.desktop-tab-button,
+.desktop-sidebar-button,
+.desktop-radio-card,
 .primary-button,
 .secondary-button,
-.tertiary-button,
-.desktop-nav-button {
-  border: none;
+.tertiary-button {
   cursor: pointer;
   transition:
     transform 140ms ease,
-    box-shadow 140ms ease,
     border-color 140ms ease,
-    background-color 140ms ease;
+    background-color 140ms ease,
+    box-shadow 140ms ease;
   font: inherit;
+}
+
+.desktop-tab-button,
+.desktop-sidebar-button,
+.desktop-radio-card {
+  border: 1px solid var(--desktop-border);
+  border-radius: var(--desktop-radius-md);
+  background: var(--desktop-surface-muted);
+  color: var(--desktop-text);
+}
+
+.desktop-tab-button {
+  padding: 0.7rem 1rem;
+  font-weight: 700;
+}
+
+.desktop-tab-button--active,
+.desktop-sidebar-button--active,
+.desktop-radio-card--active {
+  border-color: var(--desktop-border-strong);
+  box-shadow: 0 0 0 1px rgba(75, 224, 154, 0.08);
+}
+
+.desktop-sidebar-button {
+  display: grid;
+  gap: 0.22rem;
+  width: 100%;
+  text-align: left;
+  padding: 1rem;
+}
+
+.desktop-sidebar-button-label,
+.desktop-radio-title {
+  font-weight: 700;
+  color: var(--desktop-text);
+}
+
+.desktop-radio-list {
+  display: grid;
+  gap: 0.8rem;
+}
+
+.desktop-radio-card {
+  display: grid;
+  gap: 0.3rem;
+  padding: 1rem;
+  text-align: left;
 }
 
 .primary-button,
@@ -460,87 +469,130 @@
 }
 
 .primary-button {
-  background: linear-gradient(135deg, #69f0a3, #41c68d);
-  color: #111116;
-  box-shadow: 0 0 22px rgba(118, 255, 170, 0.16);
+  border: none;
+  background: linear-gradient(135deg, var(--desktop-accent), var(--desktop-accent-strong));
+  color: #09110d;
 }
 
 .secondary-button {
-  background: rgba(255, 255, 255, 0.03);
-  border: 1px solid rgba(118, 255, 170, 0.24);
-  color: #f7fff8;
+  border: 1px solid var(--desktop-border);
+  background: var(--desktop-surface-strong);
+  color: var(--desktop-text);
 }
 
 .tertiary-button {
+  border: 1px solid transparent;
   background: transparent;
-  border: 1px solid rgba(196, 205, 255, 0.2);
-  color: rgba(220, 247, 234, 0.78);
+  color: var(--desktop-text-soft);
 }
 
-.primary-button:hover,
-.secondary-button:hover,
-.tertiary-button:hover,
-.desktop-nav-button:hover {
-  transform: translateY(-1px);
-}
-
-.primary-button:disabled,
-.secondary-button:disabled,
-.tertiary-button:disabled,
-.desktop-nav-button:disabled {
-  cursor: not-allowed;
-  opacity: 0.62;
-  transform: none;
-  box-shadow: none;
-}
-
-.desktop-nav-list {
+.desktop-app-shell {
   display: grid;
-  gap: 0.85rem;
-  margin-top: 1.5rem;
+  gap: 1rem;
+  padding: 1.25rem;
 }
 
-.desktop-nav-button {
-  display: grid;
-  gap: 0.18rem;
-  text-align: left;
+.desktop-status-strip {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
   padding: 0.95rem 1rem;
-  border-radius: 1.1rem;
-  border: 1px solid rgba(118, 255, 170, 0.14);
-  background: rgba(18, 17, 23, 0.55);
+  border-radius: var(--desktop-radius-md);
+  border: 1px solid var(--desktop-border);
+  background: var(--desktop-surface-strong);
 }
 
-.desktop-nav-button--active {
-  border-color: rgba(118, 255, 170, 0.36);
-  box-shadow: 0 0 22px rgba(118, 255, 170, 0.08);
+.desktop-status-chip,
+.desktop-value-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  border-radius: 999px;
+  padding: 0.5rem 0.8rem;
+  border: 1px solid var(--desktop-border);
+  background: var(--desktop-surface-muted);
 }
 
-.desktop-nav-label {
-  font-size: 0.98rem;
+.desktop-status-chip {
   font-weight: 700;
-  color: #ffffff;
 }
 
-.desktop-workspace-main {
+.desktop-status-chip--success {
+  border-color: rgba(75, 224, 154, 0.32);
+  background: rgba(75, 224, 154, 0.08);
+}
+
+.desktop-status-chip--warning {
+  border-color: rgba(244, 187, 89, 0.32);
+  background: rgba(244, 187, 89, 0.08);
+}
+
+.desktop-status-chip--danger {
+  border-color: rgba(240, 105, 105, 0.32);
+  background: rgba(240, 105, 105, 0.08);
+}
+
+.desktop-status-chip--neutral {
+  border-color: rgba(126, 160, 255, 0.28);
+  background: rgba(126, 160, 255, 0.08);
+}
+
+.desktop-value-chip-label {
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--desktop-text-soft);
+}
+
+.desktop-value-chip-value {
+  color: var(--desktop-text);
+  font-weight: 700;
+}
+
+.desktop-main-layout {
+  display: grid;
+  grid-template-columns: minmax(15rem, 18rem) minmax(0, 1fr);
+  gap: 1rem;
+}
+
+.desktop-sidebar {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.desktop-section-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: end;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.desktop-two-column-grid {
+  display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
 }
 
-.desktop-list {
-  margin: 1rem 0 0;
-  padding-left: 1.25rem;
-  color: rgb(203 213 225 / 1);
+.desktop-modal-scrim {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.25rem;
+  background: rgba(10, 12, 16, 0.45);
 }
 
-.desktop-list li + li {
-  margin-top: 0.8rem;
+.desktop-modal-card {
+  width: min(100%, 42rem);
+  display: grid;
+  gap: 1rem;
 }
 
-@media (max-width: 1080px) {
-  .desktop-setup-layout,
-  .desktop-workspace-layout,
-  .desktop-workspace-main {
-    grid-template-columns: 1fr;
-  }
+.desktop-detail-value-block {
+  white-space: pre-wrap;
 }
 
 @media (max-width: 960px) {
@@ -548,13 +600,23 @@
     padding: 1rem;
   }
 
-  .desktop-highlight {
-    width: 100%;
-    justify-content: space-between;
+  .desktop-main-layout,
+  .desktop-two-column-grid {
+    grid-template-columns: 1fr;
   }
 
-  .desktop-action-row {
+  .desktop-folder-item,
+  .desktop-entity-item,
+  .desktop-utility-footer,
+  .desktop-section-header,
+  .desktop-list-editor-header,
+  .desktop-recommended-row {
     flex-direction: column;
+    align-items: stretch;
+  }
+
+  .desktop-entity-actions {
+    justify-items: stretch;
   }
 
   .primary-button,
@@ -562,27 +624,5 @@
   .tertiary-button,
   .desktop-inline-button {
     width: 100%;
-  }
-
-  .desktop-folder-item {
-    align-items: stretch;
-    flex-direction: column;
-  }
-
-  .desktop-inventory-item {
-    align-items: stretch;
-    flex-direction: column;
-  }
-
-  .desktop-inventory-meta {
-    justify-content: flex-start;
-  }
-
-  .desktop-inventory-side {
-    justify-items: start;
-  }
-
-  .desktop-library-timestamp {
-    text-align: left;
   }
 }

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -7,6 +7,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import App from "./App";
 import type {
   ApkDiscoverySnapshot,
+  BdbToolState,
   DesktopSettings,
   DeviceStatusSnapshot,
   InstalledTitlesSnapshot,
@@ -26,16 +27,18 @@ const currentWindowState = vi.hoisted(() => ({
 const onFocusChangedMock = vi.hoisted(() => vi.fn().mockResolvedValue(() => {}));
 const onThemeChangedMock = vi.hoisted(() => vi.fn().mockResolvedValue(() => {}));
 const onCloseRequestedMock = vi.hoisted(() => vi.fn().mockResolvedValue(() => {}));
+const closeWindowMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 
 vi.mock("@tauri-apps/api/window", () => ({
   getCurrentWindow: vi.fn(() => ({
     get label() {
       return currentWindowState.label;
     },
-    theme: vi.fn().mockResolvedValue(currentWindowState.theme),
+    theme: vi.fn(() => Promise.resolve(currentWindowState.theme)),
     onThemeChanged: onThemeChangedMock,
     onFocusChanged: onFocusChangedMock,
     onCloseRequested: onCloseRequestedMock,
+    close: closeWindowMock,
   })),
 }));
 
@@ -59,63 +62,107 @@ const listenMock = vi.mocked(listen);
 const openMock = vi.mocked(open);
 const getCurrentWindowMock = vi.mocked(getCurrentWindow);
 
-const missingToolFixture: SetupGateState = {
+const runnableToolFixture: BdbToolState = {
+  status: "runnable",
+  summary: "Board's install tool is ready to use.",
+  guidance: "BE Home confirmed that the Board Install Tool can open from its saved location.",
+  executablePath:
+    "C:\\Users\\Matt\\AppData\\Local\\Board Enthusiasts\\BE Home for Desktop\\tools\\bdb.exe",
+  executableExists: true,
+  storage: {
+    defaultPath: "C:\\Users\\Matt\\AppData\\Local\\Board Enthusiasts\\BE Home for Desktop\\tools",
+    overridePath: null,
+    effectivePath: "C:\\Users\\Matt\\AppData\\Local\\Board Enthusiasts\\BE Home for Desktop\\tools",
+    source: "default",
+  },
+  sourcePlan: {
+    manifestSource: "bundled",
+    remoteManifestUrl: "https://example.com/bdb-sources.json",
+    manifestCachePath: null,
+    manifestSchemaVersion: 2,
+    support: {
+      status: "supported",
+      operatingSystem: "windows",
+      architecture: "x86_64",
+      windowsBuild: 26100,
+      platformKey: "windows-x86_64",
+      reason: null,
+      guidance: "This machine matches a Board-published bdb target.",
+    },
+    source: {
+      platformKey: "windows-x86_64",
+      downloadUrl: "https://example.com/bdb.exe",
+      version: "Board OS Version: 1.8.1",
+    },
+  },
+  versionCheck: {
+    status: "available",
+    command: "bdb version",
+    value: "Board OS Version: 1.8.1",
+    exitCode: 0,
+    summary: "Installed version: Board OS Version: 1.8.1",
+    detail: null,
+  },
+  updateStatus: {
+    status: "upToDate",
+    currentVersion: "Board OS Version: 1.8.1",
+    availableVersion: "Board OS Version: 1.8.1",
+    guidance: "This Board Install Tool matches the latest version in BE Home's source list.",
+  },
+  supportRequestDraft: null,
+  validation: {
+    status: "runnable",
+    command: "bdb help",
+    exitCode: 0,
+    summary: "BE Home could open bdb from its managed tools folder.",
+    detail: null,
+  },
+};
+
+const missingToolFixture: BdbToolState = {
+  ...runnableToolFixture,
+  status: "missing",
+  summary: "BE Home has not downloaded bdb into the managed tools folder yet.",
+  guidance: "Continue setup and BE Home will download Board's bdb into its managed tools folder for you.",
+  executableExists: false,
+  versionCheck: {
+    status: "unavailable",
+    command: "bdb version",
+    value: null,
+    exitCode: null,
+    summary: "BE Home has not downloaded the Board Install Tool yet.",
+    detail: null,
+  },
+  updateStatus: {
+    status: "unknown",
+    currentVersion: null,
+    availableVersion: "Board OS Version: 1.8.1",
+    guidance:
+      "Download the Board Install Tool first, then use Check for Update whenever you want to compare it with Board's latest download.",
+  },
+  validation: {
+    status: "missing",
+    command: "bdb help",
+    exitCode: null,
+    summary: "No managed bdb executable is present yet.",
+    detail: null,
+  },
+};
+
+const readySetupFixture: SetupGateState = {
   appName: "BE Home for Desktop",
   version: "0.1.0",
   platformLabel: "Windows",
-  status: "requiresSetup",
-  requiredStep: "toolSetup",
-  summary: "BE Home still needs to download Board's install tool before the workspace can open.",
-  guidance: "Continue setup and BE Home will download Board's bdb into its managed tools folder for you.",
-  toolState: {
-    status: "missing",
-    summary: "Board's install tool is missing.",
-    guidance: "Download bdb so BE Home can keep Board actions inside the desktop flow.",
-    executablePath: "C:\\Users\\Matt\\AppData\\Local\\Board Enthusiasts\\BE Home for Desktop\\tools\\bdb.exe",
-    executableExists: false,
-    storage: {
-      defaultPath: "C:\\Users\\Matt\\AppData\\Local\\Board Enthusiasts\\BE Home for Desktop\\tools",
-      overridePath: null,
-      effectivePath: "C:\\Users\\Matt\\AppData\\Local\\Board Enthusiasts\\BE Home for Desktop\\tools",
-      source: "default",
-    },
-    sourcePlan: {
-      manifestSource: "bundled",
-      remoteManifestUrl: "https://example.com/bdb-sources.json",
-      manifestCachePath: null,
-      manifestSchemaVersion: 1,
-      support: {
-        status: "supported",
-        operatingSystem: "windows",
-        architecture: "x86_64",
-        windowsBuild: 26100,
-        platformKey: "windows-x86_64",
-        reason: null,
-        guidance: "This machine matches a Board-published bdb target.",
-      },
-      source: {
-        platformKey: "windows-x86_64",
-        downloadUrl: "https://example.com/bdb.exe",
-      },
-    },
-    validation: {
-      status: "missing",
-      command: "bdb help",
-      exitCode: null,
-      summary: "No managed bdb executable is present yet.",
-      detail: null,
-    },
-  },
+  status: "ready",
+  requiredStep: "workspace",
+  summary: "Board's install tool is ready, so BE Home can open your desktop workspace.",
+  guidance: "You can come back to repair the install tool later if anything changes.",
+  toolState: runnableToolFixture,
   storage: {
     operatingSystem: "windows",
     settingsFilePath:
       "C:\\Users\\Matt\\AppData\\Local\\Board Enthusiasts\\BE Home for Desktop\\settings\\managed-storage.json",
-    bdbTools: {
-      defaultPath: "C:\\Users\\Matt\\AppData\\Local\\Board Enthusiasts\\BE Home for Desktop\\tools",
-      overridePath: null,
-      effectivePath: "C:\\Users\\Matt\\AppData\\Local\\Board Enthusiasts\\BE Home for Desktop\\tools",
-      source: "default",
-    },
+    bdbTools: runnableToolFixture.storage,
     apkLibrary: {
       defaultPath:
         "C:\\Users\\Matt\\AppData\\Local\\Board Enthusiasts\\BE Home for Desktop\\apk-library",
@@ -128,34 +175,25 @@ const missingToolFixture: SetupGateState = {
   defaultScanFolders: ["C:\\Users\\Matt\\Downloads"],
 };
 
-const runnableFixture: SetupGateState = {
-  ...missingToolFixture,
-  status: "ready",
-  requiredStep: "workspace",
-  summary: "Board's install tool is ready, so BE Home can open your desktop workspace.",
-  guidance: "You can come back to repair the install tool later if anything changes.",
-  toolState: {
-    ...missingToolFixture.toolState,
-    status: "runnable",
-    summary: "Board's install tool is ready to use.",
-    executableExists: true,
-    validation: {
-      status: "runnable",
-      command: "bdb help",
-      exitCode: 0,
-      summary: "BE Home could open bdb from its managed tools folder.",
-      detail: null,
-    },
-  },
+const needsSetupFixture: SetupGateState = {
+  ...readySetupFixture,
+  status: "requiresSetup",
+  requiredStep: "toolSetup",
+  summary: "BE Home still needs to download Board's install tool before the workspace can open.",
+  guidance: "Continue setup and BE Home will download Board's bdb into its managed tools folder for you.",
+  toolState: missingToolFixture,
 };
 
 const desktopSettingsFixture: DesktopSettings = {
   operatingSystem: "windows",
   settingsFilePath:
     "C:\\Users\\Matt\\AppData\\Local\\Board Enthusiasts\\BE Home for Desktop\\settings\\managed-storage.json",
-  bdbTools: runnableFixture.storage.bdbTools,
-  apkLibrary: runnableFixture.storage.apkLibrary,
-  bdbExecutablePath: runnableFixture.toolState.executablePath,
+  bdbTools: readySetupFixture.storage.bdbTools,
+  apkLibrary: readySetupFixture.storage.apkLibrary,
+  bdbExecutablePath: runnableToolFixture.executablePath,
+  boardConnection: {
+    pollIntervalSeconds: 5,
+  },
   scanFolders: [
     {
       path: "C:\\Users\\Matt\\Downloads",
@@ -169,21 +207,22 @@ const deviceStatusFixture: DeviceStatusSnapshot = {
   summary: "Board connection looks ready.",
   guidance: "You can keep using the desktop workspace while BE Home refreshes the connection in the background.",
   detail: "Board connected and ready.",
+  boardOsVersion: "1.8.1",
   pollIntervalMs: 5000,
   bdbVersion: {
     status: "available",
     command: "bdb version",
-    value: "bdb 0.19.0",
+    value: "Board OS Version: 1.8.1",
     exitCode: 0,
-    summary: "BE Home is using `bdb 0.19.0`.",
+    summary: "BE Home is using `Board OS Version: 1.8.1`.",
     detail: null,
   },
 };
 
 const installedTitlesFixture: InstalledTitlesSnapshot = {
   status: "ready",
-  summary: "Board reported 1 installed title(s).",
-  guidance: "The current device inventory is ready to review.",
+  summary: "Board reported 1 installed title.",
+  guidance: "The current title list is ready to review.",
   titles: [
     {
       stableId: "package:co.board.luckydice",
@@ -198,7 +237,7 @@ const installedTitlesFixture: InstalledTitlesSnapshot = {
 
 const apkDiscoveryFixture: ApkDiscoverySnapshot = {
   status: "ready",
-  summary: "BE Home found 1 strong Board APK match.",
+  summary: "BE Home found 1 strong Board match.",
   guidance: "Use rescan after you add new downloads to a watched folder.",
   candidates: [
     {
@@ -237,10 +276,20 @@ const managedLibraryFixture: ManagedApkLibrarySnapshot = {
   ],
 };
 
-function installDefaultInvokeHandlers(setupState: SetupGateState = runnableFixture): void {
+function installDefaultInvokeHandlers(options?: {
+  setupState?: SetupGateState;
+  toolState?: BdbToolState;
+  desktopSettings?: DesktopSettings;
+}): void {
+  const setupState = options?.setupState ?? readySetupFixture;
+  const toolState = options?.toolState ?? runnableToolFixture;
+  const desktopSettings = options?.desktopSettings ?? desktopSettingsFixture;
+
   invokeHandlers.current = {
     load_setup_gate_state: () => setupState,
-    load_desktop_settings: () => desktopSettingsFixture,
+    load_bdb_tool_state: () => toolState,
+    refresh_bdb_tool_state: () => toolState,
+    load_desktop_settings: () => desktopSettings,
     load_device_status_snapshot: () => deviceStatusFixture,
     load_installed_titles_snapshot: () => installedTitlesFixture,
     load_apk_discovery_snapshot: () => apkDiscoveryFixture,
@@ -254,11 +303,11 @@ function installDefaultInvokeHandlers(setupState: SetupGateState = runnableFixtu
     exit_application: () => undefined,
     acquire_bdb_tool: () => ({
       outcome: "downloaded",
-      summary: "Downloaded bdb.",
-      guidance: "Ready to go.",
-      toolState: runnableFixture.toolState,
+      summary: "Downloaded the Board Install Tool.",
+      guidance: "The Board Install Tool is ready.",
+      toolState: runnableToolFixture,
     }),
-    save_desktop_settings: () => desktopSettingsFixture,
+    save_desktop_settings: () => desktopSettings,
   };
 }
 
@@ -284,6 +333,7 @@ describe("App", () => {
     onFocusChangedMock.mockResolvedValue(() => {});
     onThemeChangedMock.mockResolvedValue(() => {});
     onCloseRequestedMock.mockResolvedValue(() => {});
+    closeWindowMock.mockResolvedValue(undefined);
 
     installDefaultInvokeHandlers();
   });
@@ -291,23 +341,23 @@ describe("App", () => {
   it("defaults to the main workspace window when the label is missing", async () => {
     render(<App />);
 
-    expect(await screen.findByText("Your desktop install space is ready.")).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: "Device Board connection" }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: "APK Library Local APKs" }),
-    ).toBeInTheDocument();
+    expect(await screen.findByText("Keep your Board installs close by.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Games & Apps/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Installed on Board/i })).toBeInTheDocument();
+    expect(screen.getByLabelText("What this Board status means")).toBeInTheDocument();
   });
 
   it("routes the setup wizard window", async () => {
     currentWindowState.label = "setup-wizard";
-    installDefaultInvokeHandlers(missingToolFixture);
+    installDefaultInvokeHandlers({
+      setupState: needsSetupFixture,
+      toolState: missingToolFixture,
+    });
 
     render(<App />);
 
-    expect(await screen.findByText("Get your install workspace ready")).toBeInTheDocument();
-    expect(screen.getAllByRole("button", { name: "Cancel" }).length).toBeGreaterThan(0);
+    expect(await screen.findByText("Set up BE Home for Desktop")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Next" })).toBeInTheDocument();
   });
 
   it("routes the settings window", async () => {
@@ -315,8 +365,8 @@ describe("App", () => {
 
     render(<App />);
 
-    expect(await screen.findByText("Keep folders and storage understandable")).toBeInTheDocument();
-    expect(screen.getByText("Board tool")).toBeInTheDocument();
+    expect(await screen.findByText("BE Home for Desktop settings")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Board Install Tool" })).toBeInTheDocument();
   });
 
   it("routes the about window", async () => {
@@ -325,49 +375,67 @@ describe("App", () => {
     render(<App />);
 
     expect(await screen.findByText("BE Home for Desktop")).toBeInTheDocument();
-    expect(
-      screen.getByText(/Board Developer Bridge \(bdb\)/),
-    ).toBeInTheDocument();
+    expect(screen.getByText(/Board Developer Bridge \(bdb\)/)).toBeInTheDocument();
   });
 
   it("shows the main-window setup blocker and opens the setup wizard", async () => {
-    installDefaultInvokeHandlers(missingToolFixture);
+    installDefaultInvokeHandlers({
+      setupState: needsSetupFixture,
+      toolState: missingToolFixture,
+    });
 
     render(<App />);
 
-    expect(
-      await screen.findByText("Finish setup in the wizard before opening the workspace."),
-    ).toBeInTheDocument();
+    expect(await screen.findByText("Finish setup in the Setup Wizard first.")).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: "Open setup wizard" }));
+    fireEvent.click(screen.getByRole("button", { name: "Open Setup Wizard" }));
 
     await waitFor(() => {
       expect(invokeMock).toHaveBeenCalledWith("open_setup_wizard_window");
     });
   });
 
-  it("loads the ready workspace data on the main window", async () => {
+  it("lazy-loads installed titles only after that section is opened", async () => {
     render(<App />);
 
-    expect(
-      await screen.findByText("Keep the latest device check easy to trust."),
-    ).toBeInTheDocument();
+    expect(await screen.findByText("Choose a game or app from this computer.")).toBeInTheDocument();
+    expect(invokeMock).not.toHaveBeenCalledWith("load_installed_titles_snapshot");
+
+    fireEvent.click(screen.getByRole("button", { name: /Installed on Board/i }));
 
     await waitFor(() => {
-      expect(invokeMock).toHaveBeenCalledWith("load_device_status_snapshot");
-      expect(invokeMock).toHaveBeenCalledWith("load_desktop_settings");
-      expect(invokeMock).toHaveBeenCalledWith("load_apk_discovery_snapshot");
-      expect(invokeMock).toHaveBeenCalledWith("load_managed_apk_library_snapshot");
       expect(invokeMock).toHaveBeenCalledWith("load_installed_titles_snapshot");
     });
   });
 
-  it("falls back to the unsupported-window panel for unknown labels", async () => {
-    currentWindowState.label = "mystery-window";
+  it("keeps manual choice available even when no scan folders are selected", async () => {
+    installDefaultInvokeHandlers({
+      desktopSettings: {
+        ...desktopSettingsFixture,
+        scanFolders: [],
+      },
+    });
 
     render(<App />);
 
-    expect(await screen.findByText("This desktop window is not recognized.")).toBeInTheDocument();
+    expect(await screen.findByRole("button", { name: "Choose Game or App" })).toBeInTheDocument();
+    expect(screen.getByText("Manual choice only")).toBeInTheDocument();
+  });
+
+  it("cancelling setup uses the shared dismiss command", async () => {
+    currentWindowState.label = "setup-wizard";
+    installDefaultInvokeHandlers({
+      setupState: needsSetupFixture,
+      toolState: missingToolFixture,
+    });
+
+    render(<App />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Cancel" }));
+
+    await waitFor(() => {
+      expect(invokeMock).toHaveBeenCalledWith("dismiss_setup_wizard_window");
+    });
   });
 
   it("applies the current window theme to the document", async () => {
@@ -384,7 +452,7 @@ describe("App", () => {
   it("keeps Tauri window listeners wired for the routed shell", async () => {
     render(<App />);
 
-    await screen.findByText("Your desktop install space is ready.");
+    await screen.findByText("Keep your Board installs close by.");
 
     expect(getCurrentWindowMock).toHaveBeenCalled();
     expect(onFocusChangedMock).toHaveBeenCalled();

--- a/src/desktop/client.ts
+++ b/src/desktop/client.ts
@@ -108,6 +108,13 @@ export function loadBdbToolState(): Promise<BdbToolState> {
 }
 
 /**
+ * Reloads the managed `bdb` tool state after refreshing the remote source manifest.
+ */
+export function refreshBdbToolState(): Promise<BdbToolState> {
+  return invoke<BdbToolState>("refresh_bdb_tool_state");
+}
+
+/**
  * Downloads or repairs the managed `bdb` binary, then returns the updated state.
  */
 export function acquireBdbTool(repair = false): Promise<BdbAcquisitionResult> {

--- a/src/desktop/types.ts
+++ b/src/desktop/types.ts
@@ -193,6 +193,7 @@ export interface DeviceStatusSnapshot {
   summary: string;
   guidance: string;
   detail: string | null;
+  boardOsVersion: string | null;
   pollIntervalMs: number;
   bdbVersion: BdbVersionDetails;
 }
@@ -268,6 +269,7 @@ export interface BdbPlatformSupport {
 export interface BdbDownloadSource {
   platformKey: string;
   downloadUrl: string;
+  version: string | null;
 }
 
 /**
@@ -293,6 +295,53 @@ export type BdbToolStatus = "unsupported" | "missing" | "downloaded" | "runnable
 export type BdbRunnableStatus = "unsupported" | "missing" | "blocked" | "runnable";
 
 /**
+ * Describes whether BE Home could read a friendly Board Install Tool version line.
+ */
+export type BdbToolVersionStatus = "available" | "unavailable";
+
+/**
+ * Describes the latest `bdb version` check for the managed Board Install Tool.
+ */
+export interface BdbToolVersionCheck {
+  status: BdbToolVersionStatus;
+  command: string;
+  value: string | null;
+  exitCode: number | null;
+  summary: string;
+  detail: string | null;
+}
+
+/**
+ * Describes the latest manual update-check result for the managed Board Install Tool.
+ */
+export type BdbUpdateStatusKind =
+  | "upToDate"
+  | "updateAvailable"
+  | "unknown"
+  | "unsupported"
+  | "error";
+
+/**
+ * Describes whether the current Board Install Tool matches BE Home's latest source version.
+ */
+export interface BdbUpdateStatus {
+  status: BdbUpdateStatusKind;
+  currentVersion: string | null;
+  availableVersion: string | null;
+  guidance: string;
+}
+
+/**
+ * Describes a prefilled Board support request draft for unsupported-OS cases.
+ */
+export interface SupportRequestDraft {
+  to: string;
+  subject: string;
+  body: string;
+  mailtoUrl: string;
+}
+
+/**
  * Describes the latest no-device-required validation result for the managed `bdb` binary.
  */
 export interface BdbRunnableValidation {
@@ -314,6 +363,9 @@ export interface BdbToolState {
   executableExists: boolean;
   storage: ManagedStorageLocation;
   sourcePlan: BdbSourcePlan;
+  versionCheck: BdbToolVersionCheck;
+  updateStatus: BdbUpdateStatus;
+  supportRequestDraft: SupportRequestDraft | null;
   validation: BdbRunnableValidation;
 }
 
@@ -389,7 +441,15 @@ export interface DesktopSettings {
   bdbTools: ManagedStorageLocation;
   apkLibrary: ManagedStorageLocation;
   bdbExecutablePath: string;
+  boardConnection: BoardConnectionSettings;
   scanFolders: ConfiguredScanFolder[];
+}
+
+/**
+ * Describes the saved Board connection preferences for the desktop app.
+ */
+export interface BoardConnectionSettings {
+  pollIntervalSeconds: number;
 }
 
 /**
@@ -405,5 +465,6 @@ export interface ManagedStorageOverridesInput {
  */
 export interface DesktopSettingsInput {
   apkLibraryOverride: string | null;
+  boardConnectionPollIntervalSeconds?: number;
   scanFolderPaths: string[];
 }

--- a/src/main-window/MainWorkspaceApp.tsx
+++ b/src/main-window/MainWorkspaceApp.tsx
@@ -13,7 +13,6 @@ import {
   loadInstalledTitlesSnapshot,
   loadManagedApkLibrarySnapshot,
   loadSetupGateState,
-  openSettingsWindow,
   openSetupWizardWindow,
   uninstallInstalledTitleFromBoard,
 } from "../desktop/client";
@@ -36,98 +35,101 @@ import {
   SETTINGS_UPDATED_EVENT,
   type MainWorkspaceNavigationEvent,
 } from "../desktop-shell/constants";
-import { DetailRow, StatusChip, StatusSummaryCard } from "../desktop-shell/ui";
 
-type WorkspaceSectionId = "device" | "apkLibrary" | "installed";
+type WorkspaceSectionId = "gamesAndApps" | "installedOnBoard";
+type NoticeTone = "success" | "warning" | "neutral";
 
-interface WorkspaceSection {
-  id: WorkspaceSectionId;
+interface DeviceState {
+  loading: boolean;
+  snapshot: DeviceStatusSnapshot | null;
+  errorMessage: string | null;
+  errorDetail: string | null;
+}
+
+interface InstalledTitlesState {
+  loading: boolean;
+  snapshot: InstalledTitlesSnapshot | null;
+  errorMessage: string | null;
+  errorDetail: string | null;
+}
+
+interface ApkDiscoveryState {
+  loading: boolean;
+  snapshot: ApkDiscoverySnapshot | null;
+  manualCandidate: ApkCandidate | null;
+  errorMessage: string | null;
+  errorDetail: string | null;
+}
+
+interface ManagedLibraryState {
+  loading: boolean;
+  snapshot: ManagedApkLibrarySnapshot | null;
+  errorMessage: string | null;
+  errorDetail: string | null;
+  actionPath: string | null;
+  actionMessage: string | null;
+  actionDetail: string | null;
+}
+
+interface InstallState {
+  actionPath: string | null;
+  message: string | null;
+  detail: string | null;
+  lastStatus: InstallApkResult["status"] | null;
+}
+
+interface InstalledTitleActionState {
+  actionKind: "launch" | "uninstall" | null;
+  actionPackage: string | null;
+  confirmPackage: string | null;
+  message: string | null;
+  detail: string | null;
+  tone: NoticeTone | null;
+}
+
+interface BoardStatusPresentation {
+  tone: "success" | "danger" | "warning" | "neutral";
   label: string;
-  eyebrow: string;
+  tooltip: string;
 }
 
-type DeviceGuidanceAction = "refresh" | "settings";
-
-interface DeviceGuidanceContent {
-  eyebrow: string;
-  title: string;
-  summary: string;
-  steps: string[];
-  tone: "success" | "warning" | "neutral";
-  primaryAction: DeviceGuidanceAction;
-  primaryActionLabel: string;
-  secondaryAction?: DeviceGuidanceAction;
-  secondaryActionLabel?: string;
-}
-
-const DEFAULT_DEVICE_POLL_INTERVAL_MS = 5_000;
-
-const workspaceSections: WorkspaceSection[] = [
+const workspaceSections: Array<{ id: WorkspaceSectionId; label: string; summary: string }> = [
   {
-    id: "device",
-    label: "Device",
-    eyebrow: "Board connection",
+    id: "gamesAndApps",
+    label: "Games & Apps",
+    summary: "Files on this computer and your saved library",
   },
   {
-    id: "apkLibrary",
-    label: "APK Library",
-    eyebrow: "Local APKs",
-  },
-  {
-    id: "installed",
+    id: "installedOnBoard",
     label: "Installed on Board",
-    eyebrow: "Current titles",
+    summary: "What is already on your Board",
   },
 ];
 
 export default function MainWorkspaceApp() {
   const [setupGateState, setSetupGateState] = useState<SetupGateState | null>(null);
   const [desktopSettings, setDesktopSettings] = useState<DesktopSettings | null>(null);
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  const [deviceStatusState, setDeviceStatusState] = useState<{
-    loading: boolean;
-    snapshot: DeviceStatusSnapshot | null;
-    errorMessage: string | null;
-    errorDetail: string | null;
-  }>({
+  const [windowError, setWindowError] = useState<string | null>(null);
+  const [deviceState, setDeviceState] = useState<DeviceState>({
     loading: false,
     snapshot: null,
     errorMessage: null,
     errorDetail: null,
   });
-  const [installedTitlesState, setInstalledTitlesState] = useState<{
-    loading: boolean;
-    snapshot: InstalledTitlesSnapshot | null;
-    errorMessage: string | null;
-    errorDetail: string | null;
-  }>({
+  const [installedTitlesState, setInstalledTitlesState] = useState<InstalledTitlesState>({
     loading: false,
     snapshot: null,
     errorMessage: null,
     errorDetail: null,
   });
-  const [apkDiscoveryState, setApkDiscoveryState] = useState<{
-    loading: boolean;
-    snapshot: ApkDiscoverySnapshot | null;
-    manualCandidate: ApkCandidate | null;
-    errorMessage: string | null;
-    errorDetail: string | null;
-  }>({
+  const [apkDiscoveryState, setApkDiscoveryState] = useState<ApkDiscoveryState>({
     loading: false,
     snapshot: null,
     manualCandidate: null,
     errorMessage: null,
     errorDetail: null,
   });
-  const [managedLibraryState, setManagedLibraryState] = useState<{
-    loading: boolean;
-    snapshot: ManagedApkLibrarySnapshot | null;
-    errorMessage: string | null;
-    errorDetail: string | null;
-    actionPath: string | null;
-    actionMessage: string | null;
-    actionDetail: string | null;
-  }>({
+  const [managedLibraryState, setManagedLibraryState] = useState<ManagedLibraryState>({
     loading: false,
     snapshot: null,
     errorMessage: null,
@@ -136,39 +138,29 @@ export default function MainWorkspaceApp() {
     actionMessage: null,
     actionDetail: null,
   });
-  const [apkInstallState, setApkInstallState] = useState<{
-    actionPath: string | null;
-    message: string | null;
-    detail: string | null;
-    lastStatus: InstallApkResult["status"] | null;
-  }>({
+  const [apkInstallState, setApkInstallState] = useState<InstallState>({
     actionPath: null,
     message: null,
     detail: null,
     lastStatus: null,
   });
-  const apkInstallInFlightRef = useRef(false);
-  const [installedTitleActionState, setInstalledTitleActionState] = useState<{
-    actionKind: "launch" | "uninstall" | null;
-    actionPackage: string | null;
-    confirmPackage: string | null;
-    message: string | null;
-    detail: string | null;
-    tone: "success" | "warning" | null;
-  }>({
-    actionKind: null,
-    actionPackage: null,
-    confirmPackage: null,
-    message: null,
-    detail: null,
-    tone: null,
-  });
+  const [installedTitleActionState, setInstalledTitleActionState] =
+    useState<InstalledTitleActionState>({
+      actionKind: null,
+      actionPackage: null,
+      confirmPackage: null,
+      message: null,
+      detail: null,
+      tone: null,
+    });
+  const [activeSectionId, setActiveSectionId] = useState<WorkspaceSectionId>("gamesAndApps");
   const [windowFocused, setWindowFocused] = useState(true);
   const [documentVisible, setDocumentVisible] = useState(
     typeof document === "undefined" ? true : document.visibilityState !== "hidden",
   );
-  const [activeWorkspaceSection, setActiveWorkspaceSection] =
-    useState<WorkspaceSectionId>("device");
+  const [gamesAndAppsLoaded, setGamesAndAppsLoaded] = useState(false);
+  const [installedLoaded, setInstalledLoaded] = useState(false);
+  const apkInstallInFlightRef = useRef(false);
 
   useEffect(() => {
     void refreshSetupGateState();
@@ -177,16 +169,59 @@ export default function MainWorkspaceApp() {
   useEffect(() => {
     if (setupGateState?.status === "ready") {
       void refreshDesktopSettings();
-      return;
+    } else {
+      setDesktopSettings(null);
+      setGamesAndAppsLoaded(false);
+      setInstalledLoaded(false);
     }
-
-    setDesktopSettings(null);
   }, [setupGateState?.status]);
 
-  const devicePollIntervalMs =
-    deviceStatusState.snapshot?.pollIntervalMs ?? DEFAULT_DEVICE_POLL_INTERVAL_MS;
-  const devicePollingActive =
-    setupGateState?.status === "ready" && documentVisible && windowFocused;
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      setDocumentVisible(document.visibilityState !== "hidden");
+    };
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+
+    let removeFocusListener: (() => void) | null = null;
+    void getCurrentWindow()
+      .onFocusChanged(({ payload }) => {
+        setWindowFocused(payload);
+      })
+      .then((unlisten) => {
+        removeFocusListener = unlisten;
+      })
+      .catch(() => {
+        setWindowFocused(true);
+      });
+
+    return () => {
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      if (removeFocusListener !== null) {
+        removeFocusListener();
+      }
+    };
+  }, []);
+
+  const refreshSetupGateState = useEffectEvent(async (): Promise<void> => {
+    try {
+      const state = await loadSetupGateState();
+      setSetupGateState(state);
+      setWindowError(null);
+    } catch {
+      setWindowError(
+        "BE Home couldn't open the desktop workspace just yet. Please close the app and try again.",
+      );
+    }
+  });
+
+  const refreshDesktopSettings = useEffectEvent(async (): Promise<void> => {
+    try {
+      const settings = await loadDesktopSettings();
+      setDesktopSettings(settings);
+    } catch {
+      setWindowError("BE Home couldn't load the latest desktop settings.");
+    }
+  });
 
   const refreshDeviceStatus = useEffectEvent(
     async (source: "initial" | "poll" | "manual" = "manual"): Promise<void> => {
@@ -195,7 +230,7 @@ export default function MainWorkspaceApp() {
       }
 
       if (source !== "poll") {
-        setDeviceStatusState((previous) => ({
+        setDeviceState((previous) => ({
           ...previous,
           loading: true,
           errorMessage: null,
@@ -205,21 +240,21 @@ export default function MainWorkspaceApp() {
 
       try {
         const snapshot = await loadDeviceStatusSnapshot();
-        setDeviceStatusState({
+        setDeviceState({
           loading: false,
           snapshot,
           errorMessage: null,
           errorDetail: null,
         });
       } catch {
-        setDeviceStatusState((previous) => ({
+        setDeviceState((previous) => ({
           loading: false,
           snapshot: previous.snapshot,
-          errorMessage: "BE Home couldn't refresh the latest Board connection check.",
+          errorMessage: "BE Home couldn't refresh the latest Board check.",
           errorDetail:
             source === "poll"
-              ? "We'll keep trying again while the desktop window stays visible."
-              : "Please try refreshing the device check again in a moment.",
+              ? "It will keep trying again while the window stays visible."
+              : "Please try again in a moment.",
         }));
       }
     },
@@ -250,11 +285,11 @@ export default function MainWorkspaceApp() {
         setInstalledTitlesState((previous) => ({
           loading: false,
           snapshot: previous.snapshot,
-          errorMessage: "BE Home couldn't refresh the installed titles right now.",
+          errorMessage: "BE Home couldn't load the latest installed titles.",
           errorDetail:
             source === "initial"
-              ? "The first installed-title read did not finish cleanly. You can try again from the Installed on Board section."
-              : "Please try refreshing the installed titles again in a moment.",
+              ? "Open Installed on Board again in a moment."
+              : "Please try refreshing the list again.",
         }));
       }
     },
@@ -286,11 +321,11 @@ export default function MainWorkspaceApp() {
         setApkDiscoveryState((previous) => ({
           ...previous,
           loading: false,
-          errorMessage: "BE Home couldn't refresh the current APK scan just yet.",
+          errorMessage: "BE Home couldn't rescan this computer right now.",
           errorDetail:
             source === "initial"
-              ? "You can try again from the APK Library section once the workspace finishes loading."
-              : "Please try rescanning the current folders again in a moment.",
+              ? "Open Games & Apps again in a moment."
+              : "Please try rescanning again.",
         }));
       }
     },
@@ -322,45 +357,22 @@ export default function MainWorkspaceApp() {
         setManagedLibraryState((previous) => ({
           ...previous,
           loading: false,
-          errorMessage: "BE Home couldn't refresh the managed APK library right now.",
+          errorMessage: "BE Home couldn't load your saved library right now.",
           errorDetail:
             source === "initial"
-              ? "The first library read did not finish cleanly. You can try again from the APK Library section."
-              : "Please try refreshing the managed library again in a moment.",
+              ? "Open Games & Apps again in a moment."
+              : "Please try refreshing the saved library again.",
         }));
       }
     },
   );
 
-  useEffect(() => {
-    const handleVisibilityChange = () => {
-      setDocumentVisible(document.visibilityState !== "hidden");
-    };
-    document.addEventListener("visibilitychange", handleVisibilityChange);
-
-    let removeFocusListener: (() => void) | null = null;
-    void getCurrentWindow()
-      .onFocusChanged(({ payload }) => {
-        setWindowFocused(payload);
-      })
-      .then((unlisten) => {
-        removeFocusListener = unlisten;
-      })
-      .catch(() => {
-        setWindowFocused(true);
-      });
-
-    return () => {
-      document.removeEventListener("visibilitychange", handleVisibilityChange);
-      if (removeFocusListener !== null) {
-        removeFocusListener();
-      }
-    };
-  }, []);
-
+  const devicePollIntervalMs =
+    deviceState.snapshot?.pollIntervalMs ??
+    (desktopSettings?.boardConnection.pollIntervalSeconds ?? 5) * 1000;
   useEffect(() => {
     if (setupGateState?.status !== "ready") {
-      setDeviceStatusState({
+      setDeviceState({
         loading: false,
         snapshot: null,
         errorMessage: null,
@@ -381,97 +393,31 @@ export default function MainWorkspaceApp() {
     return () => {
       window.clearInterval(timer);
     };
-  }, [
-    devicePollIntervalMs,
-    documentVisible,
-    setupGateState?.status,
-    windowFocused,
-  ]);
+  }, [devicePollIntervalMs, documentVisible, setupGateState?.status, windowFocused]);
 
   useEffect(() => {
     if (setupGateState?.status !== "ready") {
-      setInstalledTitlesState({
-        loading: false,
-        snapshot: null,
-        errorMessage: null,
-        errorDetail: null,
-      });
       return;
     }
 
-    void refreshInstalledTitles("initial");
-  }, [setupGateState?.status]);
-
-  useEffect(() => {
-    if (setupGateState?.status !== "ready") {
-      setApkDiscoveryState({
-        loading: false,
-        snapshot: null,
-        manualCandidate: null,
-        errorMessage: null,
-        errorDetail: null,
-      });
-      return;
+    if (activeSectionId === "gamesAndApps" && !gamesAndAppsLoaded) {
+      setGamesAndAppsLoaded(true);
+      void refreshApkDiscovery("initial");
+      void refreshManagedLibrary("initial");
     }
 
-    void refreshApkDiscovery("initial");
-  }, [setupGateState?.status]);
-
-  useEffect(() => {
-    if (setupGateState?.status !== "ready") {
-      setManagedLibraryState({
-        loading: false,
-        snapshot: null,
-        errorMessage: null,
-        errorDetail: null,
-        actionPath: null,
-        actionMessage: null,
-        actionDetail: null,
-      });
-      return;
+    if (activeSectionId === "installedOnBoard" && !installedLoaded) {
+      setInstalledLoaded(true);
+      void refreshInstalledTitles("initial");
     }
-
-    void refreshManagedLibrary("initial");
-  }, [setupGateState?.status]);
-
-  async function refreshSetupGateState(): Promise<void> {
-    try {
-      const state = await loadSetupGateState();
-      setSetupGateState(state);
-      setErrorMessage(null);
-    } catch {
-      setErrorMessage(
-        "We couldn't reach the desktop host just yet. Try reloading the window or restarting the app.",
-      );
-    }
-  }
-
-  async function refreshDesktopSettings(): Promise<void> {
-    try {
-      const settings = await loadDesktopSettings();
-      setDesktopSettings(settings);
-    } catch {
-      setErrorMessage(
-        "BE Home couldn't load the latest folder settings just yet. Try reopening the main window.",
-      );
-    }
-  }
+  }, [activeSectionId, gamesAndAppsLoaded, installedLoaded, setupGateState?.status]);
 
   const handleShellNavigation = useEffectEvent((payload: MainWorkspaceNavigationEvent) => {
-    const nextSection = payload.target === "installedOnBoard" ? "installed" : "apkLibrary";
-    setActiveWorkspaceSection(nextSection);
-
-    if (nextSection === "installed") {
-      void refreshInstalledTitles("manual");
-      return;
-    }
-
-    void refreshApkDiscovery("manual");
-    void refreshManagedLibrary("manual");
+    setActiveSectionId(payload.target);
   });
 
   const handleShellRescan = useEffectEvent(() => {
-    setActiveWorkspaceSection("apkLibrary");
+    setActiveSectionId("gamesAndApps");
     void refreshApkDiscovery("manual");
     void refreshManagedLibrary("manual");
   });
@@ -479,9 +425,14 @@ export default function MainWorkspaceApp() {
   const handleSettingsUpdated = useEffectEvent(() => {
     void refreshSetupGateState();
     void refreshDesktopSettings();
-    void refreshApkDiscovery("manual");
-    void refreshManagedLibrary("manual");
     void refreshDeviceStatus("manual");
+    if (gamesAndAppsLoaded) {
+      void refreshApkDiscovery("manual");
+      void refreshManagedLibrary("manual");
+    }
+    if (installedLoaded) {
+      void refreshInstalledTitles("manual");
+    }
   });
 
   useEffect(() => {
@@ -517,10 +468,6 @@ export default function MainWorkspaceApp() {
     };
   }, []);
 
-  async function handleOpenSettingsWindow(): Promise<void> {
-    await openSettingsWindow();
-  }
-
   async function handleOpenSetupWizard(): Promise<void> {
     await openSetupWizardWindow();
   }
@@ -553,8 +500,8 @@ export default function MainWorkspaceApp() {
       setManagedLibraryState((previous) => ({
         ...previous,
         actionPath: null,
-        errorMessage: "BE Home couldn't add that APK to the managed library just yet.",
-        errorDetail: "Please try the same file again in a moment.",
+        errorMessage: "BE Home couldn't save that file right now.",
+        errorDetail: "Please try the same game or app again in a moment.",
       }));
       return null;
     }
@@ -591,10 +538,10 @@ export default function MainWorkspaceApp() {
     } catch (error) {
       setApkInstallState({
         actionPath: null,
-        message: "BE Home couldn't finish that install request just yet.",
+        message: "BE Home couldn't finish that install right now.",
         detail: extractActionErrorDetail(
           error,
-          "Please keep Board connected and try the same APK again in a moment.",
+          "Please keep Board connected and try the same game or app again.",
         ),
         lastStatus: "failed",
       });
@@ -657,8 +604,8 @@ export default function MainWorkspaceApp() {
         actionKind: null,
         actionPackage: null,
         confirmPackage: null,
-        message: `BE Home couldn't remove ${displayName} just yet.`,
-        detail: "Please keep Board connected and try removing the title again in a moment.",
+        message: `BE Home couldn't remove ${displayName} right now.`,
+        detail: "Please keep Board connected and try removing it again.",
         tone: "warning",
       });
       return null;
@@ -696,8 +643,8 @@ export default function MainWorkspaceApp() {
         actionKind: null,
         actionPackage: null,
         confirmPackage: null,
-        message: `BE Home couldn't launch ${displayName} just yet.`,
-        detail: "Please keep Board connected and try opening the title again in a moment.",
+        message: `BE Home couldn't open ${displayName} right now.`,
+        detail: "Please keep Board connected and try again.",
         tone: "warning",
       });
       return null;
@@ -707,16 +654,13 @@ export default function MainWorkspaceApp() {
   async function handleChooseManualApk(): Promise<void> {
     const selectedPath = await pickSinglePath(
       await open({
-        directory: false,
+        multiple: false,
         filters: [
           {
-            name: "Android Packages",
+            name: "Games and apps",
             extensions: ["apk"],
           },
         ],
-        multiple: false,
-        defaultPath:
-          desktopSettings?.scanFolders[0]?.path ?? desktopSettings?.apkLibrary.effectivePath,
       }),
     );
     if (selectedPath === null) {
@@ -747,20 +691,27 @@ export default function MainWorkspaceApp() {
       setApkDiscoveryState((previous) => ({
         ...previous,
         loading: false,
-        errorMessage: "BE Home couldn't inspect that APK just yet.",
-        errorDetail: "Choose another `.apk` file or try the same file again in a moment.",
+        errorMessage: "BE Home couldn't read that file yet.",
+        errorDetail: "Choose another game or app, or try the same file again.",
       }));
     }
   }
 
-  if (errorMessage !== null) {
+  const boardStatus = buildBoardStatusPresentation(deviceState.snapshot, setupGateState, deviceState);
+  const bdbVersionValue =
+    deviceState.snapshot?.bdbVersion.value ??
+    setupGateState?.toolState.versionCheck.value ??
+    "Unavailable";
+  const boardOsVersionValue = deviceState.snapshot?.boardOsVersion ?? "Unavailable";
+
+  if (windowError !== null) {
     return (
       <main className="page-shell desktop-shell">
         <section className="page-grid narrow">
           <section className="panel desktop-state-card" aria-live="polite">
-            <div className="eyebrow">We couldn't open the desktop app</div>
-            <h2>Please close BE Home for Desktop and try again.</h2>
-            <p className="panel-description">{errorMessage}</p>
+            <div className="eyebrow">BE Home for Desktop</div>
+            <h2>Please close the app and try again.</h2>
+            <p className="panel-description">{windowError}</p>
           </section>
         </section>
       </main>
@@ -773,10 +724,9 @@ export default function MainWorkspaceApp() {
         <section className="page-grid narrow">
           <section className="panel desktop-state-card" aria-live="polite">
             <div className="eyebrow">Opening BE Home for Desktop</div>
-            <h2>Just a moment while we check your setup.</h2>
+            <h2>Getting your desktop workspace ready</h2>
             <p className="panel-description">
-              We're checking whether Board's install tool is ready and whether your desktop
-              workspace can open.
+              BE Home is checking your setup and Board status.
             </p>
           </section>
         </section>
@@ -788,36 +738,13 @@ export default function MainWorkspaceApp() {
     return (
       <main className="page-shell desktop-shell">
         <section className="page-grid narrow">
-          <section className="hero-panel compact desktop-banner">
-            <div className="hero-copy desktop-banner-copy">
-              <div className="eyebrow">Setup required</div>
-              <h1>Finish setup in the wizard before opening the workspace.</h1>
-              <p>{setupGateState.summary}</p>
-              <p className="desktop-platform-note">
-                {setupGateState.platformLabel} desktop · v{setupGateState.version}
-              </p>
-            </div>
-            <div className="desktop-highlight-row" aria-label="Setup status">
-              <StatusChip label="Setup" value="Wizard required" />
-              <StatusChip label="Board tool" value={setupGateState.toolState.summary} />
-            </div>
-          </section>
-
-          <section className="panel desktop-workspace-panel">
-            <div className="eyebrow">Next step</div>
-            <h2>Open the setup wizard to continue.</h2>
-            <p className="panel-description">
-              The desktop shell is ready, but BE Home still needs to finish setup before the main
-              workspace should be used.
-            </p>
-            <StatusSummaryCard
-              title="Current setup state"
-              summary={setupGateState.summary}
-              guidance={setupGateState.guidance}
-            />
-            <div className="desktop-action-row">
+          <section className="panel desktop-state-card desktop-inline-message--warning" aria-live="polite">
+            <div className="eyebrow">Setup Needed</div>
+            <h2>Finish setup in the Setup Wizard first.</h2>
+            <p className="panel-description">{setupGateState.summary}</p>
+            <div className="desktop-inline-button-row">
               <button className="primary-button" onClick={() => void handleOpenSetupWizard()} type="button">
-                Open setup wizard
+                Open Setup Wizard
               </button>
             </div>
           </section>
@@ -827,102 +754,86 @@ export default function MainWorkspaceApp() {
   }
 
   return (
-    <main className="page-shell desktop-shell">
+    <main className="page-shell desktop-shell desktop-shell--workspace">
       <section className="page-grid desktop-grid">
-        <section className="hero-panel compact desktop-banner">
-          <div className="hero-copy desktop-banner-copy">
-            <div className="eyebrow">BE Home for Desktop</div>
-            <h1>Your desktop install space is ready.</h1>
-            <p>
-              Keep Board checks, local APK choices, and installed-title actions in one desktop
-              workspace instead of bouncing between tools.
-            </p>
-            <p className="desktop-platform-note">
-              {setupGateState.platformLabel} desktop · v{setupGateState.version}
-            </p>
-          </div>
-          <div className="desktop-highlight-row" aria-label="Workspace summary">
-            <StatusChip label="Board tool" value={setupGateState.toolState.summary} />
-            <StatusChip
-              label="Library"
-              value={desktopSettings?.apkLibrary.effectivePath ?? "Loading..."}
-            />
-            <StatusChip
-              label="Scan folders"
-              value={
-                desktopSettings === null
-                  ? "Loading..."
-                  : desktopSettings.scanFolders.length === 0
-                    ? "Manual picks only"
-                    : `${desktopSettings.scanFolders.length} configured`
-              }
-            />
-          </div>
-        </section>
+        <section className="panel desktop-app-shell">
+          <header className="desktop-app-header">
+            <div className="desktop-app-heading">
+              <div className="eyebrow">BE Home for Desktop</div>
+              <h1>Keep your Board installs close by.</h1>
+              <p className="panel-description">
+                Choose between the files on this computer and what is already installed on your
+                Board.
+              </p>
+            </div>
+          </header>
 
-        <section className="desktop-workspace-layout">
-          <aside className="panel desktop-nav-panel" aria-label="Workspace navigation">
-            <div className="eyebrow">Workspace</div>
-            <h2>Choose the area you want to keep close.</h2>
-            <nav className="desktop-nav-list">
+          <section className="desktop-status-strip" aria-label="Board status">
+            <span className={`desktop-status-chip desktop-status-chip--${boardStatus.tone}`}>
+              {boardStatus.label}
+            </span>
+            <button
+              aria-label="What this Board status means"
+              className="desktop-help-chip"
+              title={boardStatus.tooltip}
+              type="button"
+            >
+              ?
+            </button>
+            <StatusValueChip label="bdb" value={bdbVersionValue} />
+            <StatusValueChip label="Board OS" value={boardOsVersionValue} />
+          </section>
+
+          <section className="desktop-main-layout">
+            <aside className="desktop-sidebar" aria-label="Workspace sections">
               {workspaceSections.map((section) => (
                 <button
                   className={
-                    section.id === activeWorkspaceSection
-                      ? "desktop-nav-button desktop-nav-button--active"
-                      : "desktop-nav-button"
+                    section.id === activeSectionId
+                      ? "desktop-sidebar-button desktop-sidebar-button--active"
+                      : "desktop-sidebar-button"
                   }
                   key={section.id}
-                  onClick={() => setActiveWorkspaceSection(section.id)}
+                  onClick={() => setActiveSectionId(section.id)}
                   type="button"
                 >
-                  <span className="desktop-nav-label">{section.label}</span>
-                  <span className="desktop-nav-summary">{section.eyebrow}</span>
+                  <span className="desktop-sidebar-button-label">{section.label}</span>
+                  <span className="desktop-sidebar-button-summary">{section.summary}</span>
                 </button>
               ))}
-            </nav>
-          </aside>
+            </aside>
 
-          <section className="desktop-workspace-main">
-            {activeWorkspaceSection === "device" ? (
-              <DeviceWorkspacePanel
-                deviceStatusState={deviceStatusState}
-                pollingActive={devicePollingActive}
-                setupGateState={setupGateState}
-                onOpenSettings={() => void handleOpenSettingsWindow()}
-                onRefresh={() => void refreshDeviceStatus("manual")}
-              />
-            ) : null}
-
-            {activeWorkspaceSection === "apkLibrary" ? (
-              <ApkLibraryWorkspacePanel
-                apkDiscoveryState={apkDiscoveryState}
-                apkInstallState={apkInstallState}
-                desktopSettings={desktopSettings}
-                managedLibraryState={managedLibraryState}
-                onChooseManualApk={() => void handleChooseManualApk()}
-                onImportCandidate={(sourcePath) => void handleImportApkIntoManagedLibrary(sourcePath)}
-                onInstallApk={(apkPath) => void handleInstallApk(apkPath)}
-                onRefresh={() => void refreshApkDiscovery("manual")}
-                onRefreshManagedLibrary={() => void refreshManagedLibrary("manual")}
-              />
-            ) : null}
-
-            {activeWorkspaceSection === "installed" ? (
-              <InstalledTitlesWorkspacePanel
-                installedTitleActionState={installedTitleActionState}
-                installedTitlesState={installedTitlesState}
-                onCancelUninstall={handleCancelUninstall}
-                onLaunchTitle={(packageName, displayName) =>
-                  void handleLaunchInstalledTitle(packageName, displayName)
-                }
-                onRefresh={() => void refreshInstalledTitles("manual")}
-                onRequestUninstall={handleRequestUninstall}
-                onUninstallTitle={(packageName, displayName) =>
-                  void handleUninstallInstalledTitle(packageName, displayName)
-                }
-              />
-            ) : null}
+            <section className="desktop-main-content">
+              {activeSectionId === "gamesAndApps" ? (
+                <GamesAndAppsSection
+                  apkDiscoveryState={apkDiscoveryState}
+                  apkInstallState={apkInstallState}
+                  desktopSettings={desktopSettings}
+                  managedLibraryState={managedLibraryState}
+                  onChooseManualApk={() => void handleChooseManualApk()}
+                  onImportCandidate={(sourcePath) => void handleImportApkIntoManagedLibrary(sourcePath)}
+                  onInstallApk={(apkPath) => void handleInstallApk(apkPath)}
+                  onRescan={() => {
+                    void refreshApkDiscovery("manual");
+                    void refreshManagedLibrary("manual");
+                  }}
+                />
+              ) : (
+                <InstalledOnBoardSection
+                  installedTitleActionState={installedTitleActionState}
+                  installedTitlesState={installedTitlesState}
+                  onCancelUninstall={handleCancelUninstall}
+                  onLaunchTitle={(packageName, displayName) =>
+                    void handleLaunchInstalledTitle(packageName, displayName)
+                  }
+                  onRefresh={() => void refreshInstalledTitles("manual")}
+                  onRequestUninstall={handleRequestUninstall}
+                  onUninstallTitle={(packageName, displayName) =>
+                    void handleUninstallInstalledTitle(packageName, displayName)
+                  }
+                />
+              )}
+            </section>
           </section>
         </section>
       </section>
@@ -930,51 +841,43 @@ export default function MainWorkspaceApp() {
   );
 }
 
-interface ApkLibraryWorkspacePanelProps {
-  apkDiscoveryState: {
-    loading: boolean;
-    snapshot: ApkDiscoverySnapshot | null;
-    manualCandidate: ApkCandidate | null;
-    errorMessage: string | null;
-    errorDetail: string | null;
-  };
-  apkInstallState: {
-    actionPath: string | null;
-    message: string | null;
-    detail: string | null;
-    lastStatus: InstallApkResult["status"] | null;
-  };
-  desktopSettings: DesktopSettings | null;
-  managedLibraryState: {
-    loading: boolean;
-    snapshot: ManagedApkLibrarySnapshot | null;
-    errorMessage: string | null;
-    errorDetail: string | null;
-    actionPath: string | null;
-    actionMessage: string | null;
-    actionDetail: string | null;
-  };
-  onInstallApk: (apkPath: string) => void;
-  onChooseManualApk: () => void;
-  onImportCandidate: (sourcePath: string) => void;
-  onRefresh: () => void;
-  onRefreshManagedLibrary: () => void;
+interface StatusValueChipProps {
+  label: string;
+  value: string;
 }
 
-function ApkLibraryWorkspacePanel({
+function StatusValueChip({ label, value }: StatusValueChipProps) {
+  return (
+    <span className="desktop-value-chip">
+      <span className="desktop-value-chip-label">{label}</span>
+      <span className="desktop-value-chip-value">{value}</span>
+    </span>
+  );
+}
+
+interface GamesAndAppsSectionProps {
+  apkDiscoveryState: ApkDiscoveryState;
+  apkInstallState: InstallState;
+  desktopSettings: DesktopSettings | null;
+  managedLibraryState: ManagedLibraryState;
+  onChooseManualApk: () => void;
+  onImportCandidate: (sourcePath: string) => void;
+  onInstallApk: (apkPath: string) => void;
+  onRescan: () => void;
+}
+
+function GamesAndAppsSection({
   apkDiscoveryState,
   apkInstallState,
   desktopSettings,
   managedLibraryState,
-  onInstallApk,
   onChooseManualApk,
   onImportCandidate,
-  onRefresh,
-  onRefreshManagedLibrary,
-}: ApkLibraryWorkspacePanelProps) {
+  onInstallApk,
+  onRescan,
+}: GamesAndAppsSectionProps) {
   const discoverySnapshot = apkDiscoveryState.snapshot;
   const librarySnapshot = managedLibraryState.snapshot;
-  const scanFolderCount = desktopSettings?.scanFolders.length ?? 0;
   const importedSourcePathKeys = new Set(
     managedLibraryState.snapshot?.items.flatMap((item) => [
       pathIdentityKey(item.originalSourcePath),
@@ -984,269 +887,208 @@ function ApkLibraryWorkspacePanel({
   const manualCandidateImported =
     apkDiscoveryState.manualCandidate !== null &&
     importedSourcePathKeys.has(pathIdentityKey(apkDiscoveryState.manualCandidate.sourcePath));
+  const scanFolderCount = desktopSettings?.scanFolders.length ?? 0;
 
   return (
-    <>
-      <article className="panel desktop-workspace-panel">
-        <div className="eyebrow">APK Library</div>
-        <h2>Keep local APK discovery simple and repeatable.</h2>
-        <p className="panel-description">
-          BE Home can walk your configured scan folders for `.apk` files, then keep manual file
-          picks on the same discovery model so the later heuristic and library steps have one place
-          to build from.
-        </p>
-
-        {discoverySnapshot !== null ? (
-          <article
-            className={`desktop-status-band desktop-status-band--${apkDiscoveryStatusTone(discoverySnapshot.status)}`}
-          >
-            <span className="desktop-status-band-label">
-              {apkDiscoveryStatusLabel(discoverySnapshot.status)}
-            </span>
-            <h3>{discoverySnapshot.summary}</h3>
-            <p>{discoverySnapshot.guidance}</p>
-          </article>
-        ) : null}
-
-        {apkDiscoveryState.errorMessage !== null ? (
-          <article className="desktop-inline-message desktop-inline-message--warning">
-            <h3>{apkDiscoveryState.errorMessage}</h3>
-            {apkDiscoveryState.errorDetail !== null ? <p>{apkDiscoveryState.errorDetail}</p> : null}
-          </article>
-        ) : null}
-
-        {apkInstallState.message !== null ? (
-          <article
-            className={
-              apkInstallState.lastStatus === "failed"
-                ? "desktop-inline-message desktop-inline-message--warning"
-                : "desktop-inline-message"
-            }
-          >
-            <h3>{apkInstallState.message}</h3>
-            {apkInstallState.detail !== null ? <p>{apkInstallState.detail}</p> : null}
-          </article>
-        ) : null}
-
-        <dl className="desktop-detail-grid">
-          <DetailRow
-            label="Scan folders"
-            value={scanFolderCount === 0 ? "No folders configured yet" : String(scanFolderCount)}
-          />
-          <DetailRow
-            label="Scanned APKs"
-            value={discoverySnapshot ? String(discoverySnapshot.candidates.length) : "Loading..."}
-          />
-          <DetailRow
-            label="Manual pick"
-            value={
-              apkDiscoveryState.manualCandidate?.fileName ??
-              "Choose an `.apk` when you already know the file you want."
-            }
-          />
-        </dl>
-
-        <div className="desktop-action-row">
-          <button
-            className="primary-button"
-            disabled={apkDiscoveryState.loading}
-            onClick={onChooseManualApk}
-            type="button"
-          >
-            Choose APK
+    <section className="desktop-section-stack">
+      <section className="desktop-section-header">
+        <div>
+          <div className="eyebrow">Games &amp; Apps</div>
+          <h2>Choose a game or app from this computer.</h2>
+          <p className="panel-description">
+            BE Home can check your chosen folders, keep saved copies in one library, or let you
+            pick a file manually whenever you want.
+          </p>
+        </div>
+        <div className="desktop-inline-button-row">
+          <button className="primary-button" onClick={onChooseManualApk} type="button">
+            Choose Game or App
           </button>
           <button
             className="secondary-button"
-            disabled={apkDiscoveryState.loading}
-            onClick={onRefresh}
+            disabled={apkDiscoveryState.loading || managedLibraryState.loading}
+            onClick={onRescan}
             type="button"
           >
-            {apkDiscoveryState.loading ? "Scanning..." : "Rescan folders"}
+            {apkDiscoveryState.loading || managedLibraryState.loading ? "Refreshing..." : "Rescan"}
           </button>
         </div>
-      </article>
+      </section>
 
-      <article className="panel desktop-workspace-panel">
-        <div className="eyebrow">Current candidates</div>
-        <h2>See what BE Home has already discovered.</h2>
-        <p className="panel-description">
-          Duplicate scan results stay collapsed to a stable path-based identity, so rescans do not
-          fill this list with repeat entries.
-        </p>
+      <section className="desktop-summary-row">
+        <StatusValueChip
+          label="Folders"
+          value={scanFolderCount === 0 ? "Manual choice only" : `${scanFolderCount} selected`}
+        />
+        <StatusValueChip
+          label="Saved library"
+          value={librarySnapshot === null ? "Loading..." : `${librarySnapshot.items.length} saved`}
+        />
+      </section>
 
-        {apkDiscoveryState.manualCandidate !== null ? (
-          <article
-            className={
-              apkDiscoveryState.manualCandidate.confidence === "strongMatch"
-                ? "desktop-inline-card"
-                : "desktop-inline-message desktop-inline-message--warning"
-            }
-          >
-            <h3>Latest manual APK pick</h3>
-            <p>{apkDiscoveryState.manualCandidate.fileName}</p>
-            <p>{apkConfidenceLabel(apkDiscoveryState.manualCandidate.confidence)}</p>
-            <p>{apkDiscoveryState.manualCandidate.confidenceSummary}</p>
-            {apkDiscoveryState.manualCandidate.packageName !== null ? (
-              <p>{apkDiscoveryState.manualCandidate.packageName}</p>
-            ) : null}
-            <div className="desktop-action-row">
-              <button
-                className="primary-button"
-                disabled={apkInstallState.actionPath !== null}
-                onClick={() => onInstallApk(apkDiscoveryState.manualCandidate!.sourcePath)}
-                type="button"
-              >
-                {apkInstallState.actionPath === apkDiscoveryState.manualCandidate.sourcePath
-                  ? "Installing..."
-                  : apkDiscoveryState.manualCandidate.confidence === "strongMatch"
-                    ? "Install on Board"
-                    : "Install anyway"}
-              </button>
-              <button
-                className="secondary-button"
-                disabled={
-                  managedLibraryState.actionPath === apkDiscoveryState.manualCandidate.sourcePath ||
-                  manualCandidateImported
-                }
-                onClick={() => onImportCandidate(apkDiscoveryState.manualCandidate!.sourcePath)}
-                type="button"
-              >
-                {managedLibraryState.actionPath === apkDiscoveryState.manualCandidate.sourcePath
-                  ? "Copying..."
-                  : manualCandidateImported
-                    ? "Already in library"
-                    : "Keep a copy"}
-              </button>
-            </div>
-          </article>
-        ) : null}
+      {apkInstallState.message !== null ? (
+        <article
+          className={
+            apkInstallState.lastStatus === "failed"
+              ? "desktop-inline-message desktop-inline-message--warning"
+              : "desktop-inline-message desktop-inline-message--success"
+          }
+        >
+          <h3>{apkInstallState.message}</h3>
+          {apkInstallState.detail !== null ? <p>{apkInstallState.detail}</p> : null}
+        </article>
+      ) : null}
 
-        {discoverySnapshot === null ? (
-          <article className="desktop-inline-card">
-            <h3>Scanning the current APK folders.</h3>
-            <p>BE Home is walking the configured folders for `.apk` files now.</p>
-          </article>
-        ) : discoverySnapshot.candidates.length === 0 ? (
-          <article className="desktop-inline-card">
-            <h3>{discoverySnapshot.summary}</h3>
-            <p>{discoverySnapshot.guidance}</p>
-          </article>
-        ) : (
-          <ul className="desktop-inventory-list">
-            {discoverySnapshot.candidates.map((candidate) => (
-              <li className="desktop-inventory-item" key={candidate.stableId}>
-                <div className="desktop-inventory-copy">
-                  <h3>{candidate.fileName}</h3>
-                  <p>{candidate.sourcePath}</p>
-                </div>
-                <div className="desktop-inventory-side">
-                  <div className="desktop-inventory-meta">
-                    <span className="desktop-inventory-pill">
-                      {apkConfidenceLabel(candidate.confidence)}
-                    </span>
-                    <span className="desktop-inventory-pill">
+      <section className="desktop-two-column-grid">
+        <article className="desktop-content-card">
+          <div className="eyebrow">Found on This Computer</div>
+          <h3>Folders BE Home can already see</h3>
+          <p className="desktop-section-copy">
+            {scanFolderCount === 0
+              ? "No folders are selected right now. You can still choose a file manually."
+              : "These are the strongest matches from your selected folders."}
+          </p>
+
+          {apkDiscoveryState.errorMessage !== null ? (
+            <article className="desktop-inline-message desktop-inline-message--warning">
+              <h3>{apkDiscoveryState.errorMessage}</h3>
+              {apkDiscoveryState.errorDetail !== null ? <p>{apkDiscoveryState.errorDetail}</p> : null}
+            </article>
+          ) : discoverySnapshot === null ? (
+            <article className="desktop-inline-card">
+              <h3>Loading games and apps</h3>
+              <p>BE Home is checking the folders you selected.</p>
+            </article>
+          ) : discoverySnapshot.candidates.length === 0 ? (
+            <article className="desktop-inline-card">
+              <h3>{discoverySnapshot.summary}</h3>
+              <p>{discoverySnapshot.guidance}</p>
+            </article>
+          ) : (
+            <ul className="desktop-entity-list">
+              {discoverySnapshot.candidates.map((candidate) => (
+                <li className="desktop-entity-item" key={candidate.stableId}>
+                  <div className="desktop-entity-copy">
+                    <h4>{candidate.fileName}</h4>
+                    <p>{candidate.packageName ?? "Package name not available yet"}</p>
+                    <p className="desktop-entity-meta">
+                      {candidate.discoveredFromPath ?? candidate.sourcePath} ·{" "}
                       {formatFileSize(candidate.fileSizeBytes)}
-                    </span>
+                    </p>
                   </div>
-                  <div className="desktop-inline-action-stack">
-                    <button
-                      className="primary-button desktop-inline-button"
-                      disabled={apkInstallState.actionPath !== null}
-                      onClick={() => onInstallApk(candidate.sourcePath)}
-                      type="button"
-                    >
-                      {apkInstallState.actionPath === candidate.sourcePath
-                        ? "Installing..."
-                        : "Install on Board"}
-                    </button>
-                    <button
-                      className="secondary-button desktop-inline-button"
-                      disabled={
-                        managedLibraryState.actionPath === candidate.sourcePath ||
-                        importedSourcePathKeys.has(pathIdentityKey(candidate.sourcePath))
-                      }
-                      onClick={() => onImportCandidate(candidate.sourcePath)}
-                      type="button"
-                    >
-                      {managedLibraryState.actionPath === candidate.sourcePath
-                        ? "Copying..."
-                        : importedSourcePathKeys.has(pathIdentityKey(candidate.sourcePath))
-                          ? "Already in library"
-                          : "Keep a copy"}
-                    </button>
+                  <div className="desktop-entity-actions">
+                    <span className="desktop-entity-pill">{apkConfidenceLabel(candidate.confidence)}</span>
+                    <div className="desktop-inline-action-stack">
+                      <button
+                        className="primary-button desktop-inline-button"
+                        disabled={apkInstallState.actionPath === candidate.sourcePath}
+                        onClick={() => onInstallApk(candidate.sourcePath)}
+                        type="button"
+                      >
+                        {apkInstallState.actionPath === candidate.sourcePath ? "Installing..." : "Install"}
+                      </button>
+                      <button
+                        className="secondary-button desktop-inline-button"
+                        disabled={managedLibraryState.actionPath === candidate.sourcePath}
+                        onClick={() => onImportCandidate(candidate.sourcePath)}
+                        type="button"
+                      >
+                        {managedLibraryState.actionPath === candidate.sourcePath
+                          ? "Saving..."
+                          : "Save Copy"}
+                      </button>
+                    </div>
                   </div>
-                </div>
-              </li>
-            ))}
-          </ul>
-        )}
-      </article>
+                </li>
+              ))}
+            </ul>
+          )}
+        </article>
 
-      <article className="panel desktop-workspace-panel">
-        <div className="eyebrow">Managed library</div>
-        <h2>Keep reusable APK copies in one steady inventory.</h2>
-        <p className="panel-description">
-          BE Home stores imported APKs as managed copies, keeps the original source path nearby in
-          the inventory, and leaves your original downloads where they were.
+        <article className="desktop-content-card">
+          <div className="eyebrow">Chosen Manually</div>
+          <h3>Use any game or app file you already trust.</h3>
+          <p className="desktop-section-copy">
+            If you already know which file you want, you can choose it directly even when no scan
+            folders are selected.
+          </p>
+
+          {apkDiscoveryState.manualCandidate === null ? (
+            <article className="desktop-inline-card">
+              <h3>No file chosen yet</h3>
+              <p>Choose a game or app to install it right away or save a copy for later.</p>
+            </article>
+          ) : (
+            <article className="desktop-manual-card">
+              <h4>{apkDiscoveryState.manualCandidate.fileName}</h4>
+              <p>{apkDiscoveryState.manualCandidate.packageName ?? "Package name not available yet"}</p>
+              <p className="desktop-entity-meta">
+                {apkConfidenceLabel(apkDiscoveryState.manualCandidate.confidence)}
+              </p>
+              {apkDiscoveryState.manualCandidate.confidence !== "strongMatch" ? (
+                <article className="desktop-inline-message desktop-inline-message--warning">
+                  <h3>BE Home could not fully confirm this file for Board.</h3>
+                  <p>
+                    If this is the file you want, you can still install it now or save a copy for
+                    later.
+                  </p>
+                </article>
+              ) : null}
+              <div className="desktop-inline-action-stack">
+                <button
+                  className="primary-button desktop-inline-button"
+                  disabled={apkInstallState.actionPath === apkDiscoveryState.manualCandidate.sourcePath}
+                  onClick={() => onInstallApk(apkDiscoveryState.manualCandidate!.sourcePath)}
+                  type="button"
+                >
+                  {apkInstallState.actionPath === apkDiscoveryState.manualCandidate.sourcePath
+                    ? "Installing..."
+                    : "Install"}
+                </button>
+                <button
+                  className="secondary-button desktop-inline-button"
+                  disabled={
+                    managedLibraryState.actionPath === apkDiscoveryState.manualCandidate.sourcePath ||
+                    manualCandidateImported
+                  }
+                  onClick={() => onImportCandidate(apkDiscoveryState.manualCandidate!.sourcePath)}
+                  type="button"
+                >
+                  {managedLibraryState.actionPath === apkDiscoveryState.manualCandidate.sourcePath
+                    ? "Saving..."
+                    : manualCandidateImported
+                      ? "Saved Copy Ready"
+                      : "Save Copy"}
+                </button>
+              </div>
+            </article>
+          )}
+        </article>
+      </section>
+
+      <article className="desktop-content-card">
+        <div className="eyebrow">Saved Library</div>
+        <h3>Saved copies you can reuse later</h3>
+        <p className="desktop-section-copy">
+          BE Home keeps saved copies here so reinstalling later takes fewer steps.
         </p>
-
-        {librarySnapshot !== null ? (
-          <article
-            className={`desktop-status-band desktop-status-band--${managedLibraryStatusTone(librarySnapshot.status)}`}
-          >
-            <span className="desktop-status-band-label">
-              {managedLibraryStatusLabel(librarySnapshot.status)}
-            </span>
-            <h3>{librarySnapshot.summary}</h3>
-            <p>{librarySnapshot.guidance}</p>
-          </article>
-        ) : null}
 
         {managedLibraryState.actionMessage !== null ? (
-          <article className="desktop-inline-message">
+          <article className="desktop-inline-message desktop-inline-message--success">
             <h3>{managedLibraryState.actionMessage}</h3>
-            {managedLibraryState.actionDetail !== null ? (
-              <p>{managedLibraryState.actionDetail}</p>
-            ) : null}
+            {managedLibraryState.actionDetail !== null ? <p>{managedLibraryState.actionDetail}</p> : null}
           </article>
         ) : null}
 
         {managedLibraryState.errorMessage !== null ? (
           <article className="desktop-inline-message desktop-inline-message--warning">
             <h3>{managedLibraryState.errorMessage}</h3>
-            {managedLibraryState.errorDetail !== null ? (
-              <p>{managedLibraryState.errorDetail}</p>
-            ) : null}
+            {managedLibraryState.errorDetail !== null ? <p>{managedLibraryState.errorDetail}</p> : null}
           </article>
-        ) : null}
-
-        <dl className="desktop-detail-grid">
-          <DetailRow
-            label="Managed items"
-            value={librarySnapshot ? String(librarySnapshot.items.length) : "Loading..."}
-          />
-          <DetailRow
-            label="Current library folder"
-            value={desktopSettings?.apkLibrary.effectivePath ?? "Loading..."}
-          />
-          <DetailRow label="Copy behavior" value="Original downloads stay in place" />
-        </dl>
-
-        <div className="desktop-action-row">
-          <button
-            className="secondary-button"
-            disabled={managedLibraryState.loading}
-            onClick={onRefreshManagedLibrary}
-            type="button"
-          >
-            {managedLibraryState.loading ? "Refreshing..." : "Refresh managed library"}
-          </button>
-        </div>
-
-        {librarySnapshot === null ? (
+        ) : librarySnapshot === null ? (
           <article className="desktop-inline-card">
-            <h3>Loading the managed library inventory.</h3>
-            <p>BE Home is reading the current managed APK manifest and retained copies.</p>
+            <h3>Loading your saved library</h3>
+            <p>BE Home is loading the copies you already saved.</p>
           </article>
         ) : librarySnapshot.items.length === 0 ? (
           <article className="desktop-inline-card">
@@ -1254,36 +1096,24 @@ function ApkLibraryWorkspacePanel({
             <p>{librarySnapshot.guidance}</p>
           </article>
         ) : (
-          <ul className="desktop-inventory-list">
+          <ul className="desktop-entity-list">
             {librarySnapshot.items.map((item) => (
-              <li className="desktop-inventory-item" key={item.stableId}>
-                <div className="desktop-inventory-copy">
-                  <h3>{item.fileName}</h3>
+              <li className="desktop-entity-item" key={item.stableId}>
+                <div className="desktop-entity-copy">
+                  <h4>{item.fileName}</h4>
                   <p>{item.packageName ?? "Package name not available yet"}</p>
-                  <p>Original: {item.originalSourcePath}</p>
-                  <p>Managed copy: {item.managedPath}</p>
-                </div>
-                <div className="desktop-inventory-side">
-                  <div className="desktop-inventory-meta">
-                    <span className="desktop-inventory-pill">
-                      {apkConfidenceLabel(item.confidence)}
-                    </span>
-                    <span className="desktop-inventory-pill">
-                      {formatFileSize(item.fileSizeBytes)}
-                    </span>
-                  </div>
-                  <p className="desktop-library-timestamp">
-                    Imported {formatTimestamp(item.importedAtUnixMs)}
+                  <p className="desktop-entity-meta">
+                    Saved {formatTimestamp(item.importedAtUnixMs)} · {formatFileSize(item.fileSizeBytes)}
                   </p>
+                </div>
+                <div className="desktop-entity-actions">
                   <button
                     className="primary-button desktop-inline-button"
-                    disabled={apkInstallState.actionPath !== null}
+                    disabled={apkInstallState.actionPath === item.managedPath}
                     onClick={() => onInstallApk(item.managedPath)}
                     type="button"
                   >
-                    {apkInstallState.actionPath === item.managedPath
-                      ? "Installing..."
-                      : "Install on Board"}
+                    {apkInstallState.actionPath === item.managedPath ? "Installing..." : "Install"}
                   </button>
                 </div>
               </li>
@@ -1291,25 +1121,13 @@ function ApkLibraryWorkspacePanel({
           </ul>
         )}
       </article>
-    </>
+    </section>
   );
 }
 
-interface InstalledTitlesWorkspacePanelProps {
-  installedTitleActionState: {
-    actionKind: "launch" | "uninstall" | null;
-    actionPackage: string | null;
-    confirmPackage: string | null;
-    message: string | null;
-    detail: string | null;
-    tone: "success" | "warning" | null;
-  };
-  installedTitlesState: {
-    loading: boolean;
-    snapshot: InstalledTitlesSnapshot | null;
-    errorMessage: string | null;
-    errorDetail: string | null;
-  };
+interface InstalledOnBoardSectionProps {
+  installedTitleActionState: InstalledTitleActionState;
+  installedTitlesState: InstalledTitlesState;
   onCancelUninstall: () => void;
   onLaunchTitle: (packageName: string, displayName: string) => void;
   onRefresh: () => void;
@@ -1317,7 +1135,7 @@ interface InstalledTitlesWorkspacePanelProps {
   onUninstallTitle: (packageName: string, displayName: string) => void;
 }
 
-function InstalledTitlesWorkspacePanel({
+function InstalledOnBoardSection({
   installedTitleActionState,
   installedTitlesState,
   onCancelUninstall,
@@ -1325,89 +1143,61 @@ function InstalledTitlesWorkspacePanel({
   onRefresh,
   onRequestUninstall,
   onUninstallTitle,
-}: InstalledTitlesWorkspacePanelProps) {
+}: InstalledOnBoardSectionProps) {
   const snapshot = installedTitlesState.snapshot;
-  const launchReadyCount = snapshot?.titles.filter((title) => title.canLaunch).length ?? 0;
 
   return (
-    <>
-      <article className="panel desktop-workspace-panel">
-        <div className="eyebrow">Installed on Board</div>
-        <h2>Keep the current Board inventory in one stable place.</h2>
-        <p className="panel-description">
-          This view turns `bdb list` into a title model the later uninstall and launch work can
-          reuse, without asking the renderer to parse command output on its own.
-        </p>
-
-        {snapshot !== null ? (
-          <article
-            className={`desktop-status-band desktop-status-band--${installedTitlesStatusTone(snapshot.status)}`}
-          >
-            <span className="desktop-status-band-label">
-              {installedTitlesStatusLabel(snapshot.status)}
-            </span>
-            <h3>{snapshot.summary}</h3>
-            <p>{snapshot.guidance}</p>
-          </article>
-        ) : null}
-
-        {installedTitlesState.errorMessage !== null ? (
-          <article className="desktop-inline-message desktop-inline-message--warning">
-            <h3>{installedTitlesState.errorMessage}</h3>
-            {installedTitlesState.errorDetail !== null ? (
-              <p>{installedTitlesState.errorDetail}</p>
-            ) : null}
-          </article>
-        ) : null}
-
-        {installedTitleActionState.message !== null ? (
-          <article
-            className={
-              installedTitleActionState.tone === "warning"
-                ? "desktop-inline-message desktop-inline-message--warning"
-                : "desktop-inline-message"
-            }
-          >
-            <h3>{installedTitleActionState.message}</h3>
-            {installedTitleActionState.detail !== null ? (
-              <p>{installedTitleActionState.detail}</p>
-            ) : null}
-          </article>
-        ) : null}
-
-        <dl className="desktop-detail-grid">
-          <DetailRow
-            label="Reported titles"
-            value={snapshot ? String(snapshot.titles.length) : "Loading..."}
-          />
-          <DetailRow label="Launch ready" value={snapshot ? String(launchReadyCount) : "Loading..."} />
-          <DetailRow label="Refresh" value={installedTitlesState.loading ? "Working now" : "Manual"} />
-        </dl>
-
-        <div className="desktop-action-row">
+    <section className="desktop-section-stack">
+      <section className="desktop-section-header">
+        <div>
+          <div className="eyebrow">Installed on Board</div>
+          <h2>Review what is already on your Board.</h2>
+          <p className="panel-description">
+            Open a game that is ready to launch, or remove something you no longer want on the
+            device.
+          </p>
+        </div>
+        <div className="desktop-inline-button-row">
           <button
             className="secondary-button"
             disabled={installedTitlesState.loading}
             onClick={onRefresh}
             type="button"
           >
-            {installedTitlesState.loading ? "Refreshing..." : "Refresh installed titles"}
+            {installedTitlesState.loading ? "Refreshing..." : "Refresh"}
           </button>
         </div>
-      </article>
+      </section>
 
-      <article className="panel desktop-workspace-panel">
-        <div className="eyebrow">Current title list</div>
-        <h2>Use launch and uninstall actions next to the title they affect.</h2>
-        <p className="panel-description">
-          When package identity is available, BE Home keeps the launch and uninstall actions on the
-          same row so the current device inventory stays easy to review.
+      {installedTitleActionState.message !== null ? (
+        <article
+          className={
+            installedTitleActionState.tone === "warning"
+              ? "desktop-inline-message desktop-inline-message--warning"
+              : "desktop-inline-message desktop-inline-message--success"
+          }
+        >
+          <h3>{installedTitleActionState.message}</h3>
+          {installedTitleActionState.detail !== null ? <p>{installedTitleActionState.detail}</p> : null}
+        </article>
+      ) : null}
+
+      <article className="desktop-content-card">
+        <div className="eyebrow">Current List</div>
+        <h3>Titles BE Home can read right now</h3>
+        <p className="desktop-section-copy">
+          BE Home keeps launch and remove actions next to the title they affect.
         </p>
 
-        {snapshot === null ? (
+        {installedTitlesState.errorMessage !== null ? (
+          <article className="desktop-inline-message desktop-inline-message--warning">
+            <h3>{installedTitlesState.errorMessage}</h3>
+            {installedTitlesState.errorDetail !== null ? <p>{installedTitlesState.errorDetail}</p> : null}
+          </article>
+        ) : snapshot === null ? (
           <article className="desktop-inline-card">
-            <h3>Loading the current Board inventory.</h3>
-            <p>BE Home is asking `bdb list` for the latest installed titles.</p>
+            <h3>Loading installed titles</h3>
+            <p>BE Home is asking Board for the latest list.</p>
           </article>
         ) : snapshot.titles.length === 0 ? (
           <article className="desktop-inline-card">
@@ -1415,22 +1205,14 @@ function InstalledTitlesWorkspacePanel({
             <p>{snapshot.guidance}</p>
           </article>
         ) : (
-          <ul className="desktop-inventory-list">
+          <ul className="desktop-entity-list">
             {snapshot.titles.map((title) => (
-              <li className="desktop-inventory-item" key={title.stableId}>
-                <div className="desktop-inventory-copy">
-                  <h3>{title.displayName}</h3>
+              <li className="desktop-entity-item" key={title.stableId}>
+                <div className="desktop-entity-copy">
+                  <h4>{title.displayName}</h4>
                   <p>{title.subtitle ?? "Package details are not available yet"}</p>
                 </div>
-                <div className="desktop-inventory-side">
-                  <div className="desktop-inventory-meta">
-                    <span className="desktop-inventory-pill">
-                      {title.canLaunch ? "Launch ready" : "Launch unavailable"}
-                    </span>
-                    <span className="desktop-inventory-pill">
-                      {title.canUninstall ? "Can uninstall" : "Read only"}
-                    </span>
-                  </div>
+                <div className="desktop-entity-actions">
                   {title.packageName !== null && title.canUninstall ? (
                     installedTitleActionState.confirmPackage === title.packageName ? (
                       <div className="desktop-inline-action-stack">
@@ -1443,7 +1225,7 @@ function InstalledTitlesWorkspacePanel({
                           {installedTitleActionState.actionPackage === title.packageName &&
                           installedTitleActionState.actionKind === "uninstall"
                             ? "Removing..."
-                            : "Confirm remove"}
+                            : "Confirm Remove"}
                         </button>
                         <button
                           className="secondary-button desktop-inline-button"
@@ -1465,7 +1247,7 @@ function InstalledTitlesWorkspacePanel({
                           >
                             {installedTitleActionState.actionPackage === title.packageName &&
                             installedTitleActionState.actionKind === "launch"
-                              ? "Launching..."
+                              ? "Opening..."
                               : "Open on Board"}
                           </button>
                         ) : null}
@@ -1479,418 +1261,78 @@ function InstalledTitlesWorkspacePanel({
                         </button>
                       </div>
                     )
-                  ) : null}
+                  ) : (
+                    <span className="desktop-entity-pill">Read only</span>
+                  )}
                 </div>
               </li>
             ))}
           </ul>
         )}
       </article>
-    </>
+    </section>
   );
 }
 
-interface DeviceWorkspacePanelProps {
-  deviceStatusState: {
-    loading: boolean;
-    snapshot: DeviceStatusSnapshot | null;
-    errorMessage: string | null;
-    errorDetail: string | null;
-  };
-  pollingActive: boolean;
-  setupGateState: SetupGateState;
-  onOpenSettings: () => void;
-  onRefresh: () => void;
-}
-
-function DeviceWorkspacePanel({
-  deviceStatusState,
-  pollingActive,
-  setupGateState,
-  onOpenSettings,
-  onRefresh,
-}: DeviceWorkspacePanelProps) {
-  const snapshot = deviceStatusState.snapshot;
-  const guidanceContent = snapshot ? buildDeviceGuidanceContent(snapshot, setupGateState) : null;
-
-  return (
-    <>
-      <article className="panel desktop-workspace-panel">
-        <div className="eyebrow">Board connection</div>
-        <h2>Keep the latest device check easy to trust.</h2>
-        <p className="panel-description">
-          BE Home uses the managed Board install tool to confirm whether your Board is nearby,
-          ready, and worth keeping in view while the app is open.
-        </p>
-
-        {snapshot !== null ? (
-          <article
-            className={`desktop-status-band desktop-status-band--${deviceStatusTone(snapshot.status)}`}
-          >
-            <span className="desktop-status-band-label">{deviceStatusLabel(snapshot.status)}</span>
-            <h3>{snapshot.summary}</h3>
-            <p>{snapshot.guidance}</p>
-          </article>
-        ) : null}
-
-        {deviceStatusState.errorMessage !== null ? (
-          <article className="desktop-inline-message desktop-inline-message--warning">
-            <h3>{deviceStatusState.errorMessage}</h3>
-            {deviceStatusState.errorDetail !== null ? <p>{deviceStatusState.errorDetail}</p> : null}
-          </article>
-        ) : null}
-
-        {snapshot === null ? (
-          <article className="desktop-inline-card">
-            <h3>Loading the latest Board connection check.</h3>
-            <p>
-              BE Home is asking the managed install tool for its current version and Board
-              connection state.
-            </p>
-          </article>
-        ) : (
-          <>
-            <dl className="desktop-detail-grid">
-              <DetailRow label="Connection state" value={deviceStatusLabel(snapshot.status)} />
-              <DetailRow
-                label="bdb version"
-                value={snapshot.bdbVersion.value ?? "Version not available yet"}
-              />
-              <DetailRow
-                label="Live refresh"
-                value={
-                  pollingActive
-                    ? `Every ${Math.floor(snapshot.pollIntervalMs / 1000)} seconds while this window stays visible`
-                    : "Paused until the desktop window is visible and focused again"
-                }
-              />
-              <DetailRow
-                label="Managed bdb location"
-                value={setupGateState.toolState.executablePath}
-              />
-            </dl>
-
-            <StatusSummaryCard
-              title="Current bdb version check"
-              summary={snapshot.bdbVersion.summary}
-              guidance={snapshot.bdbVersion.detail ?? snapshot.guidance}
-            />
-          </>
-        )}
-      </article>
-
-      {guidanceContent === null ? (
-        <article className="panel desktop-workspace-panel">
-          <div className="eyebrow">Recovery help</div>
-          <h2>
-            {deviceStatusState.errorMessage !== null
-              ? "Try the device check again."
-              : "We’ll load the right next steps after the first device check."}
-          </h2>
-          <p className="panel-description">
-            {deviceStatusState.errorDetail ??
-              "Once BE Home has the current Board status, this area will turn it into simple recovery guidance instead of terminal-style troubleshooting."}
-          </p>
-          {deviceStatusState.errorMessage !== null ? (
-            <div className="desktop-action-row">
-              <button
-                className="primary-button"
-                disabled={deviceStatusState.loading}
-                onClick={onRefresh}
-                type="button"
-              >
-                {deviceStatusState.loading ? "Refreshing..." : "Refresh device check"}
-              </button>
-            </div>
-          ) : null}
-        </article>
-      ) : (
-        <article
-          className={`panel desktop-workspace-panel desktop-guidance-panel desktop-guidance-panel--${guidanceContent.tone}`}
-        >
-          <div className="eyebrow">{guidanceContent.eyebrow}</div>
-          <h2>{guidanceContent.title}</h2>
-          <p className="panel-description">{guidanceContent.summary}</p>
-          <ol className="desktop-guidance-list">
-            {guidanceContent.steps.map((step) => (
-              <li key={step}>{step}</li>
-            ))}
-          </ol>
-          <dl className="desktop-detail-grid">
-            <DetailRow label="Tool state" value={setupGateState.toolState.summary} />
-            <DetailRow
-              label="Runnable check"
-              value={setupGateState.toolState.validation.summary}
-            />
-            <DetailRow
-              label="Source manifest"
-              value={setupGateState.toolState.sourcePlan.manifestSource}
-            />
-            <DetailRow
-              label="Managed tool folder"
-              value={setupGateState.toolState.storage.effectivePath}
-            />
-          </dl>
-          <div className="desktop-action-row">
-            <button
-              className="primary-button"
-              disabled={deviceStatusState.loading}
-              onClick={guidanceContent.primaryAction === "settings" ? onOpenSettings : onRefresh}
-              type="button"
-            >
-              {guidanceContent.primaryAction === "refresh" && deviceStatusState.loading
-                ? "Refreshing..."
-                : guidanceContent.primaryActionLabel}
-            </button>
-            {guidanceContent.secondaryAction !== undefined &&
-            guidanceContent.secondaryActionLabel !== undefined ? (
-              <button
-                className="secondary-button"
-                disabled={deviceStatusState.loading}
-                onClick={guidanceContent.secondaryAction === "settings" ? onOpenSettings : onRefresh}
-                type="button"
-              >
-                {guidanceContent.secondaryAction === "refresh" && deviceStatusState.loading
-                  ? "Refreshing..."
-                  : guidanceContent.secondaryActionLabel}
-              </button>
-            ) : null}
-          </div>
-        </article>
-      )}
-    </>
-  );
-}
-
-function deviceStatusLabel(value: DeviceStatusSnapshot["status"]): string {
-  switch (value) {
-    case "toolMissing":
-      return "Tool missing";
-    case "toolBroken":
-      return "Tool needs repair";
-    case "unsupportedHost":
-      return "Unsupported host";
-    case "boardDisconnected":
-      return "Board disconnected";
-    case "boardConnected":
-      return "Board connected";
-    case "executionError":
-    default:
-      return "Needs retry";
+function buildBoardStatusPresentation(
+  snapshot: DeviceStatusSnapshot | null,
+  setupGateState: SetupGateState | null,
+  deviceState: DeviceState,
+): BoardStatusPresentation {
+  if (setupGateState?.toolState.status === "unsupported" || snapshot?.status === "unsupportedHost") {
+    return {
+      tone: "neutral",
+      label: "Board support unavailable",
+      tooltip:
+        "Gray means Board does not currently publish support for this computer, so BE Home cannot check Board status here.",
+    };
   }
-}
 
-function deviceStatusTone(
-  value: DeviceStatusSnapshot["status"],
-): "success" | "warning" | "neutral" {
-  switch (value) {
+  if (snapshot === null) {
+    return {
+      tone: "neutral",
+      label: "Checking Board",
+      tooltip: "BE Home is checking for your Board now.",
+    };
+  }
+
+  switch (snapshot.status) {
     case "boardConnected":
-      return "success";
+      return {
+        tone: "success",
+        label: "Board connected",
+        tooltip: "Green means BE Home can see your Board right now.",
+      };
+    case "boardDisconnected":
+      return {
+        tone: "danger",
+        label: "Board not connected",
+        tooltip:
+          "Red means BE Home cannot see a connected Board right now. Plug in your Board and wake it if needed.",
+      };
     case "toolMissing":
     case "toolBroken":
-    case "boardDisconnected":
     case "executionError":
-      return "warning";
-    case "unsupportedHost":
     default:
-      return "neutral";
-  }
-}
-
-function installedTitlesStatusLabel(value: InstalledTitlesSnapshot["status"]): string {
-  switch (value) {
-    case "ready":
-      return "Inventory ready";
-    case "empty":
-      return "Nothing installed yet";
-    case "unavailable":
-    default:
-      return "Temporarily unavailable";
-  }
-}
-
-function installedTitlesStatusTone(
-  value: InstalledTitlesSnapshot["status"],
-): "success" | "warning" | "neutral" {
-  switch (value) {
-    case "ready":
-      return "success";
-    case "empty":
-      return "neutral";
-    case "unavailable":
-    default:
-      return "warning";
-  }
-}
-
-function apkDiscoveryStatusLabel(value: ApkDiscoverySnapshot["status"]): string {
-  switch (value) {
-    case "ready":
-      return "Candidates found";
-    case "empty":
-    default:
-      return "Nothing found yet";
-  }
-}
-
-function apkDiscoveryStatusTone(
-  value: ApkDiscoverySnapshot["status"],
-): "success" | "warning" | "neutral" {
-  switch (value) {
-    case "ready":
-      return "success";
-    case "empty":
-    default:
-      return "neutral";
-  }
-}
-
-function managedLibraryStatusLabel(value: ManagedApkLibrarySnapshot["status"]): string {
-  switch (value) {
-    case "ready":
-      return "Library ready";
-    case "empty":
-    default:
-      return "Nothing copied yet";
-  }
-}
-
-function managedLibraryStatusTone(
-  value: ManagedApkLibrarySnapshot["status"],
-): "success" | "warning" | "neutral" {
-  switch (value) {
-    case "ready":
-      return "success";
-    case "empty":
-    default:
-      return "neutral";
+      return {
+        tone: "warning",
+        label: "Board needs attention",
+        tooltip:
+          deviceState.errorDetail ??
+          "Amber means BE Home needs a quick fix or retry before it can trust the current Board status.",
+      };
   }
 }
 
 function apkConfidenceLabel(value: ApkCandidate["confidence"]): string {
   switch (value) {
     case "strongMatch":
-      return "Strong Board match";
+      return "Strong match";
     case "possibleMatch":
-      return "Possible Board match";
+      return "Possible match";
     case "unknown":
     default:
-      return "Board match unknown";
-  }
-}
-
-function formatTimestamp(value: number): string {
-  if (value <= 0) {
-    return "just now";
-  }
-
-  return new Date(value).toISOString().slice(0, 16).replace("T", " ");
-}
-
-function pathIdentityKey(path: string): string {
-  return path.toLowerCase();
-}
-
-function buildDeviceGuidanceContent(
-  snapshot: DeviceStatusSnapshot,
-  setupGateState: SetupGateState,
-): DeviceGuidanceContent {
-  switch (snapshot.status) {
-    case "boardConnected":
-      return {
-        eyebrow: "Ready to use",
-        title: "Board is connected and the desktop workspace can stay ahead of you.",
-        summary:
-          "You can move into local APK work, installed-title refreshes, and later install actions without leaving the desktop flow.",
-        steps: [
-          "Keep Board connected with USB while you install or refresh titles.",
-          "Use APK Library when you want to work from local files or managed copies.",
-          "Refresh this panel again any time you reconnect the cable or wake the device.",
-        ],
-        tone: "success",
-        primaryAction: "refresh",
-        primaryActionLabel: "Refresh device check",
-      };
-    case "boardDisconnected":
-      return {
-        eyebrow: "Reconnect Board",
-        title: "Connect Board and refresh when you're ready.",
-        summary:
-          "BE Home can finish device-aware work once Board is connected again, so this state stays focused on the quickest path back.",
-        steps: [
-          "Connect Board to this computer with USB.",
-          "Wake the Board screen and leave it on the main device UI for a moment.",
-          "Choose refresh here once the cable and device both look settled.",
-        ],
-        tone: "warning",
-        primaryAction: "refresh",
-        primaryActionLabel: "Refresh device check",
-      };
-    case "toolMissing":
-      return {
-        eyebrow: "Repair needed",
-        title: "Board's install tool needs to be put back in place.",
-        summary:
-          "The desktop app cannot check Board again until the managed bdb copy is available in settings.",
-        steps: [
-          "Open Settings so you can repair or re-download Board's install tool.",
-          "Let BE Home finish the repair in the managed tools folder.",
-          "Come back here and refresh the device check once repair is done.",
-        ],
-        tone: "warning",
-        primaryAction: "settings",
-        primaryActionLabel: "Open settings",
-        secondaryAction: "refresh",
-        secondaryActionLabel: "Refresh device check",
-      };
-    case "toolBroken":
-      return {
-        eyebrow: "Repair needed",
-        title: "Board's install tool needs a quick repair before device checks can continue.",
-        summary:
-          "BE Home found the stored bdb copy, but this computer is not letting it run cleanly enough to trust the result.",
-        steps: [
-          "Open Settings and choose the repair action for bdb.",
-          "Let the fresh copy finish downloading into the managed tools folder.",
-          "Return here and refresh the device check once repair is complete.",
-        ],
-        tone: "warning",
-        primaryAction: "settings",
-        primaryActionLabel: "Open settings",
-        secondaryAction: "refresh",
-        secondaryActionLabel: "Refresh device check",
-      };
-    case "unsupportedHost":
-      return {
-        eyebrow: "Unsupported system",
-        title: "This computer is outside Board's current supported desktop list.",
-        summary:
-          "BE Home will stay honest here instead of asking you to troubleshoot a setup Board does not currently publish bdb for.",
-        steps: [
-          setupGateState.toolState.guidance,
-          "If Board expands desktop support later, refresh the check from this panel.",
-          "For now, use a computer that matches Board's published support matrix for bdb.",
-        ],
-        tone: "neutral",
-        primaryAction: "refresh",
-        primaryActionLabel: "Refresh device check",
-      };
-    case "executionError":
-    default:
-      return {
-        eyebrow: "Try again",
-        title: "The last device check didn't finish cleanly.",
-        summary:
-          "This usually means the latest `bdb status` attempt could not settle into a clear connected or disconnected answer yet.",
-        steps: [
-          "Reconnect Board if the cable looks loose or the device has gone to sleep.",
-          "Close any other window or terminal that might still be using bdb.",
-          "Refresh the device check here once the connection path looks clear again.",
-        ],
-        tone: "warning",
-        primaryAction: "refresh",
-        primaryActionLabel: "Refresh device check",
-      };
+      return "Board match unclear";
   }
 }
 
@@ -1904,6 +1346,18 @@ function formatFileSize(value: number): string {
   }
 
   return `${value} bytes`;
+}
+
+function formatTimestamp(value: number): string {
+  if (value <= 0) {
+    return "just now";
+  }
+
+  return new Date(value).toLocaleString();
+}
+
+function pathIdentityKey(path: string): string {
+  return path.toLowerCase();
 }
 
 function extractActionErrorDetail(error: unknown, fallback: string): string {

--- a/src/settings-window/SettingsWindowApp.tsx
+++ b/src/settings-window/SettingsWindowApp.tsx
@@ -1,29 +1,54 @@
+import { getCurrentWindow } from "@tauri-apps/api/window";
 import { open } from "@tauri-apps/plugin-dialog";
+import { openUrl } from "@tauri-apps/plugin-opener";
 import { useEffect, useState } from "react";
 import {
   acquireBdbTool,
   emitSettingsUpdated,
+  loadBdbToolState,
   loadDesktopSettings,
-  loadSetupGateState,
+  refreshBdbToolState,
   saveDesktopSettings,
 } from "../desktop/client";
 import type {
+  BdbToolState,
   DesktopSettings,
   DesktopSettingsInput,
-  SetupGateState,
+  SupportRequestDraft,
 } from "../desktop/types";
-import { locationSourceLabel } from "../desktop-shell/formatters";
-import { DetailRow, StatusSummaryCard } from "../desktop-shell/ui";
 
-interface SettingsActionState {
-  loading: boolean;
-  message: string | null;
+type SettingsTabId = "locations" | "boardConnection" | "boardTool";
+
+interface InlineNotice {
+  tone: "neutral" | "warning" | "success";
+  title: string;
   detail: string | null;
 }
 
-async function pickSinglePath(
-  selection: string | string[] | null,
-): Promise<string | null> {
+const pollIntervalOptions = [
+  { label: "5 seconds", value: 5 },
+  { label: "10 seconds", value: 10 },
+  { label: "30 seconds", value: 30 },
+];
+
+function iconButton(icon: string, label: string, onClick: () => void, disabled = false) {
+  return (
+    <button
+      aria-label={label}
+      className="desktop-icon-button"
+      disabled={disabled}
+      onClick={onClick}
+      title={label}
+      type="button"
+    >
+      <span aria-hidden="true" className="material-symbols-outlined">
+        {icon}
+      </span>
+    </button>
+  );
+}
+
+async function pickSinglePath(selection: string | string[] | null): Promise<string | null> {
   if (selection === null) {
     return null;
   }
@@ -35,62 +60,82 @@ async function pickSinglePath(
   return selection;
 }
 
+function normalizeLibraryOverride(defaultPath: string, currentPath: string): string | null {
+  const trimmed = currentPath.trim();
+  if (trimmed.length === 0 || trimmed === defaultPath) {
+    return null;
+  }
+
+  return trimmed;
+}
+
+function toolActionLabel(toolState: BdbToolState): string {
+  if (!toolState.executableExists) {
+    return "Download";
+  }
+
+  if (toolState.updateStatus.status === "updateAvailable") {
+    return "Download Update";
+  }
+
+  return "Reinstall";
+}
+
 export default function SettingsWindowApp() {
-  const [setupGateState, setSetupGateState] = useState<SetupGateState | null>(null);
+  const [activeTabId, setActiveTabId] = useState<SettingsTabId>("locations");
   const [desktopSettings, setDesktopSettings] = useState<DesktopSettings | null>(null);
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  const [settingsActionState, setSettingsActionState] = useState<SettingsActionState>({
-    loading: false,
-    message: null,
-    detail: null,
-  });
+  const [toolState, setToolState] = useState<BdbToolState | null>(null);
+  const [windowError, setWindowError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [inlineNotice, setInlineNotice] = useState<InlineNotice | null>(null);
+  const [supportDialogDraft, setSupportDialogDraft] = useState<SupportRequestDraft | null>(null);
 
   useEffect(() => {
     void refreshWindowState();
   }, []);
 
-  async function refreshWindowState(): Promise<void> {
+  async function refreshWindowState(options?: { refreshManifest?: boolean }): Promise<void> {
     try {
-      const [setupState, settings] = await Promise.all([
-        loadSetupGateState(),
+      const [settings, latestToolState] = await Promise.all([
         loadDesktopSettings(),
+        options?.refreshManifest === true ? refreshBdbToolState() : loadBdbToolState(),
       ]);
-      setSetupGateState(setupState);
       setDesktopSettings(settings);
-      setErrorMessage(null);
+      setToolState(latestToolState);
+      setWindowError(null);
     } catch {
-      setErrorMessage(
-        "BE Home couldn't load your settings just yet. Try closing and reopening the window.",
+      setWindowError(
+        "BE Home couldn't load this settings window just yet. Please close it and try again.",
       );
     }
   }
 
-  async function persistDesktopSettings(
+  async function persistSettings(
     input: DesktopSettingsInput,
-    successMessage: string,
+    successTitle: string,
+    successDetail: string,
   ): Promise<void> {
-    setSettingsActionState({
-      loading: true,
-      message: null,
-      detail: null,
-    });
+    setBusy(true);
+    setInlineNotice(null);
 
     try {
       const savedSettings = await saveDesktopSettings(input);
       setDesktopSettings(savedSettings);
-      setSettingsActionState({
-        loading: false,
-        message: successMessage,
-        detail: "Your changes are saved and will still be here when you reopen the app.",
+      setInlineNotice({
+        tone: "success",
+        title: successTitle,
+        detail: successDetail,
       });
       await emitSettingsUpdated();
       await refreshWindowState();
     } catch {
-      setSettingsActionState({
-        loading: false,
-        message: "BE Home couldn't save those settings.",
+      setInlineNotice({
+        tone: "warning",
+        title: "BE Home couldn't save these settings yet.",
         detail: "Please try again in a moment.",
       });
+    } finally {
+      setBusy(false);
     }
   }
 
@@ -113,23 +158,22 @@ export default function SettingsWindowApp() {
     }
 
     if (desktopSettings.scanFolders.some((folder) => folder.path === selectedPath)) {
-      setSettingsActionState({
-        loading: false,
-        message: "That folder is already on your scan list.",
-        detail: "Choose another folder if you want BE Home to watch an additional place.",
+      setInlineNotice({
+        tone: "neutral",
+        title: "That folder is already on the list.",
+        detail: "Choose another folder if you want BE Home to check an additional place.",
       });
       return;
     }
 
-    await persistDesktopSettings(
+    await persistSettings(
       {
         apkLibraryOverride: desktopSettings.apkLibrary.overridePath,
-        scanFolderPaths: [
-          ...desktopSettings.scanFolders.map((folder) => folder.path),
-          selectedPath,
-        ],
+        boardConnectionPollIntervalSeconds: desktopSettings.boardConnection.pollIntervalSeconds,
+        scanFolderPaths: [...desktopSettings.scanFolders.map((folder) => folder.path), selectedPath],
       },
-      "BE Home added a new scan folder.",
+      "Games and apps folders updated.",
+      "BE Home will keep this new folder in view the next time you rescan.",
     );
   }
 
@@ -138,18 +182,20 @@ export default function SettingsWindowApp() {
       return;
     }
 
-    await persistDesktopSettings(
+    await persistSettings(
       {
         apkLibraryOverride: desktopSettings.apkLibrary.overridePath,
+        boardConnectionPollIntervalSeconds: desktopSettings.boardConnection.pollIntervalSeconds,
         scanFolderPaths: desktopSettings.scanFolders
           .map((folder) => folder.path)
-          .filter((scanFolderPath) => scanFolderPath !== path),
+          .filter((folderPath) => folderPath !== path),
       },
-      "BE Home updated your scan folder list.",
+      "Games and apps folders updated.",
+      "BE Home saved the new folder list.",
     );
   }
 
-  async function handleChangeApkLibraryLocation(): Promise<void> {
+  async function handleChangeLibraryLocation(): Promise<void> {
     if (desktopSettings === null) {
       return;
     }
@@ -165,77 +211,173 @@ export default function SettingsWindowApp() {
       return;
     }
 
-    await persistDesktopSettings(
+    await persistSettings(
       {
-        apkLibraryOverride: selectedPath,
+        apkLibraryOverride: normalizeLibraryOverride(
+          desktopSettings.apkLibrary.defaultPath,
+          selectedPath,
+        ),
+        boardConnectionPollIntervalSeconds: desktopSettings.boardConnection.pollIntervalSeconds,
         scanFolderPaths: desktopSettings.scanFolders.map((folder) => folder.path),
       },
-      "BE Home updated the managed APK library location.",
+      "Saved library location updated.",
+      "BE Home will use this folder for saved copies from now on.",
     );
   }
 
-  async function handleResetApkLibraryLocation(): Promise<void> {
+  async function handleResetLibraryLocation(): Promise<void> {
     if (desktopSettings === null) {
       return;
     }
 
-    await persistDesktopSettings(
+    await persistSettings(
       {
         apkLibraryOverride: null,
+        boardConnectionPollIntervalSeconds: desktopSettings.boardConnection.pollIntervalSeconds,
         scanFolderPaths: desktopSettings.scanFolders.map((folder) => folder.path),
       },
-      "BE Home switched the APK library back to the app default folder.",
+      "Saved library location reset.",
+      "BE Home is using the recommended location again.",
     );
   }
 
-  async function handleRepairFromSettings(): Promise<void> {
-    setSettingsActionState({
-      loading: true,
-      message: null,
-      detail: null,
-    });
+  async function handleChangePollInterval(nextValue: number): Promise<void> {
+    if (desktopSettings === null) {
+      return;
+    }
+
+    await persistSettings(
+      {
+        apkLibraryOverride: desktopSettings.apkLibrary.overridePath,
+        boardConnectionPollIntervalSeconds: nextValue,
+        scanFolderPaths: desktopSettings.scanFolders.map((folder) => folder.path),
+      },
+      "Board connection timing updated.",
+      "BE Home will use the new refresh timing the next time it checks your Board.",
+    );
+  }
+
+  async function handleCheckForUpdate(): Promise<void> {
+    setBusy(true);
+    setInlineNotice(null);
 
     try {
-      const result = await acquireBdbTool(true);
-      setSettingsActionState({
-        loading: false,
-        message: result.summary,
-        detail: result.guidance,
+      const latestToolState = await refreshBdbToolState();
+      setToolState(latestToolState);
+      setInlineNotice({
+        tone:
+          latestToolState.updateStatus.status === "updateAvailable" ? "warning" : "neutral",
+        title: "BE Home checked Board's latest Board Install Tool version.",
+        detail: latestToolState.updateStatus.guidance,
       });
       await emitSettingsUpdated();
-      await refreshWindowState();
     } catch {
-      setSettingsActionState({
-        loading: false,
-        message: "BE Home couldn't start the bdb repair just yet.",
+      setInlineNotice({
+        tone: "warning",
+        title: "BE Home couldn't check for updates right now.",
         detail: "Please try again in a moment.",
+      });
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function handleRepairOrReinstall(): Promise<void> {
+    if (toolState === null) {
+      return;
+    }
+
+    setBusy(true);
+    setInlineNotice(null);
+
+    try {
+      const result = await acquireBdbTool(toolState.executableExists);
+      setInlineNotice({
+        tone: result.outcome === "failed" ? "warning" : "success",
+        title: result.summary,
+        detail: result.guidance,
+      });
+      await refreshWindowState({ refreshManifest: true });
+      await emitSettingsUpdated();
+    } catch {
+      setInlineNotice({
+        tone: "warning",
+        title: "BE Home couldn't finish that Board Install Tool action.",
+        detail: "Please try again in a moment.",
+      });
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function handleOpenSupportEmail(): Promise<void> {
+    if (supportDialogDraft === null) {
+      return;
+    }
+
+    try {
+      await openUrl(supportDialogDraft.mailtoUrl);
+    } catch {
+      setInlineNotice({
+        tone: "warning",
+        title: "BE Home couldn't open your email app automatically.",
+        detail: "You can still copy the draft from this window.",
       });
     }
   }
 
-  if (errorMessage !== null) {
+  async function handleCopySupportDraft(): Promise<void> {
+    if (supportDialogDraft === null) {
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(
+        [`To: ${supportDialogDraft.to}`, `Subject: ${supportDialogDraft.subject}`, "", supportDialogDraft.body].join(
+          "\n",
+        ),
+      );
+      setInlineNotice({
+        tone: "success",
+        title: "Email draft copied.",
+        detail: "Paste it into your mail app, then add your email address and name before sending.",
+      });
+    } catch {
+      setInlineNotice({
+        tone: "warning",
+        title: "BE Home couldn't copy the email draft automatically.",
+        detail: "Please use the draft text shown in this window instead.",
+      });
+    }
+  }
+
+  async function handleCloseWindow(): Promise<void> {
+    await getCurrentWindow().close();
+  }
+
+  if (windowError !== null) {
     return (
       <main className="page-shell desktop-shell desktop-utility-window">
         <section className="page-grid narrow">
           <section className="panel desktop-state-card" aria-live="polite">
             <div className="eyebrow">Settings</div>
             <h2>Please close BE Home for Desktop and try again.</h2>
-            <p className="panel-description">{errorMessage}</p>
+            <p className="panel-description">{windowError}</p>
           </section>
         </section>
       </main>
     );
   }
 
-  if (setupGateState === null || desktopSettings === null) {
+  if (desktopSettings === null || toolState === null) {
     return (
       <main className="page-shell desktop-shell desktop-utility-window">
         <section className="page-grid narrow">
           <section className="panel desktop-state-card" aria-live="polite">
             <div className="eyebrow">Settings</div>
-            <h2>Loading your folder settings.</h2>
+            <h2>Loading settings</h2>
             <p className="panel-description">
-              BE Home is loading your current scan folders and storage choices.
+              BE Home is loading your folder choices and Board Install Tool details.
             </p>
           </section>
         </section>
@@ -245,138 +387,323 @@ export default function SettingsWindowApp() {
 
   return (
     <main className="page-shell desktop-shell desktop-utility-window">
-      <section className="page-grid desktop-grid">
-        <article className="hero-panel desktop-banner desktop-banner--compact">
-          <div className="hero-copy desktop-banner-copy">
-            <div className="eyebrow">Settings</div>
-            <h1>Keep folders and storage understandable</h1>
-            <p>
-              These settings stay focused on the places BE Home actually uses, so you can shape
-              your install routine without hunting through app files.
-            </p>
-          </div>
-        </article>
+      <section className="page-grid narrow desktop-utility-grid">
+        <section className="panel desktop-utility-card">
+          <header className="desktop-utility-header">
+            <div className="desktop-utility-heading">
+              <div className="eyebrow">Settings</div>
+              <h1>BE Home for Desktop settings</h1>
+              <p className="panel-description">
+                Keep the most important folders, Board checks, and Board Install Tool options in
+                one easy place.
+              </p>
+            </div>
+            <nav aria-label="Settings sections" className="desktop-tab-row">
+              <button
+                className={
+                  activeTabId === "locations"
+                    ? "desktop-tab-button desktop-tab-button--active"
+                    : "desktop-tab-button"
+                }
+                onClick={() => setActiveTabId("locations")}
+                type="button"
+              >
+                Locations
+              </button>
+              <button
+                className={
+                  activeTabId === "boardConnection"
+                    ? "desktop-tab-button desktop-tab-button--active"
+                    : "desktop-tab-button"
+                }
+                onClick={() => setActiveTabId("boardConnection")}
+                type="button"
+              >
+                Board Connection
+              </button>
+              <button
+                className={
+                  activeTabId === "boardTool"
+                    ? "desktop-tab-button desktop-tab-button--active"
+                    : "desktop-tab-button"
+                }
+                onClick={() => setActiveTabId("boardTool")}
+                type="button"
+              >
+                Board Install Tool
+              </button>
+            </nav>
+          </header>
 
-        <section className="desktop-settings-layout">
-          <article className="panel desktop-workspace-panel">
-            <div className="eyebrow">Scan folders</div>
-            <h2>Keep your local game folders in view.</h2>
-            <p className="panel-description">
-              BE Home can check these folders when you want to find downloads again later.
-            </p>
-            <div className="desktop-folder-list">
-              {desktopSettings.scanFolders.length === 0 ? (
-                <p className="desktop-folder-empty">
-                  You do not have any scan folders yet. Add one when you want BE Home to keep a
-                  folder in view.
-                </p>
-              ) : (
-                desktopSettings.scanFolders.map((folder) => (
-                  <article className="desktop-folder-card" key={folder.path}>
-                    <div className="desktop-folder-copy">
-                      <h3>{folder.path}</h3>
-                      <p className="desktop-folder-meta">
-                        {folder.source === "default" ? "App default" : "Custom"}
+          <section className="desktop-utility-body" aria-live="polite">
+            {activeTabId === "locations" ? (
+              <section className="desktop-settings-page">
+                <div className="eyebrow">Locations</div>
+                <h2>Choose where BE Home looks and saves.</h2>
+
+                <section className="desktop-settings-section">
+                  <div className="desktop-list-editor-header">
+                    <div>
+                      <span className="desktop-field-label">Games and apps folders</span>
+                      <p className="desktop-section-copy">
+                        BE Home checks these folders when you rescan this computer.
                       </p>
                     </div>
+                    {iconButton("add", "Add folder", () => void handleAddScanFolder(), busy)}
+                  </div>
+
+                  {desktopSettings.scanFolders.length === 0 ? (
+                    <div className="desktop-empty-note">
+                      No folders are selected. You can still choose games and apps manually.
+                    </div>
+                  ) : (
+                    <ul className="desktop-folder-list desktop-folder-list--compact">
+                      {desktopSettings.scanFolders.map((folder) => (
+                        <li className="desktop-folder-item" key={folder.path}>
+                          <div className="desktop-folder-copy">
+                            <p className="desktop-folder-path">{folder.path}</p>
+                            <p className="desktop-folder-meta">
+                              {folder.source === "default" ? "Recommended folder" : "Custom folder"}
+                            </p>
+                          </div>
+                          {iconButton(
+                            "remove",
+                            `Remove ${folder.path}`,
+                            () => void handleRemoveScanFolder(folder.path),
+                            busy,
+                          )}
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </section>
+
+                <section className="desktop-settings-section">
+                  <label className="desktop-field">
+                    <span className="desktop-field-label">Saved library folder</span>
+                    <div className="desktop-input-with-button">
+                      <input
+                        className="desktop-text-field"
+                        readOnly
+                        type="text"
+                        value={desktopSettings.apkLibrary.effectivePath}
+                      />
+                      {iconButton(
+                        "folder_open",
+                        "Choose saved library folder",
+                        () => void handleChangeLibraryLocation(),
+                        busy,
+                      )}
+                    </div>
+                  </label>
+                  <div className="desktop-recommended-row">
+                    <span className="desktop-recommended-badge">
+                      {desktopSettings.apkLibrary.overridePath === null ? "Recommended" : "Custom"}
+                    </span>
+                    {desktopSettings.apkLibrary.overridePath !== null ? (
+                      <button
+                        className="tertiary-button desktop-link-button"
+                        disabled={busy}
+                        onClick={() => void handleResetLibraryLocation()}
+                        type="button"
+                      >
+                        Use recommended location
+                      </button>
+                    ) : null}
+                  </div>
+                </section>
+
+                <section className="desktop-settings-section">
+                  <label className="desktop-field">
+                    <span className="desktop-field-label">Board Install Tool location</span>
+                    <div className="desktop-readonly-field">{desktopSettings.bdbExecutablePath}</div>
+                  </label>
+                </section>
+              </section>
+            ) : null}
+
+            {activeTabId === "boardConnection" ? (
+              <section className="desktop-settings-page">
+                <div className="eyebrow">Board Connection</div>
+                <h2>Choose how often BE Home checks your Board.</h2>
+                <p className="panel-description">
+                  BE Home only refreshes while its main window is visible.
+                </p>
+                <div className="desktop-radio-list" role="radiogroup" aria-label="Board refresh timing">
+                  {pollIntervalOptions.map((option) => (
                     <button
-                      className="secondary-button secondary-button--compact"
-                      disabled={settingsActionState.loading}
-                      onClick={() => void handleRemoveScanFolder(folder.path)}
+                      aria-checked={
+                        desktopSettings.boardConnection.pollIntervalSeconds === option.value
+                      }
+                      className={
+                        desktopSettings.boardConnection.pollIntervalSeconds === option.value
+                          ? "desktop-radio-card desktop-radio-card--active"
+                          : "desktop-radio-card"
+                      }
+                      disabled={busy}
+                      key={option.value}
+                      onClick={() => void handleChangePollInterval(option.value)}
+                      role="radio"
                       type="button"
                     >
-                      Remove
+                      <span className="desktop-radio-title">{option.label}</span>
+                      <span className="desktop-radio-copy">
+                        {option.value === 5
+                          ? "Recommended for most players."
+                          : option.value === 10
+                            ? "A little quieter while still feeling current."
+                            : "Best when you prefer fewer checks."}
+                      </span>
                     </button>
+                  ))}
+                </div>
+              </section>
+            ) : null}
+
+            {activeTabId === "boardTool" ? (
+              <section className="desktop-settings-page">
+                <div className="eyebrow">Board Install Tool</div>
+                <h2>Keep the Board Install Tool ready.</h2>
+                <p className="panel-description">
+                  BE Home uses this helper to talk to your Board and install games and apps.
+                </p>
+
+                <div className="desktop-form-grid">
+                  <label className="desktop-field">
+                    <span className="desktop-field-label">Current version</span>
+                    <div className="desktop-readonly-field">
+                      {toolState.versionCheck.value ?? "Not installed yet"}
+                    </div>
+                  </label>
+                  <label className="desktop-field">
+                    <span className="desktop-field-label">Latest version in BE Home</span>
+                    <div className="desktop-readonly-field">
+                      {toolState.updateStatus.availableVersion ?? "Not available yet"}
+                    </div>
+                  </label>
+                  <label className="desktop-field">
+                    <span className="desktop-field-label">Install location</span>
+                    <div className="desktop-readonly-field">{toolState.executablePath}</div>
+                  </label>
+                </div>
+
+                <article className="desktop-inline-card">
+                  <h3>{toolState.summary}</h3>
+                  <p>{toolState.updateStatus.guidance}</p>
+                </article>
+
+                {toolState.supportRequestDraft !== null ? (
+                  <article className="desktop-inline-message desktop-inline-message--warning">
+                    <h3>This build of the Board Install Tool is not compatible with this computer.</h3>
+                    <p>BE Home can help you start a support email to Board with the exact error.</p>
+                    <div className="desktop-inline-button-row">
+                      <button
+                        className="secondary-button"
+                        onClick={() => setSupportDialogDraft(toolState.supportRequestDraft)}
+                        type="button"
+                      >
+                        Email Board Support...
+                      </button>
+                    </div>
                   </article>
-                ))
-              )}
-            </div>
-            <div className="desktop-action-row">
-              <button
-                className="primary-button"
-                disabled={settingsActionState.loading}
-                onClick={() => void handleAddScanFolder()}
-                type="button"
+                ) : null}
+
+                <div className="desktop-inline-button-row">
+                  <button
+                    className="primary-button"
+                    disabled={busy}
+                    onClick={() => void handleRepairOrReinstall()}
+                    type="button"
+                  >
+                    {busy ? "Working..." : toolActionLabel(toolState)}
+                  </button>
+                  <button
+                    className="secondary-button"
+                    disabled={busy}
+                    onClick={() => void handleCheckForUpdate()}
+                    type="button"
+                  >
+                    Check for Update
+                  </button>
+                </div>
+              </section>
+            ) : null}
+
+            {inlineNotice !== null ? (
+              <article
+                className={
+                  inlineNotice.tone === "warning"
+                    ? "desktop-inline-message desktop-inline-message--warning"
+                    : inlineNotice.tone === "success"
+                      ? "desktop-inline-message desktop-inline-message--success"
+                      : "desktop-inline-message"
+                }
               >
-                Add scan folder
+                <h3>{inlineNotice.title}</h3>
+                {inlineNotice.detail !== null ? <p>{inlineNotice.detail}</p> : null}
+              </article>
+            ) : null}
+          </section>
+
+          <footer className="desktop-utility-footer">
+            <div />
+            <div className="desktop-utility-footer-actions">
+              <button className="primary-button" onClick={() => void handleCloseWindow()} type="button">
+                Done
               </button>
             </div>
-          </article>
+          </footer>
+        </section>
+      </section>
 
-          <article className="panel desktop-workspace-panel">
-            <div className="eyebrow">Managed APK library</div>
-            <h2>Keep your saved copies in one familiar place.</h2>
+      {supportDialogDraft !== null ? (
+        <section className="desktop-modal-scrim" role="presentation">
+          <article
+            aria-labelledby="settings-support-request-title"
+            className="panel desktop-modal-card"
+            role="dialog"
+          >
+            <div className="eyebrow">Board Support</div>
+            <h2 id="settings-support-request-title">Email Board Support</h2>
             <p className="panel-description">
-              This is where BE Home keeps the app-managed library of files you want to reuse later.
+              BE Home can open this draft in your mail app for you.
             </p>
-            <dl className="desktop-detail-grid">
-              <DetailRow label="Current location" value={desktopSettings.apkLibrary.effectivePath} />
-              <DetailRow
-                label="Location source"
-                value={locationSourceLabel(desktopSettings.apkLibrary)}
-              />
-            </dl>
-            <div className="desktop-action-row">
-              <button
-                className="primary-button"
-                disabled={settingsActionState.loading}
-                onClick={() => void handleChangeApkLibraryLocation()}
-                type="button"
-              >
-                Change library folder
-              </button>
-              {desktopSettings.apkLibrary.overridePath !== null ? (
-                <button
-                  className="secondary-button"
-                  disabled={settingsActionState.loading}
-                  onClick={() => void handleResetApkLibraryLocation()}
-                  type="button"
-                >
-                  Use app default
-                </button>
-              ) : null}
+            <div className="desktop-form-grid">
+              <label className="desktop-field">
+                <span className="desktop-field-label">To</span>
+                <div className="desktop-readonly-field">{supportDialogDraft.to}</div>
+              </label>
+              <label className="desktop-field">
+                <span className="desktop-field-label">Subject</span>
+                <div className="desktop-readonly-field">{supportDialogDraft.subject}</div>
+              </label>
+              <label className="desktop-field">
+                <span className="desktop-field-label">Email draft</span>
+                <textarea className="desktop-text-area" readOnly value={supportDialogDraft.body} />
+              </label>
             </div>
-          </article>
-
-          <article className="panel desktop-workspace-panel">
-            <div className="eyebrow">Board tool</div>
-            <h2>Keep Board's install tool ready.</h2>
-            <p className="panel-description">
-              This path is read-only here, but you can repair the managed Board tool when it needs
-              attention.
+            <p className="desktop-footnote">
+              Please enter your email address in the From field and add your name at the end before
+              sending.
             </p>
-            <dl className="desktop-detail-grid">
-              <DetailRow label="Managed bdb location" value={desktopSettings.bdbExecutablePath} />
-              <DetailRow label="Current state" value={setupGateState.toolState.summary} />
-              <DetailRow label="Settings file" value={desktopSettings.settingsFilePath} />
-            </dl>
-
-            <StatusSummaryCard
-              title="Current tool state"
-              summary={setupGateState.toolState.summary}
-              guidance={setupGateState.toolState.guidance}
-            />
-
-            <div className="desktop-action-row">
+            <div className="desktop-inline-button-row">
+              <button className="primary-button" onClick={() => void handleOpenSupportEmail()} type="button">
+                Open Mail App
+              </button>
+              <button className="secondary-button" onClick={() => void handleCopySupportDraft()} type="button">
+                Copy Email Draft
+              </button>
               <button
-                className="primary-button"
-                disabled={settingsActionState.loading}
-                onClick={() => void handleRepairFromSettings()}
+                className="tertiary-button"
+                onClick={() => setSupportDialogDraft(null)}
                 type="button"
               >
-                Repair bdb
+                Close
               </button>
             </div>
           </article>
         </section>
-
-        {settingsActionState.message !== null ? (
-          <article className="panel desktop-workspace-panel desktop-inline-message">
-            <h3>{settingsActionState.message}</h3>
-            {settingsActionState.detail !== null ? <p>{settingsActionState.detail}</p> : null}
-          </article>
-        ) : null}
-      </section>
+      ) : null}
     </main>
   );
 }

--- a/src/setup-window/SetupWizardApp.tsx
+++ b/src/setup-window/SetupWizardApp.tsx
@@ -1,93 +1,124 @@
 import { getCurrentWindow } from "@tauri-apps/api/window";
-import { useEffect, useState } from "react";
+import { open } from "@tauri-apps/plugin-dialog";
+import { openUrl } from "@tauri-apps/plugin-opener";
+import { useEffect, useMemo, useState } from "react";
 import {
   acquireBdbTool,
   dismissSetupWizardWindow,
+  emitSettingsUpdated,
+  loadBdbToolState,
+  loadDesktopSettings,
   loadSetupGateState,
+  refreshBdbToolState,
+  saveDesktopSettings,
   showMainWorkspaceWindow,
 } from "../desktop/client";
-import type { BdbAcquisitionResult, SetupGateState } from "../desktop/types";
-import {
-  formatScanFolders,
-  locationSourceLabel,
-  statusLabel,
-} from "../desktop-shell/formatters";
-import { DetailRow, StatusChip, StatusSummaryCard } from "../desktop-shell/ui";
+import type {
+  BdbToolState,
+  DesktopSettings,
+  DesktopSettingsInput,
+  SetupGateState,
+  SupportRequestDraft,
+} from "../desktop/types";
 
-type SetupViewStep = "systemCheck" | "toolSetup" | "reviewDefaults";
+type WizardStepId = "welcome" | "boardTool" | "scanFolders" | "libraryLocation" | "ready";
 
-interface SetupStepCardProps {
-  stepNumber: number;
+interface WizardStep {
+  id: WizardStepId;
+  label: string;
+}
+
+interface InlineNotice {
+  tone: "neutral" | "warning" | "success";
   title: string;
-  summary: string;
-  status: "active" | "complete" | "upcoming";
-}
-
-interface ToolActionState {
-  loading: boolean;
-  message: string | null;
   detail: string | null;
-  lastOutcome: BdbAcquisitionResult["outcome"] | null;
 }
 
-function SetupStepCard({ stepNumber, title, summary, status }: SetupStepCardProps) {
+const wizardSteps: WizardStep[] = [
+  { id: "welcome", label: "Welcome" },
+  { id: "boardTool", label: "Board Install Tool" },
+  { id: "scanFolders", label: "Look for Games & Apps" },
+  { id: "libraryLocation", label: "Library Location" },
+  { id: "ready", label: "Ready to Go" },
+];
+
+function iconButtonLabel(icon: string, label: string, onClick: () => void, disabled = false) {
   return (
-    <li
-      className={
-        status === "active"
-          ? "desktop-step-card desktop-step-card--active"
-          : status === "complete"
-            ? "desktop-step-card desktop-step-card--complete"
-            : "desktop-step-card"
-      }
+    <button
+      aria-label={label}
+      className="desktop-icon-button"
+      disabled={disabled}
+      onClick={onClick}
+      title={label}
+      type="button"
     >
-      <span className="desktop-step-number">{stepNumber}</span>
-      <div className="desktop-step-copy">
-        <h3>{title}</h3>
-        <p>{summary}</p>
-      </div>
-    </li>
+      <span aria-hidden="true" className="material-symbols-outlined">
+        {icon}
+      </span>
+    </button>
   );
 }
 
-function describeSetupStepStatus(
-  activeStep: SetupViewStep,
-  step: SetupViewStep,
-): "active" | "complete" | "upcoming" {
-  const stepOrder: Record<SetupViewStep, number> = {
-    systemCheck: 1,
-    toolSetup: 2,
-    reviewDefaults: 3,
-  };
-
-  if (step === activeStep) {
-    return "active";
+async function pickSinglePath(selection: string | string[] | null): Promise<string | null> {
+  if (selection === null) {
+    return null;
   }
 
-  if (stepOrder[step] < stepOrder[activeStep]) {
-    return "complete";
+  if (Array.isArray(selection)) {
+    return selection[0] ?? null;
   }
 
-  return "upcoming";
+  return selection;
+}
+
+function normalizeLibraryOverride(defaultPath: string, draftValue: string): string | null {
+  const normalizedDraft = draftValue.trim();
+  if (normalizedDraft.length === 0 || normalizedDraft === defaultPath) {
+    return null;
+  }
+
+  return normalizedDraft;
+}
+
+function supportInstructionText(): string {
+  return "Please enter your email address in the From field and add your name at the end before sending.";
+}
+
+function updateActionLabel(toolState: BdbToolState): string {
+  if (!toolState.executableExists) {
+    return "Download";
+  }
+
+  if (toolState.updateStatus.status === "updateAvailable") {
+    return "Download Update";
+  }
+
+  return "Reinstall";
 }
 
 export default function SetupWizardApp() {
   const [setupGateState, setSetupGateState] = useState<SetupGateState | null>(null);
-  const [setupViewStep, setSetupViewStep] = useState<SetupViewStep>("systemCheck");
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  const [toolActionState, setToolActionState] = useState<ToolActionState>({
-    loading: false,
-    message: null,
-    detail: null,
-    lastOutcome: null,
-  });
+  const [toolState, setToolState] = useState<BdbToolState | null>(null);
+  const [desktopSettings, setDesktopSettings] = useState<DesktopSettings | null>(null);
+  const [currentStepId, setCurrentStepId] = useState<WizardStepId>("welcome");
+  const [scanFolderDraft, setScanFolderDraft] = useState<string[]>([]);
+  const [libraryPathDraft, setLibraryPathDraft] = useState("");
+  const [windowError, setWindowError] = useState<string | null>(null);
+  const [inlineNotice, setInlineNotice] = useState<InlineNotice | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [supportDialogDraft, setSupportDialogDraft] = useState<SupportRequestDraft | null>(null);
+
+  const currentStepIndex = wizardSteps.findIndex((step) => step.id === currentStepId);
+  const toolStepBlocked = toolState?.supportRequestDraft !== null;
+  const canAdvancePastToolStep = toolState?.status === "runnable" && !toolStepBlocked;
 
   useEffect(() => {
-    void refreshSetupGateState();
+    void refreshWindowState();
   }, []);
 
   useEffect(() => {
     let unlistenCloseRequest: (() => void) | null = null;
+
     void getCurrentWindow()
       .onCloseRequested(async (event) => {
         event.preventDefault();
@@ -105,60 +136,80 @@ export default function SetupWizardApp() {
     };
   }, [setupGateState?.status]);
 
-  async function refreshSetupGateState(options?: {
-    showReviewDefaultsOnReady?: boolean;
-  }): Promise<void> {
+  const readySummaryRows = useMemo(
+    () =>
+      [
+        {
+          label: "Board Install Tool",
+          value:
+            toolState?.versionCheck.value ??
+            (toolState?.status === "runnable" ? "Installed" : "Still needs to be downloaded"),
+        },
+        {
+          label: "Games and apps folders",
+          value:
+            scanFolderDraft.length === 0 ? "No folders selected. You can still choose files manually." : scanFolderDraft.join("\n"),
+        },
+        {
+          label: "Saved library",
+          value: libraryPathDraft.trim(),
+        },
+      ] satisfies Array<{ label: string; value: string }>,
+    [libraryPathDraft, scanFolderDraft, toolState],
+  );
+
+  async function refreshWindowState(options?: { refreshManifest?: boolean }): Promise<void> {
     try {
-      const state = await loadSetupGateState();
-      setSetupGateState(state);
-      setErrorMessage(null);
-
-      if (state.status === "ready") {
-        setSetupViewStep("reviewDefaults");
-        return;
-      }
-
-      if (options?.showReviewDefaultsOnReady === true) {
-        setSetupViewStep("reviewDefaults");
-        return;
-      }
-
-      setSetupViewStep(state.requiredStep === "toolSetup" ? "toolSetup" : "systemCheck");
+      const [setupState, settings, latestToolState] = await Promise.all([
+        loadSetupGateState(),
+        loadDesktopSettings(),
+        options?.refreshManifest === true ? refreshBdbToolState() : loadBdbToolState(),
+      ]);
+      setSetupGateState(setupState);
+      setDesktopSettings(settings);
+      setToolState(latestToolState);
+      setScanFolderDraft(settings.scanFolders.map((folder) => folder.path));
+      setLibraryPathDraft(settings.apkLibrary.effectivePath);
+      setWindowError(null);
     } catch {
-      setErrorMessage(
-        "We couldn't reach the desktop host just yet. Try closing and reopening the app.",
+      setWindowError(
+        "BE Home couldn't load the setup wizard just yet. Please close the app and try again.",
       );
     }
   }
 
-  async function handleAcquireBdbTool(repair: boolean): Promise<void> {
-    setToolActionState({
-      loading: true,
-      message: null,
-      detail: null,
-      lastOutcome: null,
-    });
+  async function saveDraftSettings(): Promise<boolean> {
+    if (desktopSettings === null) {
+      return false;
+    }
+
+    setBusy(true);
+    setInlineNotice(null);
 
     try {
-      const result = await acquireBdbTool(repair);
-      setToolActionState({
-        loading: false,
-        message: result.summary,
-        detail: result.guidance,
-        lastOutcome: result.outcome,
-      });
-      await refreshSetupGateState({
-        showReviewDefaultsOnReady:
-          result.toolState.status === "runnable" &&
-          (result.outcome === "downloaded" || result.outcome === "repaired"),
-      });
+      const input: DesktopSettingsInput = {
+        apkLibraryOverride: normalizeLibraryOverride(
+          desktopSettings.apkLibrary.defaultPath,
+          libraryPathDraft,
+        ),
+        boardConnectionPollIntervalSeconds: desktopSettings.boardConnection.pollIntervalSeconds,
+        scanFolderPaths: scanFolderDraft,
+      };
+      const savedSettings = await saveDesktopSettings(input);
+      setDesktopSettings(savedSettings);
+      setScanFolderDraft(savedSettings.scanFolders.map((folder) => folder.path));
+      setLibraryPathDraft(savedSettings.apkLibrary.effectivePath);
+      await emitSettingsUpdated();
+      return true;
     } catch {
-      setToolActionState({
-        loading: false,
-        message: "BE Home couldn't finish the bdb setup step.",
+      setInlineNotice({
+        tone: "warning",
+        title: "BE Home couldn't save these setup choices yet.",
         detail: "Please try again in a moment.",
-        lastOutcome: "failed",
       });
+      return false;
+    } finally {
+      setBusy(false);
     }
   }
 
@@ -166,35 +217,228 @@ export default function SetupWizardApp() {
     await dismissSetupWizardWindow();
   }
 
-  async function handleOpenWorkspace(): Promise<void> {
+  async function handleDownloadOrRepair(): Promise<void> {
+    if (toolState === null) {
+      return;
+    }
+
+    setBusy(true);
+    setInlineNotice(null);
+
+    try {
+      const result = await acquireBdbTool(toolState.executableExists);
+      setInlineNotice({
+        tone: result.outcome === "failed" ? "warning" : "success",
+        title: result.summary,
+        detail: result.guidance,
+      });
+      await refreshWindowState({
+        refreshManifest: result.outcome !== "failed",
+      });
+    } catch {
+      setInlineNotice({
+        tone: "warning",
+        title: "BE Home couldn't finish that Board Install Tool step.",
+        detail: "Please try again in a moment.",
+      });
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function handleCheckForUpdate(): Promise<void> {
+    setBusy(true);
+    setInlineNotice(null);
+
+    try {
+      await refreshWindowState({ refreshManifest: true });
+      setInlineNotice({
+        tone:
+          toolState?.updateStatus.status === "updateAvailable" ? "warning" : "neutral",
+        title: "BE Home checked Board's latest Board Install Tool version.",
+        detail: toolState?.updateStatus.guidance ?? "You can review the current version details below.",
+      });
+    } catch {
+      setInlineNotice({
+        tone: "warning",
+        title: "BE Home couldn't check for Board Install Tool updates right now.",
+        detail: "Please try again in a moment.",
+      });
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function handleAddScanFolder(): Promise<void> {
+    const selectedPath = await pickSinglePath(
+      await open({
+        directory: true,
+        multiple: false,
+        defaultPath: scanFolderDraft[scanFolderDraft.length - 1] ?? libraryPathDraft,
+      }),
+    );
+    if (selectedPath === null) {
+      return;
+    }
+
+    if (scanFolderDraft.includes(selectedPath)) {
+      setInlineNotice({
+        tone: "neutral",
+        title: "That folder is already on the list.",
+        detail: "Choose another folder if you want BE Home to watch an additional place.",
+      });
+      return;
+    }
+
+    setScanFolderDraft((previous) => [...previous, selectedPath]);
+  }
+
+  function handleRemoveScanFolder(path: string): void {
+    setScanFolderDraft((previous) => previous.filter((currentPath) => currentPath !== path));
+  }
+
+  async function handleBrowseLibraryLocation(): Promise<void> {
+    const selectedPath = await pickSinglePath(
+      await open({
+        directory: true,
+        multiple: false,
+        defaultPath: libraryPathDraft,
+      }),
+    );
+    if (selectedPath !== null) {
+      setLibraryPathDraft(selectedPath);
+    }
+  }
+
+  function handleUseRecommendedLibraryLocation(): void {
+    if (desktopSettings !== null) {
+      setLibraryPathDraft(desktopSettings.apkLibrary.defaultPath);
+    }
+  }
+
+  async function handleOpenSupportEmail(): Promise<void> {
+    if (supportDialogDraft === null) {
+      return;
+    }
+
+    try {
+      await openUrl(supportDialogDraft.mailtoUrl);
+    } catch {
+      setInlineNotice({
+        tone: "warning",
+        title: "BE Home couldn't open your email app automatically.",
+        detail: "You can still copy the email draft from this window.",
+      });
+    }
+  }
+
+  async function handleCopySupportDraft(): Promise<void> {
+    if (supportDialogDraft === null) {
+      return;
+    }
+
+    const draftText = [
+      `To: ${supportDialogDraft.to}`,
+      `Subject: ${supportDialogDraft.subject}`,
+      "",
+      supportDialogDraft.body,
+    ].join("\n");
+
+    try {
+      await navigator.clipboard.writeText(draftText);
+      setInlineNotice({
+        tone: "success",
+        title: "Email draft copied.",
+        detail: "Paste it into your mail app, then add your email address and name before sending.",
+      });
+    } catch {
+      setInlineNotice({
+        tone: "warning",
+        title: "BE Home couldn't copy the email draft automatically.",
+        detail: "Please use the text shown in this window instead.",
+      });
+    }
+  }
+
+  async function handleFinish(): Promise<void> {
+    if (!(await saveDraftSettings())) {
+      return;
+    }
+
     await showMainWorkspaceWindow();
     await dismissSetupWizardWindow();
   }
 
-  if (errorMessage !== null) {
+  async function handleNext(): Promise<void> {
+    setInlineNotice(null);
+
+    switch (currentStepId) {
+      case "welcome":
+        setCurrentStepId("boardTool");
+        return;
+      case "boardTool":
+        if (!canAdvancePastToolStep) {
+          setInlineNotice({
+            tone: "warning",
+            title: "Finish the Board Install Tool step first.",
+            detail: toolStepBlocked
+              ? "This build of the Board Install Tool is not compatible with this computer yet."
+              : "BE Home needs the Board Install Tool ready before it can open the workspace.",
+          });
+          return;
+        }
+        setCurrentStepId("scanFolders");
+        return;
+      case "scanFolders":
+        if (await saveDraftSettings()) {
+          setCurrentStepId("libraryLocation");
+        }
+        return;
+      case "libraryLocation":
+        if (await saveDraftSettings()) {
+          setCurrentStepId("ready");
+        }
+        return;
+      case "ready":
+        await handleFinish();
+        return;
+      default:
+        return;
+    }
+  }
+
+  function handleBack(): void {
+    setInlineNotice(null);
+    setCurrentStepId((previousStepId) => {
+      const previousIndex = wizardSteps.findIndex((step) => step.id === previousStepId) - 1;
+      return wizardSteps[Math.max(previousIndex, 0)]?.id ?? "welcome";
+    });
+  }
+
+  if (windowError !== null) {
     return (
       <main className="page-shell desktop-shell desktop-utility-window">
         <section className="page-grid narrow">
           <section className="panel desktop-state-card" aria-live="polite">
             <div className="eyebrow">Setup Wizard</div>
             <h2>Please close BE Home for Desktop and try again.</h2>
-            <p className="panel-description">{errorMessage}</p>
+            <p className="panel-description">{windowError}</p>
           </section>
         </section>
       </main>
     );
   }
 
-  if (setupGateState === null) {
+  if (setupGateState === null || toolState === null || desktopSettings === null) {
     return (
       <main className="page-shell desktop-shell desktop-utility-window">
         <section className="page-grid narrow">
           <section className="panel desktop-state-card" aria-live="polite">
             <div className="eyebrow">Setup Wizard</div>
-            <h2>Just a moment while we check your setup.</h2>
+            <h2>Getting setup ready</h2>
             <p className="panel-description">
-              We're checking whether Board's install tool is ready and whether your desktop
-              workspace can open.
+              BE Home is checking your Board Install Tool, game folders, and saved library
+              location.
             </p>
           </section>
         </section>
@@ -204,242 +448,327 @@ export default function SetupWizardApp() {
 
   return (
     <main className="page-shell desktop-shell desktop-utility-window">
-      <section className="page-grid desktop-grid">
-        <section className="hero-panel desktop-banner">
-          <div className="hero-copy desktop-banner-copy">
-            <div className="eyebrow">Setup Wizard</div>
-            <h1>Get your install workspace ready</h1>
-            <p>{setupGateState.summary}</p>
-            <p className="desktop-platform-note">
-              {setupGateState.platformLabel} desktop · v{setupGateState.version}
-            </p>
-          </div>
-          <div className="desktop-highlight-row" aria-label="Setup summary">
-            <StatusChip label="Setup" value={statusLabel(setupGateState.status)} />
-            <StatusChip
-              label="Board tool"
-              value={statusLabel(setupGateState.toolState.status)}
-            />
-            <StatusChip
-              label="Managed tool folder"
-              value={locationSourceLabel(setupGateState.toolState.storage)}
-            />
-          </div>
-        </section>
+      <section className="page-grid narrow desktop-utility-grid">
+        <section className="panel desktop-utility-card">
+          <header className="desktop-utility-header">
+            <div className="desktop-utility-heading">
+              <div className="eyebrow">Setup Wizard</div>
+              <h1>Set up BE Home for Desktop</h1>
+              <p className="panel-description">
+                BE Home for Desktop helps you find games and apps on this computer, keep a saved
+                library close by, and install them on Board without command-line steps.
+              </p>
+            </div>
+            <ol className="desktop-wizard-step-row" aria-label="Setup steps">
+              {wizardSteps.map((step, index) => {
+                const state =
+                  currentStepId === step.id
+                    ? "current"
+                    : index < currentStepIndex
+                      ? "complete"
+                      : "upcoming";
 
-        <section className="desktop-setup-layout">
-          <aside className="panel desktop-stepper" aria-label="Setup steps">
-            <div className="eyebrow">Required setup</div>
-            <h2>Stay inside setup until Board's tool is ready.</h2>
-            <ol className="desktop-step-list">
-              <SetupStepCard
-                stepNumber={1}
-                title="Check this computer"
-                summary="Confirm that this computer matches Board's current download support."
-                status={describeSetupStepStatus(setupViewStep, "systemCheck")}
-              />
-              <SetupStepCard
-                stepNumber={2}
-                title="Get Board's install tool ready"
-                summary="Download or repair bdb so BE Home can use it without terminal steps."
-                status={describeSetupStepStatus(setupViewStep, "toolSetup")}
-              />
-              <SetupStepCard
-                stepNumber={3}
-                title="Review your local defaults"
-                summary="See where BE Home starts with scan folders and managed storage before the workspace opens."
-                status={describeSetupStepStatus(setupViewStep, "reviewDefaults")}
-              />
+                return (
+                  <li className={`desktop-wizard-step desktop-wizard-step--${state}`} key={step.id}>
+                    <span className="desktop-wizard-step-number">{index + 1}</span>
+                    <span>{step.label}</span>
+                  </li>
+                );
+              })}
             </ol>
-          </aside>
+          </header>
 
-          <section className="panel desktop-setup-panel" aria-live="polite">
-            {setupViewStep === "systemCheck" ? (
-              <>
-                <div className="eyebrow">Step 1</div>
-                <h2>Check this computer before downloading anything.</h2>
-                <p className="panel-description">{setupGateState.guidance}</p>
-                <dl className="desktop-detail-grid">
-                  <DetailRow label="Support status" value={statusLabel(setupGateState.status)} />
-                  <DetailRow
-                    label="Operating system"
-                    value={setupGateState.toolState.sourcePlan.support.operatingSystem}
-                  />
-                  <DetailRow
-                    label="Architecture"
-                    value={setupGateState.toolState.sourcePlan.support.architecture}
-                  />
-                  <DetailRow
-                    label="Windows build"
-                    value={
-                      setupGateState.toolState.sourcePlan.support.windowsBuild === null
-                        ? "Not needed on this platform"
-                        : String(setupGateState.toolState.sourcePlan.support.windowsBuild)
-                    }
-                  />
-                </dl>
-
-                <StatusSummaryCard
-                  title="What BE Home found"
-                  summary={setupGateState.toolState.summary}
-                  guidance={setupGateState.toolState.guidance}
-                />
-
-                <div className="desktop-action-row">
-                  <button
-                    className="primary-button"
-                    disabled={setupGateState.status === "unsupported"}
-                    onClick={() => setSetupViewStep("toolSetup")}
-                    type="button"
-                  >
-                    Continue to bdb setup
-                  </button>
-                  <button
-                    className="secondary-button"
-                    onClick={() => void refreshSetupGateState()}
-                    type="button"
-                  >
-                    Refresh checks
-                  </button>
-                  <button
-                    className="tertiary-button"
-                    onClick={() => void handleCancelSetup()}
-                    type="button"
-                  >
-                    Cancel
-                  </button>
-                </div>
-              </>
+          <section className="desktop-utility-body" aria-live="polite">
+            {currentStepId === "welcome" ? (
+              <section className="desktop-wizard-page">
+                <div className="eyebrow">Welcome</div>
+                <h2>Here’s what setup will help you do.</h2>
+                <p className="panel-description">
+                  This quick setup will download the Board Install Tool, choose where BE Home looks
+                  for games and apps, and choose where saved copies should live on this computer.
+                </p>
+                <ul className="desktop-wizard-checklist">
+                  <li>Get the Board Install Tool ready so BE Home can talk to your Board.</li>
+                  <li>Choose the folders BE Home should check for game and app files.</li>
+                  <li>Choose where saved copies should be kept for later installs.</li>
+                </ul>
+              </section>
             ) : null}
 
-            {setupViewStep === "toolSetup" ? (
-              <>
-                <div className="eyebrow">Step 2</div>
-                <h2>Get Board's install tool ready.</h2>
-                <p className="panel-description">{setupGateState.toolState.guidance}</p>
-                <dl className="desktop-detail-grid">
-                  <DetailRow
-                    label="Managed tool folder"
-                    value={setupGateState.toolState.storage.effectivePath}
-                  />
-                  <DetailRow
-                    label="Executable path"
-                    value={setupGateState.toolState.executablePath}
-                  />
-                  <DetailRow
-                    label="Runnable check"
-                    value={statusLabel(setupGateState.toolState.validation.status)}
-                  />
-                </dl>
+            {currentStepId === "boardTool" ? (
+              <section className="desktop-wizard-page">
+                <div className="eyebrow">Board Install Tool</div>
+                <h2>Get the Board Install Tool ready.</h2>
+                <p className="panel-description">
+                  BE Home needs Board’s install helper so it can install games and apps on your
+                  Board for you.
+                </p>
 
-                <StatusSummaryCard
-                  title="Current tool state"
-                  summary={setupGateState.toolState.summary}
-                  guidance={setupGateState.toolState.validation.summary}
-                />
+                <div className="desktop-form-grid">
+                  <label className="desktop-field">
+                    <span className="desktop-field-label">Install location</span>
+                    <div className="desktop-readonly-field">{toolState.executablePath}</div>
+                  </label>
+                  <label className="desktop-field">
+                    <span className="desktop-field-label">Current version</span>
+                    <div className="desktop-readonly-field">
+                      {toolState.versionCheck.value ?? "Not installed yet"}
+                    </div>
+                  </label>
+                  <label className="desktop-field">
+                    <span className="desktop-field-label">Latest version in BE Home</span>
+                    <div className="desktop-readonly-field">
+                      {toolState.updateStatus.availableVersion ?? "Not available yet"}
+                    </div>
+                  </label>
+                </div>
 
-                {toolActionState.message !== null ? (
-                  <article
-                    className={
-                      toolActionState.lastOutcome === "failed"
-                        ? "desktop-inline-message desktop-inline-message--warning"
-                        : "desktop-inline-message"
-                    }
-                  >
-                    <h3>{toolActionState.message}</h3>
-                    {toolActionState.detail !== null ? <p>{toolActionState.detail}</p> : null}
+                <article className="desktop-inline-card">
+                  <h3>{toolState.summary}</h3>
+                  <p>{toolState.guidance}</p>
+                </article>
+
+                {toolState.supportRequestDraft !== null ? (
+                  <article className="desktop-inline-message desktop-inline-message--warning">
+                    <h3>This version of the Board Install Tool is not compatible with this computer.</h3>
+                    <p>
+                      You can ask Board for support and include the exact message BE Home received
+                      from the tool.
+                    </p>
+                    <div className="desktop-inline-button-row">
+                      <button
+                        className="secondary-button"
+                        onClick={() => setSupportDialogDraft(toolState.supportRequestDraft)}
+                        type="button"
+                      >
+                        Email Board Support...
+                      </button>
+                    </div>
                   </article>
                 ) : null}
 
-                <div className="desktop-action-row">
+                <div className="desktop-inline-button-row">
                   <button
                     className="primary-button"
-                    disabled={toolActionState.loading}
-                    onClick={() =>
-                      void handleAcquireBdbTool(setupGateState.toolState.executableExists)
-                    }
+                    disabled={busy}
+                    onClick={() => void handleDownloadOrRepair()}
                     type="button"
                   >
-                    {toolActionState.loading
-                      ? "Working..."
-                      : setupGateState.toolState.executableExists
-                        ? "Repair bdb"
-                        : "Download bdb"}
+                    {busy ? "Working..." : updateActionLabel(toolState)}
                   </button>
                   <button
                     className="secondary-button"
-                    disabled={toolActionState.loading}
-                    onClick={() => void refreshSetupGateState()}
+                    disabled={busy}
+                    onClick={() => void handleCheckForUpdate()}
                     type="button"
                   >
-                    Refresh checks
-                  </button>
-                  <button
-                    className="tertiary-button"
-                    disabled={toolActionState.loading}
-                    onClick={() => setSetupViewStep("systemCheck")}
-                    type="button"
-                  >
-                    Back
-                  </button>
-                  <button
-                    className="tertiary-button"
-                    disabled={toolActionState.loading}
-                    onClick={() => void handleCancelSetup()}
-                    type="button"
-                  >
-                    Cancel
+                    Check for Update
                   </button>
                 </div>
-              </>
+
+                <p className="desktop-footnote">
+                  Board’s formal name for this helper is <strong>Board Developer Bridge (bdb)</strong>.
+                </p>
+              </section>
             ) : null}
 
-            {setupViewStep === "reviewDefaults" ? (
-              <>
-                <div className="eyebrow">Step 3</div>
-                <h2>Review the local defaults BE Home will start with.</h2>
+            {currentStepId === "scanFolders" ? (
+              <section className="desktop-wizard-page">
+                <div className="eyebrow">Look for Games &amp; Apps</div>
+                <h2>Choose the folders BE Home should check.</h2>
                 <p className="panel-description">
-                  You can change these locations later, but this is the familiar starting point
-                  BE Home will use today.
+                  BE Home can look in these folders when you rescan this computer for games and
+                  apps. You can leave the list empty if you prefer to choose files manually.
                 </p>
-                <dl className="desktop-detail-grid">
-                  <DetailRow
-                    label="Managed bdb folder"
-                    value={setupGateState.storage.bdbTools.effectivePath}
-                  />
-                  <DetailRow
-                    label="Managed APK library"
-                    value={setupGateState.storage.apkLibrary.effectivePath}
-                  />
-                  <DetailRow
-                    label="Default scan folder"
-                    value={formatScanFolders(setupGateState.defaultScanFolders)}
-                  />
-                </dl>
-                <div className="desktop-action-row">
-                  <button className="primary-button" onClick={() => void handleOpenWorkspace()} type="button">
-                    Open workspace
-                  </button>
+
+                <section className="desktop-list-editor">
+                  <div className="desktop-list-editor-header">
+                    <span className="desktop-field-label">Folders to check</span>
+                    {iconButtonLabel("add", "Add folder", () => void handleAddScanFolder(), busy)}
+                  </div>
+
+                  {scanFolderDraft.length === 0 ? (
+                    <div className="desktop-empty-note">
+                      BE Home will wait for you to choose a game or app manually.
+                    </div>
+                  ) : (
+                    <ul className="desktop-folder-list desktop-folder-list--compact">
+                      {scanFolderDraft.map((path) => (
+                        <li className="desktop-folder-item" key={path}>
+                          <div className="desktop-folder-copy">
+                            <p className="desktop-folder-path">{path}</p>
+                          </div>
+                          {iconButtonLabel(
+                            "remove",
+                            `Remove ${path}`,
+                            () => handleRemoveScanFolder(path),
+                            busy,
+                          )}
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </section>
+              </section>
+            ) : null}
+
+            {currentStepId === "libraryLocation" ? (
+              <section className="desktop-wizard-page">
+                <div className="eyebrow">Library Location</div>
+                <h2>Choose where saved copies should live.</h2>
+                <p className="panel-description">
+                  BE Home can keep reusable copies of your games and apps in one saved library so
+                  they’re easier to install again later.
+                </p>
+
+                <label className="desktop-field">
+                  <span className="desktop-field-label">Saved library folder</span>
+                  <div className="desktop-input-with-button">
+                    <input
+                      className="desktop-text-field"
+                      onChange={(event) => setLibraryPathDraft(event.target.value)}
+                      spellCheck={false}
+                      type="text"
+                      value={libraryPathDraft}
+                    />
+                    {iconButtonLabel(
+                      "folder_open",
+                      "Choose library folder",
+                      () => void handleBrowseLibraryLocation(),
+                      busy,
+                    )}
+                  </div>
+                </label>
+
+                <div className="desktop-recommended-row">
+                  <span className="desktop-recommended-badge">
+                    {normalizeLibraryOverride(desktopSettings.apkLibrary.defaultPath, libraryPathDraft) === null
+                      ? "Recommended"
+                      : "Custom"}
+                  </span>
                   <button
-                    className="tertiary-button"
-                    onClick={() => setSetupViewStep("toolSetup")}
+                    className="tertiary-button desktop-link-button"
+                    disabled={busy}
+                    onClick={handleUseRecommendedLibraryLocation}
                     type="button"
                   >
-                    Back
-                  </button>
-                  <button
-                    className="tertiary-button"
-                    onClick={() => void handleCancelSetup()}
-                    type="button"
-                  >
-                    Cancel
+                    Use recommended location
                   </button>
                 </div>
-              </>
+              </section>
+            ) : null}
+
+            {currentStepId === "ready" ? (
+              <section className="desktop-wizard-page">
+                <div className="eyebrow">Ready to Go</div>
+                <h2>Your setup choices are ready.</h2>
+                <p className="panel-description">
+                  You can finish now and open BE Home, or go back if you want to change anything.
+                </p>
+                <div className="desktop-summary-grid">
+                  {readySummaryRows.map((row) => (
+                    <div className="desktop-detail-row" key={row.label}>
+                      <dt>{row.label}</dt>
+                      <dd className="desktop-detail-value-block">{row.value}</dd>
+                    </div>
+                  ))}
+                </div>
+              </section>
+            ) : null}
+
+            {inlineNotice !== null ? (
+              <article
+                className={
+                  inlineNotice.tone === "warning"
+                    ? "desktop-inline-message desktop-inline-message--warning"
+                    : inlineNotice.tone === "success"
+                      ? "desktop-inline-message desktop-inline-message--success"
+                      : "desktop-inline-message"
+                }
+              >
+                <h3>{inlineNotice.title}</h3>
+                {inlineNotice.detail !== null ? <p>{inlineNotice.detail}</p> : null}
+              </article>
             ) : null}
           </section>
+
+          <footer className="desktop-utility-footer">
+            <button
+              className="tertiary-button"
+              disabled={busy}
+              onClick={() => void handleCancelSetup()}
+              type="button"
+            >
+              Cancel
+            </button>
+            <div className="desktop-utility-footer-actions">
+              {currentStepId !== "welcome" ? (
+                <button className="secondary-button" disabled={busy} onClick={handleBack} type="button">
+                  Back
+                </button>
+              ) : null}
+              <button
+                className="primary-button"
+                disabled={busy}
+                onClick={() => void handleNext()}
+                type="button"
+              >
+                {currentStepId === "ready" ? "Finish" : "Next"}
+              </button>
+            </div>
+          </footer>
         </section>
       </section>
+
+      {supportDialogDraft !== null ? (
+        <section className="desktop-modal-scrim" role="presentation">
+          <article
+            aria-labelledby="support-request-title"
+            className="panel desktop-modal-card"
+            role="dialog"
+          >
+            <div className="eyebrow">Board Support</div>
+            <h2 id="support-request-title">Email Board Support</h2>
+            <p className="panel-description">
+              BE Home can open a draft in your mail app with the details below.
+            </p>
+            <div className="desktop-form-grid">
+              <label className="desktop-field">
+                <span className="desktop-field-label">To</span>
+                <div className="desktop-readonly-field">{supportDialogDraft.to}</div>
+              </label>
+              <label className="desktop-field">
+                <span className="desktop-field-label">Subject</span>
+                <div className="desktop-readonly-field">{supportDialogDraft.subject}</div>
+              </label>
+              <label className="desktop-field">
+                <span className="desktop-field-label">Email draft</span>
+                <textarea
+                  className="desktop-text-area"
+                  readOnly
+                  value={supportDialogDraft.body}
+                />
+              </label>
+            </div>
+            <p className="desktop-footnote">{supportInstructionText()}</p>
+            <div className="desktop-inline-button-row">
+              <button className="primary-button" onClick={() => void handleOpenSupportEmail()} type="button">
+                Open Mail App
+              </button>
+              <button className="secondary-button" onClick={() => void handleCopySupportDraft()} type="button">
+                Copy Email Draft
+              </button>
+              <button
+                className="tertiary-button"
+                onClick={() => setSupportDialogDraft(null)}
+                type="button"
+              >
+                Close
+              </button>
+            </div>
+          </article>
+        </section>
+      ) : null}
     </main>
   );
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,9 +1,9 @@
-@import url("https://fonts.googleapis.com/css2?family=Public+Sans:wght@400;500;600;700;800&family=Syne:wght@700;800&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Public+Sans:wght@400;500;600;700;800&family=Syne:wght@700;800&family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0&display=swap");
 @import "tailwindcss";
 
 @theme {
   --font-body: "Public Sans", "Segoe UI", sans-serif;
-  --font-display: "Syne", "Trebuchet MS", sans-serif;
+  --font-display: "Syne", "Segoe UI", sans-serif;
 }
 
 @layer base {
@@ -11,10 +11,51 @@
     box-sizing: border-box;
   }
 
+  :root {
+    --desktop-accent: #4be09a;
+    --desktop-accent-strong: #3bb781;
+    --desktop-warning: #f4bb59;
+    --desktop-danger: #f06969;
+    --desktop-neutral: #7ea0ff;
+    --desktop-radius-lg: 1.4rem;
+    --desktop-radius-md: 1rem;
+    --desktop-radius-sm: 0.8rem;
+  }
+
+  html[data-theme="dark"] {
+    --desktop-bg: #151319;
+    --desktop-bg-alt: #1d1a22;
+    --desktop-surface: rgba(27, 24, 33, 0.92);
+    --desktop-surface-strong: rgba(20, 18, 25, 0.95);
+    --desktop-surface-muted: rgba(255, 255, 255, 0.03);
+    --desktop-border: rgba(118, 255, 170, 0.18);
+    --desktop-border-strong: rgba(118, 255, 170, 0.34);
+    --desktop-text: #f7f2e8;
+    --desktop-text-muted: rgba(223, 229, 240, 0.82);
+    --desktop-text-soft: rgba(223, 229, 240, 0.68);
+    --desktop-shadow: 0 24px 60px rgba(0, 0, 0, 0.34);
+    color-scheme: dark;
+  }
+
+  html[data-theme="light"] {
+    --desktop-bg: #eef4f6;
+    --desktop-bg-alt: #f7fbfc;
+    --desktop-surface: rgba(255, 255, 255, 0.95);
+    --desktop-surface-strong: rgba(255, 255, 255, 0.98);
+    --desktop-surface-muted: rgba(12, 31, 32, 0.04);
+    --desktop-border: rgba(36, 104, 83, 0.18);
+    --desktop-border-strong: rgba(36, 104, 83, 0.28);
+    --desktop-text: #142125;
+    --desktop-text-muted: rgba(20, 33, 37, 0.82);
+    --desktop-text-soft: rgba(20, 33, 37, 0.62);
+    --desktop-shadow: 0 20px 42px rgba(15, 39, 49, 0.12);
+    color-scheme: light;
+  }
+
   html {
     font-family: var(--font-body);
-    color: #f7f2e8;
-    background-color: #17151a;
+    color: var(--desktop-text);
+    background-color: var(--desktop-bg);
     overflow-x: clip;
   }
 
@@ -22,17 +63,26 @@
     min-height: 100vh;
     margin: 0;
     background:
-      radial-gradient(circle at top left, rgba(243, 154, 46, 0.18), transparent 28%),
-      radial-gradient(circle at top right, rgba(77, 117, 244, 0.18), transparent 24%),
-      radial-gradient(circle at 50% 0%, rgba(255, 251, 240, 0.08), transparent 38%),
-      linear-gradient(180deg, #17151a 0%, #1d1a20 50%, #151318 100%);
-    color: #f7f2e8;
+      radial-gradient(circle at top left, rgba(243, 154, 46, 0.18), transparent 24%),
+      radial-gradient(circle at top right, rgba(77, 117, 244, 0.18), transparent 20%),
+      linear-gradient(180deg, var(--desktop-bg) 0%, var(--desktop-bg-alt) 100%);
+    color: var(--desktop-text);
     overflow-x: clip;
   }
 
   #root {
     min-height: 100vh;
     overflow-x: clip;
+  }
+
+  button,
+  input,
+  textarea {
+    font: inherit;
+  }
+
+  textarea {
+    resize: vertical;
   }
 }
 
@@ -48,87 +98,85 @@
 
   .page-grid.narrow {
     width: 100%;
-    max-width: 48rem;
+    max-width: 64rem;
     margin: 0 auto;
   }
 
   .panel,
   .hero-panel {
-    padding: 1.5rem;
-    border: 1px solid rgba(118, 255, 170, 0.38);
-    border-radius: 1.75rem;
+    border: 1px solid var(--desktop-border);
+    border-radius: 1.5rem;
     background:
-      radial-gradient(circle at 16% 0%, rgba(96, 255, 164, 0.1), transparent 24%),
-      radial-gradient(circle at 100% 14%, rgba(77, 117, 244, 0.12), transparent 22%),
-      linear-gradient(180deg, rgba(37, 34, 41, 0.97), rgba(26, 24, 31, 0.97));
-    box-shadow:
-      inset 0 1px 0 rgba(235, 255, 244, 0.04),
-      0 0 0 1px rgba(118, 255, 170, 0.08),
-      0 0 18px rgba(118, 255, 170, 0.16),
-      0 0 42px rgba(118, 255, 170, 0.08),
-      0 18px 52px rgba(8, 8, 12, 0.34),
-      0 0 22px rgba(64, 198, 141, 0.12);
+      radial-gradient(circle at 0% 0%, rgba(75, 224, 154, 0.08), transparent 26%),
+      radial-gradient(circle at 100% 0%, rgba(126, 160, 255, 0.08), transparent 20%),
+      var(--desktop-surface);
+    box-shadow: var(--desktop-shadow);
     backdrop-filter: blur(18px);
   }
 
-  .hero-copy {
-    position: relative;
-    z-index: 1;
-    max-width: 48rem;
+  .panel {
+    padding: 1.5rem;
+  }
+
+  .hero-panel {
+    padding: 1.75rem;
   }
 
   .eyebrow {
     font-size: 0.75rem;
-    font-weight: 600;
-    letter-spacing: 0.24em;
+    font-weight: 700;
+    letter-spacing: 0.2em;
     text-transform: uppercase;
-    color: rgba(220, 247, 234, 0.75);
+    color: var(--desktop-text-soft);
   }
 
   .panel h2,
-  .hero-panel h1 {
-    margin: 0.75rem 0 0;
+  .hero-panel h1,
+  .panel h1 {
+    margin: 0.6rem 0 0;
     font-family: var(--font-display);
-    color: #ffffff;
+    color: var(--desktop-text);
+  }
+
+  .panel h1 {
+    font-size: clamp(1.8rem, 2.6vw, 2.4rem);
+    line-height: 1.08;
   }
 
   .panel h2 {
-    font-size: clamp(1.75rem, 2vw, 2rem);
-    font-weight: 700;
+    font-size: clamp(1.4rem, 2vw, 1.9rem);
+    line-height: 1.14;
   }
 
   .hero-panel h1 {
-    font-size: clamp(2.5rem, 4vw, 3.5rem);
-    font-weight: 800;
-    letter-spacing: 0.03em;
-    line-height: 0.96;
+    font-size: clamp(2.3rem, 3.4vw, 3.1rem);
+    line-height: 1;
     text-transform: uppercase;
   }
 
-  .hero-panel.compact h1 {
-    font-size: clamp(2.2rem, 3.6vw, 3rem);
-  }
-
-  .hero-panel p,
-  .panel-description {
+  .panel-description,
+  .hero-panel p {
     margin: 0.75rem 0 0;
-    font-size: 1rem;
-    line-height: 1.9;
-    color: rgb(203 213 225 / 1);
+    color: var(--desktop-text-muted);
+    line-height: 1.7;
   }
 
-  .status-chip {
-    display: inline-flex;
-    align-items: center;
+  .material-symbols-outlined {
+    font-family: "Material Symbols Outlined";
+    font-weight: normal;
+    font-style: normal;
+    font-size: 1.1rem;
+    line-height: 1;
+    display: inline-block;
+    text-transform: none;
+    letter-spacing: normal;
+    word-wrap: normal;
     white-space: nowrap;
-    border-radius: 999px;
-    border: 1px solid rgba(118, 255, 170, 0.2);
-    background: rgba(64, 198, 141, 0.1);
-    padding: 0.25rem 0.75rem;
-    font-size: 0.75rem;
-    font-weight: 600;
-    letter-spacing: 0.16em;
-    text-transform: uppercase;
-    color: rgb(220 247 234 / 1);
+    direction: ltr;
+    font-variation-settings:
+      "FILL" 0,
+      "wght" 400,
+      "GRAD" 0,
+      "opsz" 24;
   }
 }


### PR DESCRIPTION
## Summary
- replace the embedded setup page with a dedicated setup wizard window and shared cancel/finish flow
- move settings into a native utility window with tabs for locations, Board connection, and the Board Install Tool
- add Board Install Tool version/update/support-request handling plus schema-v2 source metadata and persisted Board poll cadence

## Validation
- npm run build
- npm run test
- python ./scripts/dev.py desktop clean --app-state-only
- bounded python ./scripts/dev.py desktop --local-only smoke

## Notes
- stacked on top of #63
- keeps schema-v1 `bdb` manifest compatibility during the schema-v2 transition