### PR TITLE
Polish the desktop workspace shell (#62)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -287,6 +287,39 @@
   font-weight: 700;
 }
 
+.desktop-help-chip-wrap {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+.desktop-help-tooltip {
+  position: absolute;
+  top: calc(100% + 0.55rem);
+  left: 50%;
+  z-index: 5;
+  width: min(18rem, 72vw);
+  padding: 0.7rem 0.8rem;
+  border-radius: var(--desktop-radius-md);
+  border: 1px solid var(--desktop-border-strong);
+  background: var(--desktop-surface);
+  color: var(--desktop-text);
+  box-shadow: var(--desktop-shadow-md);
+  line-height: 1.45;
+  opacity: 0;
+  pointer-events: none;
+  transform: translate(-50%, -0.25rem);
+  transition:
+    opacity 140ms ease,
+    transform 140ms ease;
+}
+
+.desktop-help-chip-wrap:hover .desktop-help-tooltip,
+.desktop-help-chip-wrap:focus-within .desktop-help-tooltip {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
 .desktop-icon-button:hover,
 .desktop-help-chip:hover,
 .primary-button:hover,

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -344,7 +344,11 @@ describe("App", () => {
     expect(await screen.findByText("Keep your Board installs close by.")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Games & Apps/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Installed on Board/i })).toBeInTheDocument();
-    expect(screen.getByLabelText("What this Board status means")).toBeInTheDocument();
+    expect(screen.getByLabelText("What this Board status means")).toHaveAttribute(
+      "aria-describedby",
+      "board-status-help-tooltip",
+    );
+    expect(screen.getByText("BE Home is checking for your Board now.")).toBeInTheDocument();
   });
 
   it("routes the setup wizard window", async () => {
@@ -357,6 +361,9 @@ describe("App", () => {
     render(<App />);
 
     expect(await screen.findByText("Set up BE Home for Desktop")).toBeInTheDocument();
+    expect(
+      screen.getByText(/helps you choose games and apps on this computer/i),
+    ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Next" })).toBeInTheDocument();
   });
 

--- a/src/desktop/presentation.ts
+++ b/src/desktop/presentation.ts
@@ -1,0 +1,22 @@
+/**
+ * Formats a Board Install Tool version line into a concise player-facing value when possible.
+ *
+ * @param value Raw version text reported by the desktop host.
+ * @param fallback Fallback text to use when no version text is available.
+ * @returns A shorter display value suitable for UI chips and readonly fields.
+ */
+export function formatBoardInstallToolVersion(
+  value: string | null | undefined,
+  fallback = "Unavailable",
+): string {
+  if (value === null || value === undefined) {
+    return fallback;
+  }
+
+  const trimmedValue = value.trim();
+  if (trimmedValue.length === 0) {
+    return fallback;
+  }
+
+  return trimmedValue.replace(/^Board OS Version:\s*/i, "").trim();
+}

--- a/src/main-window/MainWorkspaceApp.tsx
+++ b/src/main-window/MainWorkspaceApp.tsx
@@ -29,6 +29,7 @@ import type {
   SetupGateState,
   UninstallInstalledTitleResult,
 } from "../desktop/types";
+import { formatBoardInstallToolVersion } from "../desktop/presentation";
 import {
   MAIN_WORKSPACE_NAVIGATE_EVENT,
   MAIN_WORKSPACE_RESCAN_EVENT,
@@ -698,10 +699,9 @@ export default function MainWorkspaceApp() {
   }
 
   const boardStatus = buildBoardStatusPresentation(deviceState.snapshot, setupGateState, deviceState);
-  const bdbVersionValue =
-    deviceState.snapshot?.bdbVersion.value ??
-    setupGateState?.toolState.versionCheck.value ??
-    "Unavailable";
+  const bdbVersionValue = formatBoardInstallToolVersion(
+    deviceState.snapshot?.bdbVersion.value ?? setupGateState?.toolState.versionCheck.value,
+  );
   const boardOsVersionValue = deviceState.snapshot?.boardOsVersion ?? "Unavailable";
 
   if (windowError !== null) {
@@ -772,14 +772,19 @@ export default function MainWorkspaceApp() {
             <span className={`desktop-status-chip desktop-status-chip--${boardStatus.tone}`}>
               {boardStatus.label}
             </span>
-            <button
-              aria-label="What this Board status means"
-              className="desktop-help-chip"
-              title={boardStatus.tooltip}
-              type="button"
-            >
-              ?
-            </button>
+            <div className="desktop-help-chip-wrap">
+              <button
+                aria-describedby="board-status-help-tooltip"
+                aria-label="What this Board status means"
+                className="desktop-help-chip"
+                type="button"
+              >
+                ?
+              </button>
+              <span className="desktop-help-tooltip" id="board-status-help-tooltip" role="tooltip">
+                {boardStatus.tooltip}
+              </span>
+            </div>
             <StatusValueChip label="bdb" value={bdbVersionValue} />
             <StatusValueChip label="Board OS" value={boardOsVersionValue} />
           </section>

--- a/src/settings-window/SettingsWindowApp.tsx
+++ b/src/settings-window/SettingsWindowApp.tsx
@@ -16,6 +16,7 @@ import type {
   DesktopSettingsInput,
   SupportRequestDraft,
 } from "../desktop/types";
+import { formatBoardInstallToolVersion } from "../desktop/presentation";
 
 type SettingsTabId = "locations" | "boardConnection" | "boardTool";
 
@@ -572,13 +573,16 @@ export default function SettingsWindowApp() {
                   <label className="desktop-field">
                     <span className="desktop-field-label">Current version</span>
                     <div className="desktop-readonly-field">
-                      {toolState.versionCheck.value ?? "Not installed yet"}
+                      {formatBoardInstallToolVersion(toolState.versionCheck.value, "Not installed yet")}
                     </div>
                   </label>
                   <label className="desktop-field">
                     <span className="desktop-field-label">Latest version in BE Home</span>
                     <div className="desktop-readonly-field">
-                      {toolState.updateStatus.availableVersion ?? "Not available yet"}
+                      {formatBoardInstallToolVersion(
+                        toolState.updateStatus.availableVersion,
+                        "Not available yet",
+                      )}
                     </div>
                   </label>
                   <label className="desktop-field">

--- a/src/setup-window/SetupWizardApp.tsx
+++ b/src/setup-window/SetupWizardApp.tsx
@@ -20,6 +20,7 @@ import type {
   SetupGateState,
   SupportRequestDraft,
 } from "../desktop/types";
+import { formatBoardInstallToolVersion } from "../desktop/presentation";
 
 type WizardStepId = "welcome" | "boardTool" | "scanFolders" | "libraryLocation" | "ready";
 
@@ -141,9 +142,10 @@ export default function SetupWizardApp() {
       [
         {
           label: "Board Install Tool",
-          value:
-            toolState?.versionCheck.value ??
-            (toolState?.status === "runnable" ? "Installed" : "Still needs to be downloaded"),
+          value: formatBoardInstallToolVersion(
+            toolState?.versionCheck.value,
+            toolState?.status === "runnable" ? "Installed" : "Still needs to be downloaded",
+          ),
         },
         {
           label: "Games and apps folders",
@@ -484,6 +486,10 @@ export default function SetupWizardApp() {
                 <div className="eyebrow">Welcome</div>
                 <h2>Here’s what setup will help you do.</h2>
                 <p className="panel-description">
+                  BE Home for Desktop helps you choose games and apps on this computer and install
+                  them on your Board without working through terminal steps by hand.
+                </p>
+                <p className="panel-description">
                   This quick setup will download the Board Install Tool, choose where BE Home looks
                   for games and apps, and choose where saved copies should live on this computer.
                 </p>
@@ -512,13 +518,16 @@ export default function SetupWizardApp() {
                   <label className="desktop-field">
                     <span className="desktop-field-label">Current version</span>
                     <div className="desktop-readonly-field">
-                      {toolState.versionCheck.value ?? "Not installed yet"}
+                      {formatBoardInstallToolVersion(toolState.versionCheck.value, "Not installed yet")}
                     </div>
                   </label>
                   <label className="desktop-field">
                     <span className="desktop-field-label">Latest version in BE Home</span>
                     <div className="desktop-readonly-field">
-                      {toolState.updateStatus.availableVersion ?? "Not available yet"}
+                      {formatBoardInstallToolVersion(
+                        toolState.updateStatus.availableVersion,
+                        "Not available yet",
+                      )}
                     </div>
                   </label>
                 </div>


### PR DESCRIPTION
## Summary
- tighten the setup welcome copy so it explains what BE Home for Desktop is for before it explains the setup steps
- format Board Install Tool versions into shorter player-facing values across the wizard, settings, and workspace status strip
- replace the raw title hover on the Board status help chip with a styled tooltip that works with hover and focus

## Validation
- npm run build
- npm run test
- bounded python ./scripts/dev.py desktop --local-only smoke

## Notes
- stacked on top of #64