### PR TITLE
Close out Tauri desktop shell polish

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -8,6 +8,11 @@
     "dialog:default",
     "core:event:default",
     "core:window:default",
+    "core:window:allow-close",
+    "core:window:allow-destroy",
+    "core:window:allow-minimize",
+    "core:window:allow-toggle-maximize",
+    "core:window:allow-start-dragging",
     "opener:default"
   ]
 }

--- a/src-tauri/src/actions.rs
+++ b/src-tauri/src/actions.rs
@@ -1,12 +1,13 @@
-use crate::{apk, bdb_tool, device};
+use crate::{apk, bdb_tool, device, process_runner};
 use serde::Serialize;
-use std::io;
 use std::path::Path;
-use std::process::Command;
+use std::time::Duration;
 
 const BDB_INSTALL_ARGUMENT: &str = "install";
 const BDB_LAUNCH_ARGUMENT: &str = "launch";
 const BDB_REMOVE_ARGUMENT: &str = "remove";
+const BDB_INSTALL_TIMEOUT_SECONDS: u64 = 300;
+const BDB_ACTION_TIMEOUT_SECONDS: u64 = 30;
 
 /// Describes whether an install attempt completed successfully.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
@@ -127,15 +128,14 @@ impl ProcessRunner for CommandProcessRunner {
         executable_path: &Path,
         args: &[&str],
     ) -> Result<ProcessRunOutput, ProcessRunFailure> {
-        let output = Command::new(executable_path)
-            .args(args)
-            .output()
-            .map_err(classify_process_failure)?;
+        let output =
+            process_runner::run_with_timeout(executable_path, args, timeout_for_args(args))
+                .map_err(map_process_failure)?;
 
         Ok(ProcessRunOutput {
-            exit_code: output.status.code(),
-            stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
-            stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+            exit_code: output.exit_code,
+            stdout: output.stdout,
+            stderr: output.stderr,
         })
     }
 }
@@ -161,10 +161,7 @@ pub(crate) fn uninstall_installed_title_from_board(
     input: UninstallInstalledTitleInput,
 ) -> Result<UninstallInstalledTitleResult, String> {
     let package_name = normalize_package_name(&input.package_name)?;
-    let display_name = normalize_display_name(
-        input.display_name.as_deref(),
-        &package_name,
-    );
+    let display_name = normalize_display_name(input.display_name.as_deref(), &package_name);
     let tool_state = bdb_tool::load_current_bdb_tool_state()?;
     let device_status = device::load_current_device_status_snapshot()?;
 
@@ -260,8 +257,7 @@ fn install_apk_with_runner<P: ProcessRunner>(
             ProcessRunFailureKind::Other => InstallApkResult {
                 status: InstallApkStatus::Failed,
                 summary: format!("BE Home couldn't finish installing {file_name} on Board yet."),
-                guidance:
-                    "Keep Board connected, then try the install again in a moment.".into(),
+                guidance: "Keep Board connected, then try the install again in a moment.".into(),
                 detail: Some("The install command could not finish cleanly.".into()),
                 command,
                 exit_code: None,
@@ -299,12 +295,18 @@ fn normalize_install_output(
                 .into(),
             Some("Board reported that the app is already present.".into()),
         )
-    } else if contains_any(&normalized_output, &["not enough space", "insufficient storage", "no space"]) {
+    } else if contains_any(
+        &normalized_output,
+        &["not enough space", "insufficient storage", "no space"],
+    ) {
         (
             "Board says it does not have enough storage space for this install right now.".into(),
             Some("Free up space on Board, then try the install again.".into()),
         )
-    } else if contains_any(&normalized_output, &["invalid", "corrupt", "parse", "manifest"]) {
+    } else if contains_any(
+        &normalized_output,
+        &["invalid", "corrupt", "parse", "manifest"],
+    ) {
         (
             "Board did not accept this APK as a valid install package.".into(),
             Some("Try another copy of the APK if you have one.".into()),
@@ -340,7 +342,11 @@ fn uninstall_installed_title_with_runner<P: ProcessRunner>(
     display_name: &str,
     runner: &P,
 ) -> UninstallInstalledTitleResult {
-    let command = build_command_string(&tool_state.executable_path, BDB_REMOVE_ARGUMENT, package_name);
+    let command = build_command_string(
+        &tool_state.executable_path,
+        BDB_REMOVE_ARGUMENT,
+        package_name,
+    );
 
     if tool_state.status != bdb_tool::BdbToolStatus::Runnable {
         return blocked_uninstall_result(
@@ -389,9 +395,8 @@ fn uninstall_installed_title_with_runner<P: ProcessRunner>(
             ProcessRunFailureKind::Other => UninstallInstalledTitleResult {
                 status: UninstallInstalledTitleStatus::Failed,
                 summary: format!("BE Home couldn't finish removing {display_name} from Board yet."),
-                guidance:
-                    "Keep Board connected, then try removing the title again in a moment."
-                        .into(),
+                guidance: "Keep Board connected, then try removing the title again in a moment."
+                    .into(),
                 detail: Some("The uninstall command could not finish cleanly.".into()),
                 command,
                 exit_code: None,
@@ -458,7 +463,11 @@ fn launch_installed_title_with_runner<P: ProcessRunner>(
     display_name: &str,
     runner: &P,
 ) -> LaunchInstalledTitleResult {
-    let command = build_command_string(&tool_state.executable_path, BDB_LAUNCH_ARGUMENT, package_name);
+    let command = build_command_string(
+        &tool_state.executable_path,
+        BDB_LAUNCH_ARGUMENT,
+        package_name,
+    );
 
     if tool_state.status != bdb_tool::BdbToolStatus::Runnable {
         return blocked_launch_result(
@@ -507,8 +516,8 @@ fn launch_installed_title_with_runner<P: ProcessRunner>(
             ProcessRunFailureKind::Other => LaunchInstalledTitleResult {
                 status: LaunchInstalledTitleStatus::Failed,
                 summary: format!("BE Home couldn't finish launching {display_name} on Board yet."),
-                guidance:
-                    "Keep Board connected, then try opening the title again in a moment.".into(),
+                guidance: "Keep Board connected, then try opening the title again in a moment."
+                    .into(),
                 detail: Some("The launch command could not finish cleanly.".into()),
                 command,
                 exit_code: None,
@@ -635,11 +644,9 @@ fn tool_guidance_for_install(
             "Repair bdb from settings before trying this install again.".into(),
             Some(tool_state.guidance.clone()),
         ),
-        bdb_tool::BdbToolStatus::Runnable => (
-            "ready",
-            "Board's install tool is ready.".into(),
-            None,
-        ),
+        bdb_tool::BdbToolStatus::Runnable => {
+            ("ready", "Board's install tool is ready.".into(), None)
+        }
     }
 }
 
@@ -672,11 +679,7 @@ fn device_guidance_for_install(
             "This computer is outside Board's current support for desktop installs.".into(),
             Some(device_status.guidance.clone()),
         ),
-        device::DeviceStatusKind::BoardConnected => (
-            "ready",
-            "Board is connected.".into(),
-            None,
-        ),
+        device::DeviceStatusKind::BoardConnected => ("ready", "Board is connected.".into(), None),
     }
 }
 
@@ -771,7 +774,10 @@ fn build_command_string(executable_path: &str, command_name: &str, target: &str)
 fn normalize_package_name(value: &str) -> Result<String, String> {
     let trimmed = value.trim();
     if trimmed.is_empty() {
-        return Err("Choose an installed title with a package name before asking BE Home to remove it.".into());
+        return Err(
+            "Choose an installed title with a package name before asking BE Home to remove it."
+                .into(),
+        );
     }
 
     Ok(trimmed.to_owned())
@@ -793,16 +799,29 @@ fn path_to_string(path: &Path) -> String {
     path.to_string_lossy().into_owned()
 }
 
-fn classify_process_failure(error: io::Error) -> ProcessRunFailure {
-    let kind = match error.kind() {
-        io::ErrorKind::PermissionDenied => ProcessRunFailureKind::PermissionDenied,
-        io::ErrorKind::NotFound => ProcessRunFailureKind::NotFound,
-        _ => ProcessRunFailureKind::Other,
+fn timeout_for_args(args: &[&str]) -> Duration {
+    match args.first().copied() {
+        Some(BDB_INSTALL_ARGUMENT) => Duration::from_secs(BDB_INSTALL_TIMEOUT_SECONDS),
+        Some(BDB_LAUNCH_ARGUMENT) | Some(BDB_REMOVE_ARGUMENT) | None => {
+            Duration::from_secs(BDB_ACTION_TIMEOUT_SECONDS)
+        }
+        Some(_) => Duration::from_secs(BDB_ACTION_TIMEOUT_SECONDS),
+    }
+}
+
+fn map_process_failure(failure: process_runner::ProcessCommandFailure) -> ProcessRunFailure {
+    let kind = match failure.kind {
+        process_runner::ProcessCommandFailureKind::PermissionDenied => {
+            ProcessRunFailureKind::PermissionDenied
+        }
+        process_runner::ProcessCommandFailureKind::NotFound => ProcessRunFailureKind::NotFound,
+        process_runner::ProcessCommandFailureKind::TimedOut
+        | process_runner::ProcessCommandFailureKind::Other => ProcessRunFailureKind::Other,
     };
 
     ProcessRunFailure {
         kind,
-        detail: error.to_string(),
+        detail: failure.detail,
     }
 }
 

--- a/src-tauri/src/apk.rs
+++ b/src-tauri/src/apk.rs
@@ -112,7 +112,9 @@ fn build_apk_discovery_snapshot(scan_folder_paths: Vec<String>) -> ApkDiscoveryS
                 Some(scan_folder_path.clone()),
             ) {
                 if candidate.confidence == ApkConfidence::StrongMatch {
-                    candidates_by_key.entry(candidate.stable_id.clone()).or_insert(candidate);
+                    candidates_by_key
+                        .entry(candidate.stable_id.clone())
+                        .or_insert(candidate);
                 }
             }
         }
@@ -350,9 +352,7 @@ fn extract_utf16le_strings(bytes: &[u8]) -> Vec<String> {
     for chunk in bytes.chunks_exact(2) {
         let low = chunk[0] as char;
         let high = chunk[1];
-        if high == 0
-            && (low.is_ascii_alphanumeric() || matches!(low, '.' | '_' | '-'))
-        {
+        if high == 0 && (low.is_ascii_alphanumeric() || matches!(low, '.' | '_' | '-')) {
             current.push(low);
         } else {
             if current.len() >= 6 {
@@ -387,15 +387,11 @@ fn is_common_non_app_package(value: &str) -> bool {
 
 fn confidence_summary(confidence: ApkConfidence) -> &'static str {
     match confidence {
-        ApkConfidence::StrongMatch => {
-            "BE Home found a strong Board SDK marker in this APK."
-        }
+        ApkConfidence::StrongMatch => "BE Home found a strong Board SDK marker in this APK.",
         ApkConfidence::PossibleMatch => {
             "BE Home found some Android packaging signals, but not the strongest Board marker yet."
         }
-        ApkConfidence::Unknown => {
-            "BE Home did not find a clear Board marker in this APK yet."
-        }
+        ApkConfidence::Unknown => "BE Home did not find a clear Board marker in this APK yet.",
     }
 }
 
@@ -444,9 +440,12 @@ fn looks_like_package_name(value: &str) -> bool {
         return false;
     }
 
-    value.chars().all(|character| {
-        character.is_ascii_alphanumeric() || matches!(character, '.' | '_' | '-')
-    }) && value.chars().any(|character| character.is_ascii_lowercase())
+    value
+        .chars()
+        .all(|character| character.is_ascii_alphanumeric() || matches!(character, '.' | '_' | '-'))
+        && value
+            .chars()
+            .any(|character| character.is_ascii_lowercase())
 }
 
 fn path_identity_key(path: &str) -> String {
@@ -473,11 +472,11 @@ mod tests {
     };
     use std::fs::{self, File};
     use std::io::Write;
+    #[cfg(unix)]
+    use std::os::unix::fs::symlink;
     use std::path::{Path, PathBuf};
     use zip::write::SimpleFileOptions;
     use zip::{CompressionMethod, ZipWriter};
-    #[cfg(unix)]
-    use std::os::unix::fs::symlink;
 
     #[test]
     fn discovery_snapshot_walks_nested_scan_folders_and_deduplicates_results() {
@@ -504,7 +503,10 @@ mod tests {
 
         assert_eq!(ApkDiscoveryStatus::Ready, snapshot.status);
         assert_eq!(1, snapshot.candidates.len());
-        assert_eq!(ApkConfidence::StrongMatch, snapshot.candidates[0].confidence);
+        assert_eq!(
+            ApkConfidence::StrongMatch,
+            snapshot.candidates[0].confidence
+        );
     }
 
     #[test]
@@ -556,9 +558,15 @@ mod tests {
         })
         .expect("manual apk inspection should succeed");
 
-        assert_eq!(ApkCandidateSource::ManualSelection, candidate.discovery_source);
+        assert_eq!(
+            ApkCandidateSource::ManualSelection,
+            candidate.discovery_source
+        );
         assert_eq!(ApkConfidence::StrongMatch, candidate.confidence);
-        assert_eq!(Some("fun.board.luckydice"), candidate.package_name.as_deref());
+        assert_eq!(
+            Some("fun.board.luckydice"),
+            candidate.package_name.as_deref()
+        );
     }
 
     #[test]
@@ -590,7 +598,10 @@ mod tests {
         })
         .expect("manual apk inspection should succeed");
 
-        assert_eq!(Some("fun.board.luckydice"), candidate.package_name.as_deref());
+        assert_eq!(
+            Some("fun.board.luckydice"),
+            candidate.package_name.as_deref()
+        );
     }
 
     #[test]
@@ -640,8 +651,7 @@ mod tests {
     fn write_apk_with_manifest(path: &Path, include_strong_marker: bool, manifest: &str) {
         let file = File::create(path).expect("apk file should create");
         let mut writer = ZipWriter::new(file);
-        let options = SimpleFileOptions::default()
-            .compression_method(CompressionMethod::Stored);
+        let options = SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
 
         writer
             .start_file("AndroidManifest.xml", options)
@@ -654,12 +664,16 @@ mod tests {
             writer
                 .start_file("lib/arm64-v8a/libnativeBoardSDK.so", options)
                 .expect("strong marker should start");
-            writer.write_all(b"board-sdk").expect("strong marker should write");
+            writer
+                .write_all(b"board-sdk")
+                .expect("strong marker should write");
         } else {
             writer
                 .start_file("lib/arm64-v8a/libunity.so", options)
                 .expect("possible marker should start");
-            writer.write_all(b"unity").expect("possible marker should write");
+            writer
+                .write_all(b"unity")
+                .expect("possible marker should write");
         }
 
         writer.finish().expect("apk archive should finish");

--- a/src-tauri/src/bdb.rs
+++ b/src-tauri/src/bdb.rs
@@ -433,10 +433,7 @@ fn detect_current_platform() -> DetectedPlatform {
 
 #[cfg(target_os = "windows")]
 fn detect_windows_build_number() -> Option<u32> {
-    let output = Command::new("cmd")
-        .args(["/C", "ver"])
-        .output()
-        .ok()?;
+    let output = Command::new("cmd").args(["/C", "ver"]).output().ok()?;
 
     let version_text = String::from_utf8_lossy(&output.stdout);
     parse_windows_build_number(&version_text)
@@ -465,8 +462,9 @@ mod tests {
     use super::{
         bundled_manifest, load_manifest_with_fallbacks, parse_manifest, parse_windows_build_number,
         resolve_bdb_source_plan_for_platform, BdbArchitecture, BdbOperatingSystem,
-        BdbSourceManifestPlatform, BdbSupportStatus, BdbUnsupportedReason, DetectedPlatform, LoadedManifest,
-        LINUX_X86_64_PLATFORM_KEY, MACOS_UNIVERSAL_PLATFORM_KEY, WINDOWS_X86_64_PLATFORM_KEY,
+        BdbSourceManifestPlatform, BdbSupportStatus, BdbUnsupportedReason, DetectedPlatform,
+        LoadedManifest, LINUX_X86_64_PLATFORM_KEY, MACOS_UNIVERSAL_PLATFORM_KEY,
+        WINDOWS_X86_64_PLATFORM_KEY,
     };
     use std::cell::Cell;
     use std::fs;

--- a/src-tauri/src/bdb_tool.rs
+++ b/src-tauri/src/bdb_tool.rs
@@ -1,4 +1,4 @@
-use crate::{bdb, storage};
+use crate::{bdb, process_runner, storage};
 use reqwest::blocking::Client;
 use serde::Serialize;
 use std::fs;
@@ -6,12 +6,12 @@ use std::io;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 use std::time::Duration;
 
 const BDB_HELP_ARGUMENT: &str = "help";
 const BDB_VERSION_ARGUMENT: &str = "version";
 const BDB_DOWNLOAD_TIMEOUT_SECONDS: u64 = 30;
+const BDB_TOOL_PROBE_TIMEOUT_SECONDS: u64 = 5;
 const BOARD_SUPPORT_EMAIL: &str = "hello@board.fun";
 const BOARD_SUPPORT_SUBJECT: &str = "OS Support Request for bdb";
 
@@ -244,15 +244,17 @@ impl ProcessRunner for CommandProcessRunner {
         executable_path: &Path,
         args: &[&str],
     ) -> Result<ProcessRunOutput, ProcessRunFailure> {
-        let output = Command::new(executable_path)
-            .args(args)
-            .output()
-            .map_err(classify_process_failure)?;
+        let output = process_runner::run_with_timeout(
+            executable_path,
+            args,
+            Duration::from_secs(BDB_TOOL_PROBE_TIMEOUT_SECONDS),
+        )
+        .map_err(map_process_failure)?;
 
         Ok(ProcessRunOutput {
-            exit_code: output.status.code(),
-            stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
-            stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+            exit_code: output.exit_code,
+            stdout: output.stdout,
+            stderr: output.stderr,
         })
     }
 }
@@ -276,6 +278,16 @@ pub(crate) fn load_current_bdb_tool_state_with_remote_refresh(
         source_plan,
         storage_settings,
         &CommandProcessRunner,
+    ))
+}
+
+/// Load a lightweight `bdb` tool state for background device checks.
+pub(crate) fn load_current_bdb_tool_state_for_device_poll() -> Result<BdbToolState, String> {
+    let source_plan = bdb::resolve_current_bdb_source_plan();
+    let storage_settings = storage::load_managed_storage_settings()?;
+    Ok(inspect_bdb_tool_state_without_runtime_probe(
+        source_plan,
+        storage_settings,
     ))
 }
 
@@ -483,6 +495,96 @@ fn acquire_bdb_tool_with_dependencies<D: BinaryDownloader, P: ProcessRunner>(
     }
 }
 
+fn inspect_bdb_tool_state_without_runtime_probe(
+    source_plan: bdb::BdbSourcePlan,
+    storage_settings: storage::ManagedStorageSettings,
+) -> BdbToolState {
+    let storage_location = storage_settings.bdb_tools.clone();
+    let executable_path = resolve_bdb_executable_path(&storage_location);
+    let executable_exists = executable_path.exists();
+    let validation_command = build_validation_command(&executable_path);
+
+    if source_plan.support.status == bdb::BdbSupportStatus::Unsupported {
+        let version_check = unavailable_version_check(
+            &executable_path,
+            "BE Home cannot read a Board Install Tool version for this computer yet.".into(),
+        );
+        return BdbToolState {
+            status: BdbToolStatus::Unsupported,
+            summary: "This computer is outside Board's current bdb support matrix.".into(),
+            guidance: source_plan.support.guidance.clone(),
+            executable_path: path_to_string(&executable_path),
+            executable_exists,
+            storage: storage_location,
+            source_plan: source_plan.clone(),
+            version_check: version_check.clone(),
+            update_status: build_update_status(&source_plan, executable_exists, &version_check),
+            support_request_draft: None,
+            validation: BdbRunnableValidation {
+                status: BdbRunnableStatus::Unsupported,
+                command: validation_command,
+                exit_code: None,
+                summary: "BE Home skipped the bdb runnable check because Board does not publish a supported download for this computer.".into(),
+                detail: None,
+            },
+        };
+    }
+
+    if !executable_exists {
+        let version_check = unavailable_version_check(
+            &executable_path,
+            "BE Home has not downloaded the Board Install Tool yet.".into(),
+        );
+        return BdbToolState {
+            status: BdbToolStatus::Missing,
+            summary: "BE Home has not downloaded bdb into the managed tools folder yet.".into(),
+            guidance: "Continue setup and BE Home will download Board's bdb into its managed tools folder for you.".into(),
+            executable_path: path_to_string(&executable_path),
+            executable_exists: false,
+            storage: storage_location,
+            source_plan: source_plan.clone(),
+            version_check: version_check.clone(),
+            update_status: build_update_status(&source_plan, false, &version_check),
+            support_request_draft: None,
+            validation: BdbRunnableValidation {
+                status: BdbRunnableStatus::Missing,
+                command: validation_command,
+                exit_code: None,
+                summary: "No managed bdb executable is present yet.".into(),
+                detail: None,
+            },
+        };
+    }
+
+    let version_check = unavailable_version_check(
+        &executable_path,
+        "BE Home skips bdb version checks during background Board-status polling.".into(),
+    );
+
+    BdbToolState {
+        status: BdbToolStatus::Runnable,
+        summary: "Board's install tool is ready for background device checks.".into(),
+        guidance:
+            "BE Home will verify the Board connection without re-running the full setup check every few seconds."
+                .into(),
+        executable_path: path_to_string(&executable_path),
+        executable_exists,
+        storage: storage_location,
+        source_plan: source_plan.clone(),
+        version_check: version_check.clone(),
+        update_status: build_update_status(&source_plan, executable_exists, &version_check),
+        support_request_draft: None,
+        validation: BdbRunnableValidation {
+            status: BdbRunnableStatus::Runnable,
+            command: validation_command,
+            exit_code: None,
+            summary: "BE Home found a managed bdb executable for the background device check."
+                .into(),
+            detail: None,
+        },
+    }
+}
+
 fn download_and_store_bdb<D: BinaryDownloader>(
     storage_location: &storage::ManagedStorageLocation,
     download_url: &str,
@@ -641,9 +743,12 @@ fn load_bdb_tool_version_check<P: ProcessRunner>(
                         command,
                         value: None,
                         exit_code: output.exit_code,
-                        summary: "BE Home could not read a version number from the Board Install Tool.".into(),
+                        summary:
+                            "BE Home could not read a version number from the Board Install Tool."
+                                .into(),
                         detail: Some(
-                            "The tool opened, but it did not return a readable version line.".into(),
+                            "The tool opened, but it did not return a readable version line."
+                                .into(),
                         ),
                     },
                 }
@@ -653,7 +758,9 @@ fn load_bdb_tool_version_check<P: ProcessRunner>(
                     command,
                     value: None,
                     exit_code: output.exit_code,
-                    summary: "BE Home could not confirm which Board Install Tool version is stored here.".into(),
+                    summary:
+                        "BE Home could not confirm which Board Install Tool version is stored here."
+                            .into(),
                     detail: Some(if combined_text.is_empty() {
                         "The Board Install Tool exited before it returned a readable version line."
                             .into()
@@ -691,7 +798,10 @@ fn build_update_status(
     executable_exists: bool,
     version_check: &BdbToolVersionCheck,
 ) -> BdbUpdateStatus {
-    let available_version = source_plan.source.as_ref().and_then(|source| source.version.clone());
+    let available_version = source_plan
+        .source
+        .as_ref()
+        .and_then(|source| source.version.clone());
     let current_version = version_check.value.clone();
 
     if source_plan.support.status == bdb::BdbSupportStatus::Unsupported {
@@ -830,21 +940,27 @@ fn combined_output_text(output: &ProcessRunOutput) -> String {
 }
 
 fn first_non_empty_line(value: &str) -> Option<String> {
-    value.lines()
+    value
+        .lines()
         .map(str::trim)
         .find(|line| !line.is_empty())
         .map(str::to_owned)
 }
 
-fn classify_process_failure(error: io::Error) -> ProcessRunFailure {
-    let detail = error.to_string();
-    let kind = match error.kind() {
-        io::ErrorKind::PermissionDenied => ProcessRunFailureKind::PermissionDenied,
-        io::ErrorKind::NotFound => ProcessRunFailureKind::NotFound,
-        _ => ProcessRunFailureKind::Other,
+fn map_process_failure(failure: process_runner::ProcessCommandFailure) -> ProcessRunFailure {
+    let kind = match failure.kind {
+        process_runner::ProcessCommandFailureKind::PermissionDenied => {
+            ProcessRunFailureKind::PermissionDenied
+        }
+        process_runner::ProcessCommandFailureKind::NotFound => ProcessRunFailureKind::NotFound,
+        process_runner::ProcessCommandFailureKind::TimedOut
+        | process_runner::ProcessCommandFailureKind::Other => ProcessRunFailureKind::Other,
     };
 
-    ProcessRunFailure { kind, detail }
+    ProcessRunFailure {
+        kind,
+        detail: failure.detail,
+    }
 }
 
 fn storage_write_error(path: &Path, error: &io::Error) -> UserFacingError {
@@ -886,14 +1002,10 @@ fn percent_encode_component(value: &str) -> String {
     value
         .bytes()
         .flat_map(|byte| match byte {
-            b'A'..=b'Z'
-            | b'a'..=b'z'
-            | b'0'..=b'9'
-            | b'-'
-            | b'.'
-            | b'_'
-            | b'~' => vec![byte as char].into_iter().collect::<Vec<_>>(),
-            b' ' => vec!['%','2','0'],
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' => {
+                vec![byte as char].into_iter().collect::<Vec<_>>()
+            }
+            b' ' => vec!['%', '2', '0'],
             _ => format!("%{byte:02X}").chars().collect::<Vec<_>>(),
         })
         .collect()
@@ -1093,7 +1205,10 @@ mod tests {
             replace_stored_bdb_binary_with_rename(&temp_path, &executable_path, &mut |from, to| {
                 rename_attempt += 1;
                 if rename_attempt == 2 {
-                    return Err(io::Error::new(io::ErrorKind::Other, "simulated rename failure"));
+                    return Err(io::Error::new(
+                        io::ErrorKind::Other,
+                        "simulated rename failure",
+                    ));
                 }
 
                 fs::rename(from, to)
@@ -1107,8 +1222,9 @@ mod tests {
         );
         assert_eq!(
             "blocked-bdb",
-            fs::read_to_string(&temp_path)
-                .expect("downloaded temp file should remain available after the failed replacement")
+            fs::read_to_string(&temp_path).expect(
+                "downloaded temp file should remain available after the failed replacement"
+            )
         );
         assert!(!resolve_bdb_backup_path(&executable_path).exists());
     }

--- a/src-tauri/src/device.rs
+++ b/src-tauri/src/device.rs
@@ -1,12 +1,14 @@
-use crate::{bdb_tool, storage};
+use crate::{bdb_tool, process_runner, storage};
 use serde::Serialize;
-use std::io;
 use std::path::Path;
-use std::process::Command;
+use std::sync::{Mutex, MutexGuard, OnceLock};
+use std::time::Duration;
 
 const BDB_STATUS_ARGUMENT: &str = "status";
 const BDB_VERSION_ARGUMENT: &str = "version";
 const DEFAULT_DEVICE_STATUS_POLL_INTERVAL_MS: u32 = 5_000;
+const BACKGROUND_DEVICE_STATUS_POLL_INTERVAL_MS: u32 = 15_000;
+const BDB_STATUS_TIMEOUT_SECONDS: u64 = 3;
 
 /// Describes the normalized connection state that the device workspace can consume.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
@@ -73,6 +75,13 @@ struct ProcessRunFailure {
     detail: String,
 }
 
+#[derive(Default)]
+struct DeviceStatusSession {
+    last_status: Option<DeviceStatusKind>,
+    cached_board_os_version: Option<String>,
+    cached_bdb_version: Option<BdbVersionDetails>,
+}
+
 trait ProcessRunner {
     fn run(
         &self,
@@ -89,85 +98,131 @@ impl ProcessRunner for CommandProcessRunner {
         executable_path: &Path,
         args: &[&str],
     ) -> Result<ProcessRunOutput, ProcessRunFailure> {
-        let output = Command::new(executable_path)
-            .args(args)
-            .output()
-            .map_err(classify_process_failure)?;
+        let output = process_runner::run_with_timeout(
+            executable_path,
+            args,
+            Duration::from_secs(BDB_STATUS_TIMEOUT_SECONDS),
+        )
+        .map_err(map_process_failure)?;
 
         Ok(ProcessRunOutput {
-            exit_code: output.status.code(),
-            stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
-            stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+            exit_code: output.exit_code,
+            stdout: output.stdout,
+            stderr: output.stderr,
         })
     }
 }
 
+static DEVICE_STATUS_SESSION: OnceLock<Mutex<DeviceStatusSession>> = OnceLock::new();
+
 /// Load the current device-status snapshot for the managed `bdb` session.
 pub(crate) fn load_current_device_status_snapshot() -> Result<DeviceStatusSnapshot, String> {
-    let tool_state = bdb_tool::load_current_bdb_tool_state()?;
-    Ok(load_device_status_snapshot_with_runner(
+    let tool_state = bdb_tool::load_current_bdb_tool_state_for_device_poll()?;
+    Ok(load_device_status_snapshot_with_runner_and_session(
         &tool_state,
         &CommandProcessRunner,
+        device_status_session(),
     ))
 }
 
+#[cfg(test)]
 fn load_device_status_snapshot_with_runner<P: ProcessRunner>(
     tool_state: &bdb_tool::BdbToolState,
     runner: &P,
 ) -> DeviceStatusSnapshot {
-    let poll_interval_ms = current_poll_interval_ms();
+    let session = Mutex::new(DeviceStatusSession::default());
+    load_device_status_snapshot_with_runner_and_session(tool_state, runner, &session)
+}
+
+fn load_device_status_snapshot_with_runner_and_session<P: ProcessRunner>(
+    tool_state: &bdb_tool::BdbToolState,
+    runner: &P,
+    session: &Mutex<DeviceStatusSession>,
+) -> DeviceStatusSnapshot {
+    let configured_poll_interval_ms = current_poll_interval_ms();
     match tool_state.status {
-        bdb_tool::BdbToolStatus::Unsupported => DeviceStatusSnapshot {
-            status: DeviceStatusKind::UnsupportedHost,
-            summary: "This computer is outside Board's current support for the desktop install tool."
-                .into(),
-            guidance: tool_state.guidance.clone(),
-            detail: None,
-            board_os_version: None,
-            poll_interval_ms,
-            bdb_version: unavailable_version_details(&tool_state.executable_path, tool_state.summary.clone()),
-        },
-        bdb_tool::BdbToolStatus::Missing => DeviceStatusSnapshot {
-            status: DeviceStatusKind::ToolMissing,
-            summary: "Board's install tool still needs to be downloaded before device checks can start."
-                .into(),
-            guidance: tool_state.guidance.clone(),
-            detail: None,
-            board_os_version: None,
-            poll_interval_ms,
-            bdb_version: unavailable_version_details(
-                &tool_state.executable_path,
-                "BE Home has not downloaded bdb yet.".into(),
-            ),
-        },
-        bdb_tool::BdbToolStatus::Downloaded => DeviceStatusSnapshot {
-            status: DeviceStatusKind::ToolBroken,
-            summary: "BE Home found the Board install tool, but this computer is not letting it run cleanly yet."
-                .into(),
-            guidance: tool_state.guidance.clone(),
-            detail: Some("Choose repair in settings to fetch a fresh copy of bdb.".into()),
-            board_os_version: None,
-            poll_interval_ms,
-            bdb_version: unavailable_version_details(
-                &tool_state.executable_path,
-                "BE Home could not trust the stored bdb copy enough to read its version.".into(),
-            ),
-        },
-        bdb_tool::BdbToolStatus::Runnable => inspect_runnable_device_status(tool_state, runner),
+        bdb_tool::BdbToolStatus::Unsupported => record_status(
+            session,
+            DeviceStatusSnapshot {
+                status: DeviceStatusKind::UnsupportedHost,
+                summary:
+                    "This computer is outside Board's current support for the desktop install tool."
+                        .into(),
+                guidance: tool_state.guidance.clone(),
+                detail: None,
+                board_os_version: None,
+                poll_interval_ms: poll_interval_for_status(
+                    DeviceStatusKind::UnsupportedHost,
+                    configured_poll_interval_ms,
+                ),
+                bdb_version: unavailable_version_details(
+                    &tool_state.executable_path,
+                    tool_state.summary.clone(),
+                ),
+            },
+        ),
+        bdb_tool::BdbToolStatus::Missing => record_status(
+            session,
+            DeviceStatusSnapshot {
+                status: DeviceStatusKind::ToolMissing,
+                summary: "Board's install tool still needs to be downloaded before device checks can start."
+                    .into(),
+                guidance: tool_state.guidance.clone(),
+                detail: None,
+                board_os_version: None,
+                poll_interval_ms: poll_interval_for_status(
+                    DeviceStatusKind::ToolMissing,
+                    configured_poll_interval_ms,
+                ),
+                bdb_version: unavailable_version_details(
+                    &tool_state.executable_path,
+                    "BE Home has not downloaded bdb yet.".into(),
+                ),
+            },
+        ),
+        bdb_tool::BdbToolStatus::Downloaded => record_status(
+            session,
+            DeviceStatusSnapshot {
+                status: DeviceStatusKind::ToolBroken,
+                summary: "BE Home found the Board install tool, but this computer is not letting it run cleanly yet."
+                    .into(),
+                guidance: tool_state.guidance.clone(),
+                detail: Some("Choose repair in settings to fetch a fresh copy of bdb.".into()),
+                board_os_version: None,
+                poll_interval_ms: poll_interval_for_status(
+                    DeviceStatusKind::ToolBroken,
+                    configured_poll_interval_ms,
+                ),
+                bdb_version: unavailable_version_details(
+                    &tool_state.executable_path,
+                    "BE Home could not trust the stored bdb copy enough to read its version."
+                        .into(),
+                ),
+            },
+        ),
+        bdb_tool::BdbToolStatus::Runnable => {
+            inspect_runnable_device_status(tool_state, runner, configured_poll_interval_ms, session)
+        }
     }
 }
 
 fn inspect_runnable_device_status<P: ProcessRunner>(
     tool_state: &bdb_tool::BdbToolState,
     runner: &P,
+    configured_poll_interval_ms: u32,
+    session: &Mutex<DeviceStatusSession>,
 ) -> DeviceStatusSnapshot {
     let executable_path = Path::new(&tool_state.executable_path);
-    let version = load_bdb_version(executable_path, runner);
+    let version = bdb_version_details_from_tool_state(tool_state);
     let status_command = build_command_string(&tool_state.executable_path, BDB_STATUS_ARGUMENT);
-    let poll_interval_ms = current_poll_interval_ms();
 
     match runner.run(executable_path, &[BDB_STATUS_ARGUMENT]) {
-        Ok(output) => normalize_status_output(output, version),
+        Ok(output) => {
+            let mut snapshot =
+                normalize_status_output(output, version, configured_poll_interval_ms);
+            refresh_connected_board_details(&mut snapshot, executable_path, runner, session);
+            snapshot
+        }
         Err(failure) => {
             let (status, summary, guidance, detail) = match failure.kind {
                 ProcessRunFailureKind::PermissionDenied => (
@@ -188,19 +243,26 @@ fn inspect_runnable_device_status<P: ProcessRunner>(
                     DeviceStatusKind::ExecutionError,
                     "BE Home could not finish the latest Board connection check.".into(),
                     "Keep Board connected, close anything else using bdb, then refresh the device check.".into(),
-                    Some(format!("The last check attempted `{status_command}`.")),
+                    Some(format!(
+                        "The last check attempted `{status_command}`. {}",
+                        failure.detail
+                    )),
                 ),
             };
+            let poll_interval_ms = poll_interval_for_status(status, configured_poll_interval_ms);
 
-            DeviceStatusSnapshot {
-                status,
-                summary,
-                guidance,
-                detail,
-                board_os_version: None,
-                poll_interval_ms,
-                bdb_version: version,
-            }
+            record_status(
+                session,
+                DeviceStatusSnapshot {
+                    status,
+                    summary,
+                    guidance,
+                    detail,
+                    board_os_version: None,
+                    poll_interval_ms,
+                    bdb_version: version,
+                },
+            )
         }
     }
 }
@@ -208,16 +270,16 @@ fn inspect_runnable_device_status<P: ProcessRunner>(
 fn normalize_status_output(
     output: ProcessRunOutput,
     version: BdbVersionDetails,
+    configured_poll_interval_ms: u32,
 ) -> DeviceStatusSnapshot {
     let combined_text = combined_output_text(&output);
     let normalized_text = combined_text.to_ascii_lowercase();
-    let board_os_version =
-        extract_board_os_version(&combined_text).or_else(|| {
-            version
-                .value
-                .as_deref()
-                .and_then(extract_board_os_version)
-        });
+    let board_os_version = extract_board_os_version(&combined_text).or_else(|| {
+        version
+            .value
+            .as_deref()
+            .and_then(extract_board_os_version_from_version_text)
+    });
 
     let (status, summary, guidance, detail) = if contains_any(
         &normalized_text,
@@ -238,8 +300,7 @@ fn normalize_status_output(
                     .into(),
             ),
         )
-    } else if output.exit_code == Some(0)
-        || contains_any(&normalized_text, &["connected", "ready"])
+    } else if output.exit_code == Some(0) || contains_any(&normalized_text, &["connected", "ready"])
     {
         (
             DeviceStatusKind::BoardConnected,
@@ -258,6 +319,7 @@ fn normalize_status_output(
                 .map(|_| "The last bdb status response did not look like a normal connected or disconnected state.".into()),
         )
     };
+    let poll_interval_ms = poll_interval_for_status(status, configured_poll_interval_ms);
 
     DeviceStatusSnapshot {
         status,
@@ -265,16 +327,48 @@ fn normalize_status_output(
         guidance,
         detail,
         board_os_version,
-        poll_interval_ms: current_poll_interval_ms(),
+        poll_interval_ms,
         bdb_version: version,
     }
 }
 
-fn load_bdb_version<P: ProcessRunner>(
+fn refresh_connected_board_details<P: ProcessRunner>(
+    snapshot: &mut DeviceStatusSnapshot,
     executable_path: &Path,
     runner: &P,
-) -> BdbVersionDetails {
-    let command = build_command_string(&path_to_string(executable_path), BDB_VERSION_ARGUMENT);
+    session: &Mutex<DeviceStatusSession>,
+) {
+    if snapshot.status != DeviceStatusKind::BoardConnected {
+        record_snapshot_status(session, snapshot);
+        return;
+    }
+
+    if should_refresh_connected_details(session) {
+        let refreshed_version = load_bdb_version(executable_path, runner);
+        if let Some(board_os_version) = refreshed_version
+            .value
+            .as_deref()
+            .and_then(extract_board_os_version_from_version_text)
+        {
+            snapshot.board_os_version = Some(board_os_version);
+        }
+        snapshot.bdb_version = refreshed_version;
+        record_snapshot_status(session, snapshot);
+        return;
+    }
+
+    let (cached_board_os_version, cached_bdb_version) = cached_connected_details(session);
+    if snapshot.board_os_version.is_none() {
+        snapshot.board_os_version = cached_board_os_version;
+    }
+    if let Some(cached_bdb_version) = cached_bdb_version {
+        snapshot.bdb_version = cached_bdb_version;
+    }
+    record_snapshot_status(session, snapshot);
+}
+
+fn load_bdb_version<P: ProcessRunner>(executable_path: &Path, runner: &P) -> BdbVersionDetails {
+    let command = build_command_string(&executable_path.to_string_lossy(), BDB_VERSION_ARGUMENT);
 
     match runner.run(executable_path, &[BDB_VERSION_ARGUMENT]) {
         Ok(output) => {
@@ -329,6 +423,71 @@ fn load_bdb_version<P: ProcessRunner>(
     }
 }
 
+fn bdb_version_details_from_tool_state(tool_state: &bdb_tool::BdbToolState) -> BdbVersionDetails {
+    let version_check = &tool_state.version_check;
+    let status = match version_check.status {
+        bdb_tool::BdbToolVersionStatus::Available => BdbVersionStatus::Available,
+        bdb_tool::BdbToolVersionStatus::Unavailable => BdbVersionStatus::Unavailable,
+    };
+
+    BdbVersionDetails {
+        status,
+        command: version_check.command.clone(),
+        value: version_check.value.clone(),
+        exit_code: version_check.exit_code,
+        summary: version_check.summary.clone(),
+        detail: version_check.detail.clone(),
+    }
+}
+
+fn device_status_session() -> &'static Mutex<DeviceStatusSession> {
+    DEVICE_STATUS_SESSION.get_or_init(|| Mutex::new(DeviceStatusSession::default()))
+}
+
+fn should_refresh_connected_details(session: &Mutex<DeviceStatusSession>) -> bool {
+    let session = lock_device_status_session(session);
+    session.last_status != Some(DeviceStatusKind::BoardConnected)
+        || (session.cached_board_os_version.is_none() && session.cached_bdb_version.is_none())
+}
+
+fn cached_connected_details(
+    session: &Mutex<DeviceStatusSession>,
+) -> (Option<String>, Option<BdbVersionDetails>) {
+    let session = lock_device_status_session(session);
+    (
+        session.cached_board_os_version.clone(),
+        session.cached_bdb_version.clone(),
+    )
+}
+
+fn record_status(
+    session: &Mutex<DeviceStatusSession>,
+    snapshot: DeviceStatusSnapshot,
+) -> DeviceStatusSnapshot {
+    record_snapshot_status(session, &snapshot);
+    snapshot
+}
+
+fn record_snapshot_status(session: &Mutex<DeviceStatusSession>, snapshot: &DeviceStatusSnapshot) {
+    let mut session = lock_device_status_session(session);
+    session.last_status = Some(snapshot.status);
+    if snapshot.status == DeviceStatusKind::BoardConnected {
+        session.cached_board_os_version = snapshot.board_os_version.clone();
+        session.cached_bdb_version = Some(snapshot.bdb_version.clone());
+    } else {
+        session.cached_board_os_version = None;
+        session.cached_bdb_version = None;
+    }
+}
+
+fn lock_device_status_session(
+    session: &Mutex<DeviceStatusSession>,
+) -> MutexGuard<'_, DeviceStatusSession> {
+    session
+        .lock()
+        .unwrap_or_else(|poisoned_session| poisoned_session.into_inner())
+}
+
 fn unavailable_version_details(executable_path: &str, summary: String) -> BdbVersionDetails {
     BdbVersionDetails {
         status: BdbVersionStatus::Unavailable,
@@ -349,7 +508,8 @@ fn combined_output_text(output: &ProcessRunOutput) -> String {
 }
 
 fn extract_board_os_version(value: &str) -> Option<String> {
-    value.lines()
+    value
+        .lines()
         .map(str::trim)
         .find_map(|line| {
             let lower = line.to_ascii_lowercase();
@@ -360,26 +520,49 @@ fn extract_board_os_version(value: &str) -> Option<String> {
         .filter(|version| !version.is_empty())
 }
 
+fn extract_board_os_version_from_version_text(value: &str) -> Option<String> {
+    extract_board_os_version(value).or_else(|| {
+        first_non_empty_line(value)
+            .filter(|line| looks_like_plain_version(line))
+            .map(|line| line.trim().to_owned())
+    })
+}
+
+fn looks_like_plain_version(value: &str) -> bool {
+    let trimmed = value.trim();
+    !trimmed.is_empty()
+        && trimmed.starts_with(|character: char| character.is_ascii_digit())
+        && trimmed.chars().all(|character| {
+            character.is_ascii_alphanumeric() || matches!(character, '.' | '-' | '_')
+        })
+}
+
 fn contains_any(value: &str, candidates: &[&str]) -> bool {
     candidates.iter().any(|candidate| value.contains(candidate))
 }
 
 fn first_non_empty_line(value: &str) -> Option<String> {
-    value.lines()
+    value
+        .lines()
         .map(str::trim)
         .find(|line| !line.is_empty())
         .map(str::to_owned)
 }
 
-fn classify_process_failure(error: io::Error) -> ProcessRunFailure {
-    let detail = error.to_string();
-    let kind = match error.kind() {
-        io::ErrorKind::PermissionDenied => ProcessRunFailureKind::PermissionDenied,
-        io::ErrorKind::NotFound => ProcessRunFailureKind::NotFound,
-        _ => ProcessRunFailureKind::Other,
+fn map_process_failure(failure: process_runner::ProcessCommandFailure) -> ProcessRunFailure {
+    let kind = match failure.kind {
+        process_runner::ProcessCommandFailureKind::PermissionDenied => {
+            ProcessRunFailureKind::PermissionDenied
+        }
+        process_runner::ProcessCommandFailureKind::NotFound => ProcessRunFailureKind::NotFound,
+        process_runner::ProcessCommandFailureKind::TimedOut
+        | process_runner::ProcessCommandFailureKind::Other => ProcessRunFailureKind::Other,
     };
 
-    ProcessRunFailure { kind, detail }
+    ProcessRunFailure {
+        kind,
+        detail: failure.detail,
+    }
 }
 
 fn build_command_string(executable_path: &str, argument: &str) -> String {
@@ -388,20 +571,35 @@ fn build_command_string(executable_path: &str, argument: &str) -> String {
 
 fn current_poll_interval_ms() -> u32 {
     storage::load_desktop_settings()
-        .map(|settings| settings.board_connection.poll_interval_seconds.saturating_mul(1000))
+        .map(|settings| {
+            settings
+                .board_connection
+                .poll_interval_seconds
+                .saturating_mul(1000)
+        })
         .unwrap_or(DEFAULT_DEVICE_STATUS_POLL_INTERVAL_MS)
 }
 
-fn path_to_string(path: &Path) -> String {
-    path.to_string_lossy().into_owned()
+fn poll_interval_for_status(status: DeviceStatusKind, configured_poll_interval_ms: u32) -> u32 {
+    match status {
+        DeviceStatusKind::BoardConnected => configured_poll_interval_ms,
+        DeviceStatusKind::ToolMissing
+        | DeviceStatusKind::ToolBroken
+        | DeviceStatusKind::UnsupportedHost
+        | DeviceStatusKind::BoardDisconnected
+        | DeviceStatusKind::ExecutionError => {
+            configured_poll_interval_ms.max(BACKGROUND_DEVICE_STATUS_POLL_INTERVAL_MS)
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::{
-        load_device_status_snapshot_with_runner, BdbVersionStatus, DeviceStatusKind,
-        DeviceStatusSnapshot, ProcessRunFailure, ProcessRunFailureKind, ProcessRunOutput,
-        ProcessRunner,
+        current_poll_interval_ms, load_device_status_snapshot_with_runner,
+        load_device_status_snapshot_with_runner_and_session, BdbVersionStatus, DeviceStatusKind,
+        DeviceStatusSession, DeviceStatusSnapshot, ProcessRunFailure, ProcessRunFailureKind,
+        ProcessRunOutput, ProcessRunner, BACKGROUND_DEVICE_STATUS_POLL_INTERVAL_MS,
     };
     use crate::{
         bdb::{
@@ -415,6 +613,7 @@ mod tests {
         storage::{ManagedStorageLocation, ManagedStoragePathSource},
     };
     use std::path::Path;
+    use std::sync::Mutex;
 
     struct StaticRunner {
         version: Result<ProcessRunOutput, ProcessRunFailure>,
@@ -460,7 +659,7 @@ mod tests {
         let snapshot = runnable_snapshot_with_runner(StaticRunner {
             version: Ok(ProcessRunOutput {
                 exit_code: Some(0),
-                stdout: "bdb 0.19.0".into(),
+                stdout: "Board OS Version: 1.8.1".into(),
                 stderr: String::new(),
             }),
             status: Ok(ProcessRunOutput {
@@ -471,7 +670,31 @@ mod tests {
         });
 
         assert_eq!(DeviceStatusKind::BoardConnected, snapshot.status);
-        assert_eq!(Some("bdb 0.19.0"), snapshot.bdb_version.value.as_deref());
+        assert_eq!(
+            Some("Board OS Version: 1.8.1"),
+            snapshot.bdb_version.value.as_deref()
+        );
+        assert_eq!(Some("1.8.1"), snapshot.board_os_version.as_deref());
+        assert_eq!(current_poll_interval_ms(), snapshot.poll_interval_ms);
+    }
+
+    #[test]
+    fn connected_status_accepts_plain_board_os_version_text() {
+        let snapshot = runnable_snapshot_with_runner(StaticRunner {
+            version: Ok(ProcessRunOutput {
+                exit_code: Some(0),
+                stdout: "1.8.1".into(),
+                stderr: String::new(),
+            }),
+            status: Ok(ProcessRunOutput {
+                exit_code: Some(0),
+                stdout: "Board connected and ready.".into(),
+                stderr: String::new(),
+            }),
+        });
+
+        assert_eq!(DeviceStatusKind::BoardConnected, snapshot.status);
+        assert_eq!(Some("1.8.1"), snapshot.board_os_version.as_deref());
     }
 
     #[test]
@@ -494,15 +717,121 @@ mod tests {
             "Connect your Board with USB, unlock it if needed, then choose refresh.",
             snapshot.guidance
         );
+        assert_eq!(
+            current_poll_interval_ms().max(BACKGROUND_DEVICE_STATUS_POLL_INTERVAL_MS),
+            snapshot.poll_interval_ms
+        );
     }
 
     #[test]
-    fn failed_version_command_does_not_masquerade_as_an_available_version() {
+    fn connected_status_poll_reuses_cached_board_os_until_reconnection() {
+        let session = Mutex::new(DeviceStatusSession::default());
+        let first_snapshot = runnable_snapshot_with_runner_and_session(
+            StaticRunner {
+                version: Ok(ProcessRunOutput {
+                    exit_code: Some(0),
+                    stdout: "Board OS Version: 1.8.1".into(),
+                    stderr: String::new(),
+                }),
+                status: Ok(ProcessRunOutput {
+                    exit_code: Some(0),
+                    stdout: "Board connected and ready.".into(),
+                    stderr: String::new(),
+                }),
+            },
+            &session,
+        );
+        let second_snapshot = runnable_snapshot_with_runner_and_session(
+            StaticRunner {
+                version: Err(ProcessRunFailure {
+                    kind: ProcessRunFailureKind::Other,
+                    detail: "version should not be called while the connection stays ready".into(),
+                }),
+                status: Ok(ProcessRunOutput {
+                    exit_code: Some(0),
+                    stdout: "Board connected and ready.".into(),
+                    stderr: String::new(),
+                }),
+            },
+            &session,
+        );
+
+        assert_eq!(DeviceStatusKind::BoardConnected, first_snapshot.status);
+        assert_eq!(Some("1.8.1"), first_snapshot.board_os_version.as_deref());
+        assert_eq!(DeviceStatusKind::BoardConnected, second_snapshot.status);
+        assert_eq!(Some("1.8.1"), second_snapshot.board_os_version.as_deref());
+        assert_eq!(
+            Some("Board OS Version: 1.8.1"),
+            second_snapshot.bdb_version.value.as_deref()
+        );
+    }
+
+    #[test]
+    fn connected_status_refreshes_board_os_after_disconnection() {
+        let session = Mutex::new(DeviceStatusSession::default());
+        let first_snapshot = runnable_snapshot_with_runner_and_session(
+            StaticRunner {
+                version: Ok(ProcessRunOutput {
+                    exit_code: Some(0),
+                    stdout: "Board OS Version: 1.8.1".into(),
+                    stderr: String::new(),
+                }),
+                status: Ok(ProcessRunOutput {
+                    exit_code: Some(0),
+                    stdout: "Board connected and ready.".into(),
+                    stderr: String::new(),
+                }),
+            },
+            &session,
+        );
+        let disconnected_snapshot = runnable_snapshot_with_runner_and_session(
+            StaticRunner {
+                version: Err(ProcessRunFailure {
+                    kind: ProcessRunFailureKind::Other,
+                    detail: "version should not be called while disconnected".into(),
+                }),
+                status: Ok(ProcessRunOutput {
+                    exit_code: Some(1),
+                    stdout: "Board not connected.".into(),
+                    stderr: String::new(),
+                }),
+            },
+            &session,
+        );
+        let reconnected_snapshot = runnable_snapshot_with_runner_and_session(
+            StaticRunner {
+                version: Ok(ProcessRunOutput {
+                    exit_code: Some(0),
+                    stdout: "Board OS Version: 1.9.0".into(),
+                    stderr: String::new(),
+                }),
+                status: Ok(ProcessRunOutput {
+                    exit_code: Some(0),
+                    stdout: "Board connected and ready.".into(),
+                    stderr: String::new(),
+                }),
+            },
+            &session,
+        );
+
+        assert_eq!(Some("1.8.1"), first_snapshot.board_os_version.as_deref());
+        assert_eq!(
+            DeviceStatusKind::BoardDisconnected,
+            disconnected_snapshot.status
+        );
+        assert_eq!(None, disconnected_snapshot.board_os_version);
+        assert_eq!(
+            Some("1.9.0"),
+            reconnected_snapshot.board_os_version.as_deref()
+        );
+    }
+
+    #[test]
+    fn connected_status_marks_board_os_unavailable_when_refresh_fails() {
         let snapshot = runnable_snapshot_with_runner(StaticRunner {
-            version: Ok(ProcessRunOutput {
-                exit_code: Some(1),
-                stdout: String::new(),
-                stderr: "version probe failed".into(),
+            version: Err(ProcessRunFailure {
+                kind: ProcessRunFailureKind::Other,
+                detail: "version probe failed".into(),
             }),
             status: Ok(ProcessRunOutput {
                 exit_code: Some(0),
@@ -513,11 +842,7 @@ mod tests {
 
         assert_eq!(DeviceStatusKind::BoardConnected, snapshot.status);
         assert_eq!(BdbVersionStatus::Unavailable, snapshot.bdb_version.status);
-        assert_eq!(None, snapshot.bdb_version.value);
-        assert_eq!(
-            Some("version probe failed"),
-            snapshot.bdb_version.detail.as_deref()
-        );
+        assert_eq!(None, snapshot.board_os_version);
     }
 
     #[test]
@@ -555,12 +880,27 @@ mod tests {
 
         assert_eq!(DeviceStatusKind::ExecutionError, snapshot.status);
         assert!(snapshot.guidance.contains("Refresh the connection check"));
+        assert_eq!(
+            current_poll_interval_ms().max(BACKGROUND_DEVICE_STATUS_POLL_INTERVAL_MS),
+            snapshot.poll_interval_ms
+        );
     }
 
     fn runnable_snapshot_with_runner(runner: StaticRunner) -> DeviceStatusSnapshot {
         load_device_status_snapshot_with_runner(
             &sample_tool_state(BdbToolStatus::Runnable, BdbRunnableStatus::Runnable),
             &runner,
+        )
+    }
+
+    fn runnable_snapshot_with_runner_and_session(
+        runner: StaticRunner,
+        session: &Mutex<DeviceStatusSession>,
+    ) -> DeviceStatusSnapshot {
+        load_device_status_snapshot_with_runner_and_session(
+            &sample_tool_state(BdbToolStatus::Runnable, BdbRunnableStatus::Runnable),
+            &runner,
+            session,
         )
     }
 
@@ -606,15 +946,15 @@ mod tests {
             version_check: BdbToolVersionCheck {
                 status: BdbToolVersionStatus::Available,
                 command: "/tmp/bdb version".into(),
-                value: Some("Board OS Version: 1.8.1".into()),
+                value: Some("bdb 0.19.0".into()),
                 exit_code: Some(0),
-                summary: "Installed version: Board OS Version: 1.8.1".into(),
+                summary: "Installed version: bdb 0.19.0".into(),
                 detail: None,
             },
             update_status: BdbUpdateStatus {
                 status: BdbUpdateStatusKind::UpToDate,
-                current_version: Some("Board OS Version: 1.8.1".into()),
-                available_version: Some("Board OS Version: 1.8.1".into()),
+                current_version: Some("bdb 0.19.0".into()),
+                available_version: Some("bdb 0.19.0".into()),
                 guidance:
                     "This Board Install Tool matches the latest version in BE Home's source list."
                         .into(),

--- a/src-tauri/src/installed_titles.rs
+++ b/src-tauri/src/installed_titles.rs
@@ -1,11 +1,11 @@
-use crate::{bdb_tool, device};
+use crate::{bdb_tool, device, process_runner};
 use serde::Serialize;
 use std::collections::BTreeSet;
-use std::io;
 use std::path::Path;
-use std::process::Command;
+use std::time::Duration;
 
 const BDB_LIST_ARGUMENT: &str = "list";
+const BDB_LIST_TIMEOUT_SECONDS: u64 = 10;
 
 /// Describes whether the installed-title inventory is ready, empty, or temporarily unavailable.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
@@ -74,15 +74,17 @@ impl ProcessRunner for CommandProcessRunner {
         executable_path: &Path,
         args: &[&str],
     ) -> Result<ProcessRunOutput, ProcessRunFailure> {
-        let output = Command::new(executable_path)
-            .args(args)
-            .output()
-            .map_err(classify_process_failure)?;
+        let output = process_runner::run_with_timeout(
+            executable_path,
+            args,
+            Duration::from_secs(BDB_LIST_TIMEOUT_SECONDS),
+        )
+        .map_err(map_process_failure)?;
 
         Ok(ProcessRunOutput {
-            exit_code: output.status.code(),
-            stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
-            stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+            exit_code: output.exit_code,
+            stdout: output.stdout,
+            stderr: output.stderr,
         })
     }
 }
@@ -186,8 +188,7 @@ fn normalize_list_output(output: ProcessRunOutput) -> InstalledTitlesSnapshot {
             status: InstalledTitlesStatus::Unavailable,
             summary: "BE Home could not finish reading the installed-title list from Board yet."
                 .into(),
-            guidance:
-                "Reconnect Board if needed, then refresh the installed titles again.".into(),
+            guidance: "Reconnect Board if needed, then refresh the installed titles again.".into(),
             titles: Vec::new(),
         };
     }
@@ -250,7 +251,11 @@ fn parse_installed_title_line(index: usize, line: &str) -> Option<InstalledTitle
 
     let package_name = extract_package_name(normalized_line);
     let display_name = normalize_display_name(normalized_line, package_name.as_deref());
-    if package_name.is_none() && !display_name.chars().any(|character| character.is_ascii_alphanumeric()) {
+    if package_name.is_none()
+        && !display_name
+            .chars()
+            .any(|character| character.is_ascii_alphanumeric())
+    {
         return None;
     }
     let stable_id = build_stable_id(&display_name, package_name.as_deref(), index);
@@ -299,7 +304,10 @@ fn extract_parenthetical_package(line: &str) -> Option<String> {
 
 fn normalize_package_candidate(token: &str) -> Option<String> {
     let trimmed = token.trim_matches(|character: char| {
-        matches!(character, ',' | ';' | '|' | '(' | ')' | '[' | ']' | '"' | '\'')
+        matches!(
+            character,
+            ',' | ';' | '|' | '(' | ')' | '[' | ']' | '"' | '\''
+        )
     });
     if trimmed.is_empty() {
         return None;
@@ -420,13 +428,19 @@ fn looks_like_package_name(value: &str) -> bool {
         return false;
     }
 
-    value.chars().all(|character| {
-        character.is_ascii_alphanumeric() || matches!(character, '.' | '_' | '-')
-    }) && value.chars().any(|character| character.is_ascii_lowercase())
+    value
+        .chars()
+        .all(|character| character.is_ascii_alphanumeric() || matches!(character, '.' | '_' | '-'))
+        && value
+            .chars()
+            .any(|character| character.is_ascii_lowercase())
 }
 
 fn trim_inventory_prefix(line: &str) -> &str {
-    let digits = line.chars().take_while(|character| character.is_ascii_digit()).count();
+    let digits = line
+        .chars()
+        .take_while(|character| character.is_ascii_digit())
+        .count();
     if digits == 0 {
         return line;
     }
@@ -450,16 +464,19 @@ fn combined_output_text(output: &ProcessRunOutput) -> String {
         .join("\n")
 }
 
-fn classify_process_failure(error: io::Error) -> ProcessRunFailure {
-    let kind = match error.kind() {
-        io::ErrorKind::PermissionDenied => ProcessRunFailureKind::PermissionDenied,
-        io::ErrorKind::NotFound => ProcessRunFailureKind::NotFound,
-        _ => ProcessRunFailureKind::Other,
+fn map_process_failure(failure: process_runner::ProcessCommandFailure) -> ProcessRunFailure {
+    let kind = match failure.kind {
+        process_runner::ProcessCommandFailureKind::PermissionDenied => {
+            ProcessRunFailureKind::PermissionDenied
+        }
+        process_runner::ProcessCommandFailureKind::NotFound => ProcessRunFailureKind::NotFound,
+        process_runner::ProcessCommandFailureKind::TimedOut
+        | process_runner::ProcessCommandFailureKind::Other => ProcessRunFailureKind::Other,
     };
 
     ProcessRunFailure {
         kind,
-        _detail: error.to_string(),
+        _detail: failure.detail,
     }
 }
 
@@ -502,7 +519,10 @@ mod tests {
         let titles = parse_installed_titles("co.board.luckydice\ncom.example.familymatch");
 
         assert_eq!(2, titles.len());
-        assert_eq!(Some("co.board.luckydice"), titles[0].package_name.as_deref());
+        assert_eq!(
+            Some("co.board.luckydice"),
+            titles[0].package_name.as_deref()
+        );
         assert_eq!("co.board.luckydice", titles[0].display_name);
     }
 
@@ -512,7 +532,10 @@ mod tests {
 
         assert_eq!(1, titles.len());
         assert_eq!("Lucky Dice", titles[0].display_name);
-        assert_eq!(Some("co.board.luckydice"), titles[0].package_name.as_deref());
+        assert_eq!(
+            Some("co.board.luckydice"),
+            titles[0].package_name.as_deref()
+        );
         assert!(titles[0].can_launch);
     }
 
@@ -536,7 +559,8 @@ mod tests {
             &StaticRunner {
                 result: Ok(ProcessRunOutput {
                     exit_code: Some(0),
-                    stdout: "Lucky Dice (co.board.luckydice)\nFamily Match | fun.board.familymatch".into(),
+                    stdout: "Lucky Dice (co.board.luckydice)\nFamily Match | fun.board.familymatch"
+                        .into(),
                     stderr: String::new(),
                 }),
             },
@@ -544,7 +568,10 @@ mod tests {
 
         assert_eq!(InstalledTitlesStatus::Ready, snapshot.status);
         assert_eq!(2, snapshot.titles.len());
-        assert_eq!(Some("co.board.luckydice"), snapshot.titles[0].package_name.as_deref());
+        assert_eq!(
+            Some("co.board.luckydice"),
+            snapshot.titles[0].package_name.as_deref()
+        );
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,112 +5,183 @@ mod bdb_tool;
 mod device;
 mod installed_titles;
 mod library;
-mod shell;
+mod process_runner;
 mod setup;
+mod shell;
 mod storage;
 
-#[tauri::command]
-fn load_setup_gate_state() -> Result<setup::SetupGateState, String> {
-    setup::load_setup_gate_state()
+async fn run_blocking<T, F>(operation_name: &'static str, operation: F) -> Result<T, String>
+where
+    T: Send + 'static,
+    F: FnOnce() -> Result<T, String> + Send + 'static,
+{
+    tauri::async_runtime::spawn_blocking(operation)
+        .await
+        .map_err(|error| format!("BE Home could not finish {operation_name}: {error}"))?
 }
 
 #[tauri::command]
-fn load_apk_discovery_snapshot() -> Result<apk::ApkDiscoverySnapshot, String> {
-    apk::load_current_apk_discovery_snapshot()
+async fn load_setup_gate_state() -> Result<setup::SetupGateState, String> {
+    run_blocking("loading setup state", setup::load_setup_gate_state).await
 }
 
 #[tauri::command]
-fn inspect_manual_apk_path(input: apk::ManualApkPathInput) -> Result<apk::ApkCandidate, String> {
-    apk::inspect_manual_apk_path(input)
+async fn load_apk_discovery_snapshot() -> Result<apk::ApkDiscoverySnapshot, String> {
+    run_blocking(
+        "scanning this computer for games and apps",
+        apk::load_current_apk_discovery_snapshot,
+    )
+    .await
 }
 
 #[tauri::command]
-fn load_managed_apk_library_snapshot(
-) -> Result<library::ManagedApkLibrarySnapshot, String> {
-    library::load_current_managed_apk_library_snapshot()
+async fn inspect_manual_apk_path(
+    input: apk::ManualApkPathInput,
+) -> Result<apk::ApkCandidate, String> {
+    run_blocking("checking the selected game or app", move || {
+        apk::inspect_manual_apk_path(input)
+    })
+    .await
 }
 
 #[tauri::command]
-fn import_apk_to_managed_library(
+async fn load_managed_apk_library_snapshot() -> Result<library::ManagedApkLibrarySnapshot, String> {
+    run_blocking(
+        "loading the saved game and app library",
+        library::load_current_managed_apk_library_snapshot,
+    )
+    .await
+}
+
+#[tauri::command]
+async fn import_apk_to_managed_library(
     input: library::ManagedApkLibraryImportInput,
 ) -> Result<library::ManagedApkLibraryImportResult, String> {
-    library::import_apk_to_managed_library(input)
+    run_blocking("saving a copy of that game or app", move || {
+        library::import_apk_to_managed_library(input)
+    })
+    .await
 }
 
 #[tauri::command]
-fn install_apk_to_connected_board(
+async fn install_apk_to_connected_board(
     input: actions::InstallApkInput,
 ) -> Result<actions::InstallApkResult, String> {
-    actions::install_apk_to_connected_board(input)
+    run_blocking("installing the game or app on Board", move || {
+        actions::install_apk_to_connected_board(input)
+    })
+    .await
 }
 
 #[tauri::command]
-fn uninstall_installed_title_from_board(
+async fn uninstall_installed_title_from_board(
     input: actions::UninstallInstalledTitleInput,
 ) -> Result<actions::UninstallInstalledTitleResult, String> {
-    actions::uninstall_installed_title_from_board(input)
+    run_blocking("removing the title from Board", move || {
+        actions::uninstall_installed_title_from_board(input)
+    })
+    .await
 }
 
 #[tauri::command]
-fn launch_installed_title_on_board(
+async fn launch_installed_title_on_board(
     input: actions::LaunchInstalledTitleInput,
 ) -> Result<actions::LaunchInstalledTitleResult, String> {
-    actions::launch_installed_title_on_board(input)
+    run_blocking("opening the title on Board", move || {
+        actions::launch_installed_title_on_board(input)
+    })
+    .await
 }
 
 #[tauri::command]
-fn load_bdb_source_plan() -> bdb::BdbSourcePlan {
-    bdb::resolve_current_bdb_source_plan()
+async fn load_bdb_source_plan() -> Result<bdb::BdbSourcePlan, String> {
+    run_blocking("loading Board install tool support details", || {
+        Ok(bdb::resolve_current_bdb_source_plan())
+    })
+    .await
 }
 
 #[tauri::command]
-fn load_bdb_tool_state() -> Result<bdb_tool::BdbToolState, String> {
-    bdb_tool::load_current_bdb_tool_state()
+async fn load_bdb_tool_state() -> Result<bdb_tool::BdbToolState, String> {
+    run_blocking(
+        "checking the Board install tool",
+        bdb_tool::load_current_bdb_tool_state,
+    )
+    .await
 }
 
 #[tauri::command]
-fn refresh_bdb_tool_state() -> Result<bdb_tool::BdbToolState, String> {
-    bdb_tool::load_current_bdb_tool_state_with_remote_refresh(true)
+async fn refresh_bdb_tool_state() -> Result<bdb_tool::BdbToolState, String> {
+    run_blocking("checking for Board install tool updates", || {
+        bdb_tool::load_current_bdb_tool_state_with_remote_refresh(true)
+    })
+    .await
 }
 
 #[tauri::command]
-fn acquire_bdb_tool(repair: bool) -> Result<bdb_tool::BdbAcquisitionResult, String> {
-    bdb_tool::acquire_current_bdb_tool(repair)
+async fn acquire_bdb_tool(repair: bool) -> Result<bdb_tool::BdbAcquisitionResult, String> {
+    run_blocking("downloading the Board install tool", move || {
+        bdb_tool::acquire_current_bdb_tool(repair)
+    })
+    .await
 }
 
 #[tauri::command]
-fn load_device_status_snapshot() -> Result<device::DeviceStatusSnapshot, String> {
-    device::load_current_device_status_snapshot()
+async fn load_device_status_snapshot() -> Result<device::DeviceStatusSnapshot, String> {
+    run_blocking(
+        "checking the Board connection",
+        device::load_current_device_status_snapshot,
+    )
+    .await
 }
 
 #[tauri::command]
-fn load_installed_titles_snapshot(
+async fn load_installed_titles_snapshot(
 ) -> Result<installed_titles::InstalledTitlesSnapshot, String> {
-    installed_titles::load_current_installed_titles_snapshot()
+    run_blocking(
+        "reading installed titles from Board",
+        installed_titles::load_current_installed_titles_snapshot,
+    )
+    .await
 }
 
 #[tauri::command]
-fn load_managed_storage_settings() -> Result<storage::ManagedStorageSettings, String> {
-    storage::load_managed_storage_settings()
+async fn load_managed_storage_settings() -> Result<storage::ManagedStorageSettings, String> {
+    run_blocking(
+        "loading storage settings",
+        storage::load_managed_storage_settings,
+    )
+    .await
 }
 
 #[tauri::command]
-fn load_desktop_settings() -> Result<storage::DesktopSettings, String> {
-    storage::load_desktop_settings()
+async fn load_desktop_settings() -> Result<storage::DesktopSettings, String> {
+    run_blocking("loading desktop settings", storage::load_desktop_settings).await
 }
 
 #[tauri::command]
-fn save_managed_storage_settings(
+async fn save_managed_storage_settings(
     overrides: storage::ManagedStorageOverridesInput,
 ) -> Result<storage::ManagedStorageSettings, String> {
-    storage::save_managed_storage_settings(overrides)
+    run_blocking("saving storage settings", move || {
+        storage::save_managed_storage_settings(overrides)
+    })
+    .await
 }
 
 #[tauri::command]
-fn save_desktop_settings(
+async fn save_desktop_settings(
     input: storage::DesktopSettingsInput,
 ) -> Result<storage::DesktopSettings, String> {
-    storage::save_desktop_settings(input)
+    run_blocking("saving desktop settings", move || {
+        storage::save_desktop_settings(input)
+    })
+    .await
+}
+
+#[tauri::command]
+fn complete_setup_wizard() -> Result<(), String> {
+    storage::save_setup_completed(true)
 }
 
 #[tauri::command]
@@ -129,6 +200,11 @@ fn open_about_window(app: tauri::AppHandle) -> Result<(), String> {
 }
 
 #[tauri::command]
+fn close_about_window(app: tauri::AppHandle) -> Result<(), String> {
+    shell::close_about_window(&app)
+}
+
+#[tauri::command]
 fn show_main_workspace_window(app: tauri::AppHandle) -> Result<(), String> {
     shell::show_main_workspace_window(&app)
 }
@@ -136,6 +212,11 @@ fn show_main_workspace_window(app: tauri::AppHandle) -> Result<(), String> {
 #[tauri::command]
 fn dismiss_setup_wizard_window(app: tauri::AppHandle) -> Result<(), String> {
     shell::dismiss_setup_wizard_or_exit(&app)
+}
+
+#[tauri::command]
+fn finish_setup_wizard_window(app: tauri::AppHandle) -> Result<(), String> {
+    shell::finish_setup_wizard_window(&app)
 }
 
 #[tauri::command]
@@ -163,11 +244,6 @@ pub fn run() {
                 ))
             })
         })
-        .on_menu_event(|app, event| {
-            if let Err(error) = shell::handle_menu_event(app, event.id().as_ref()) {
-                eprintln!("BE Home for Desktop menu error: {error}");
-            }
-        })
         .invoke_handler(tauri::generate_handler![
             load_setup_gate_state,
             load_apk_discovery_snapshot,
@@ -187,11 +263,14 @@ pub fn run() {
             load_desktop_settings,
             save_managed_storage_settings,
             save_desktop_settings,
+            complete_setup_wizard,
             open_setup_wizard_window,
             open_settings_window,
             open_about_window,
+            close_about_window,
             show_main_workspace_window,
             dismiss_setup_wizard_window,
+            finish_setup_wizard_window,
             emit_settings_updated,
             exit_application
         ])
@@ -201,10 +280,15 @@ pub fn run() {
 
 #[cfg(test)]
 mod tests {
+    use std::future::Future;
+
+    fn run_command<T>(future: impl Future<Output = Result<T, String>>) -> T {
+        tauri::async_runtime::block_on(future).expect("command should complete successfully")
+    }
+
     #[test]
     fn setup_gate_state_serializes_the_bootstrap_contract() {
-        let state =
-            super::load_setup_gate_state().expect("setup gate state should load successfully");
+        let state = run_command(super::load_setup_gate_state());
         let serialized =
             serde_json::to_value(state).expect("setup gate state should serialize successfully");
 
@@ -217,8 +301,7 @@ mod tests {
 
     #[test]
     fn apk_discovery_snapshot_serializes_the_discovery_contract() {
-        let snapshot = super::load_apk_discovery_snapshot()
-            .expect("apk discovery snapshot should load successfully");
+        let snapshot = run_command(super::load_apk_discovery_snapshot());
         let serialized =
             serde_json::to_value(snapshot).expect("apk discovery snapshot should serialize");
 
@@ -229,8 +312,7 @@ mod tests {
 
     #[test]
     fn managed_apk_library_snapshot_serializes_the_library_contract() {
-        let snapshot = super::load_managed_apk_library_snapshot()
-            .expect("managed APK library snapshot should load successfully");
+        let snapshot = run_command(super::load_managed_apk_library_snapshot());
         let serialized =
             serde_json::to_value(snapshot).expect("managed APK library snapshot should serialize");
 
@@ -241,7 +323,7 @@ mod tests {
 
     #[test]
     fn bdb_source_plan_uses_the_supported_manifest_contract() {
-        let plan = super::load_bdb_source_plan();
+        let plan = run_command(super::load_bdb_source_plan());
         let serialized = serde_json::to_value(plan).expect("bdb source plan should serialize");
 
         assert!(serialized
@@ -260,7 +342,7 @@ mod tests {
 
     #[test]
     fn managed_storage_settings_serialize_with_distinct_tool_and_library_locations() {
-        let settings = super::load_managed_storage_settings().expect("managed storage should load");
+        let settings = run_command(super::load_managed_storage_settings());
         let serialized =
             serde_json::to_value(settings).expect("managed storage settings should serialize");
 
@@ -277,7 +359,7 @@ mod tests {
 
     #[test]
     fn desktop_settings_serialize_with_scan_folders_and_bdb_path() {
-        let settings = super::load_desktop_settings().expect("desktop settings should load");
+        let settings = run_command(super::load_desktop_settings());
         let serialized = serde_json::to_value(settings).expect("desktop settings should serialize");
 
         assert!(serialized.get("scanFolders").is_some());
@@ -286,7 +368,7 @@ mod tests {
 
     #[test]
     fn bdb_tool_state_serializes_the_host_side_status_contract() {
-        let state = super::load_bdb_tool_state().expect("bdb tool state should load");
+        let state = run_command(super::load_bdb_tool_state());
         let serialized = serde_json::to_value(state).expect("bdb tool state should serialize");
 
         assert!(serialized.get("status").is_some());
@@ -300,8 +382,7 @@ mod tests {
 
     #[test]
     fn device_status_snapshot_serializes_the_runtime_contract() {
-        let snapshot =
-            super::load_device_status_snapshot().expect("device status snapshot should load");
+        let snapshot = run_command(super::load_device_status_snapshot());
         let serialized =
             serde_json::to_value(snapshot).expect("device status snapshot should serialize");
 
@@ -316,8 +397,7 @@ mod tests {
 
     #[test]
     fn installed_titles_snapshot_serializes_the_inventory_contract() {
-        let snapshot = super::load_installed_titles_snapshot()
-            .expect("installed titles snapshot should load");
+        let snapshot = run_command(super::load_installed_titles_snapshot());
         let serialized =
             serde_json::to_value(snapshot).expect("installed titles snapshot should serialize");
 

--- a/src-tauri/src/library.rs
+++ b/src-tauri/src/library.rs
@@ -104,7 +104,12 @@ pub(crate) fn import_apk_to_managed_library(
     let library_root = PathBuf::from(&settings.apk_library.effective_path);
     let manifest_path = resolve_library_manifest_path()?;
 
-    import_apk_to_managed_library_at(&manifest_path, &library_root, &source_path, source_candidate)
+    import_apk_to_managed_library_at(
+        &manifest_path,
+        &library_root,
+        &source_path,
+        source_candidate,
+    )
 }
 
 fn import_apk_to_managed_library_at(
@@ -120,7 +125,8 @@ fn import_apk_to_managed_library_at(
         .items
         .iter()
         .find(|item| {
-            item.stable_id == derived_stable_id || path_identity_key(&item.managed_path) == source_key
+            item.stable_id == derived_stable_id
+                || path_identity_key(&item.managed_path) == source_key
         })
         .cloned();
     let stable_id = existing_item
@@ -136,7 +142,9 @@ fn import_apk_to_managed_library_at(
         library_root,
         &source_candidate.file_name,
         source_path,
-        existing_item.as_ref().map(|item| item.managed_path.as_str()),
+        existing_item
+            .as_ref()
+            .map(|item| item.managed_path.as_str()),
         &occupied_managed_paths,
     );
     let managed_path_string = path_to_string(&managed_path);
@@ -190,9 +198,15 @@ fn import_apk_to_managed_library_at(
 
     Ok(ManagedApkLibraryImportResult {
         summary: if source_and_destination_match {
-            format!("BE Home added {} to the managed APK library.", item.file_name)
+            format!(
+                "BE Home added {} to the managed APK library.",
+                item.file_name
+            )
         } else {
-            format!("BE Home copied {} into the managed APK library.", item.file_name)
+            format!(
+                "BE Home copied {} into the managed APK library.",
+                item.file_name
+            )
         },
         guidance: if source_and_destination_match {
             "The APK was already inside the managed library folder, so BE Home kept it in place and added it to the reusable inventory."
@@ -218,7 +232,11 @@ fn build_library_snapshot(
         right
             .imported_at_unix_ms
             .cmp(&left.imported_at_unix_ms)
-            .then_with(|| left.file_name.to_ascii_lowercase().cmp(&right.file_name.to_ascii_lowercase()))
+            .then_with(|| {
+                left.file_name
+                    .to_ascii_lowercase()
+                    .cmp(&right.file_name.to_ascii_lowercase())
+            })
             .then_with(|| left.managed_path.cmp(&right.managed_path))
     });
 
@@ -442,8 +460,7 @@ const fn library_manifest_schema_version() -> u32 {
 mod tests {
     use super::{
         build_library_snapshot, import_apk_to_managed_library_at, load_persisted_library_manifest,
-        ManagedApkLibraryImportResult, ManagedApkLibraryStatus,
-        PersistedManagedApkLibraryManifest,
+        ManagedApkLibraryImportResult, ManagedApkLibraryStatus, PersistedManagedApkLibraryManifest,
     };
     use std::fs::{self, File};
     use std::io::Write;
@@ -454,7 +471,10 @@ mod tests {
     #[test]
     fn import_copies_the_apk_into_the_managed_library_and_keeps_the_source_file() {
         let temp_directory = tempfile::tempdir().expect("temporary directory should exist");
-        let manifest_path = temp_directory.path().join("settings").join("managed-apk-library.json");
+        let manifest_path = temp_directory
+            .path()
+            .join("settings")
+            .join("managed-apk-library.json");
         let library_root = temp_directory.path().join("apk-library");
         let source_root = temp_directory.path().join("downloads");
         fs::create_dir_all(&source_root).expect("source root should exist");
@@ -480,7 +500,10 @@ mod tests {
     #[test]
     fn import_reuses_the_existing_manifest_entry_for_the_same_source_path() {
         let temp_directory = tempfile::tempdir().expect("temporary directory should exist");
-        let manifest_path = temp_directory.path().join("settings").join("managed-apk-library.json");
+        let manifest_path = temp_directory
+            .path()
+            .join("settings")
+            .join("managed-apk-library.json");
         let library_root = temp_directory.path().join("apk-library");
         let source_root = temp_directory.path().join("downloads");
         fs::create_dir_all(&source_root).expect("source root should exist");
@@ -491,7 +514,10 @@ mod tests {
         let second_result = import_candidate(&manifest_path, &library_root, &source_path);
 
         assert_eq!(first_result.item.stable_id, second_result.item.stable_id);
-        assert_eq!(first_result.item.managed_path, second_result.item.managed_path);
+        assert_eq!(
+            first_result.item.managed_path,
+            second_result.item.managed_path
+        );
 
         let manifest =
             load_persisted_library_manifest(&manifest_path).expect("manifest should load");
@@ -501,7 +527,10 @@ mod tests {
     #[test]
     fn import_reusing_a_managed_copy_keeps_one_library_entry() {
         let temp_directory = tempfile::tempdir().expect("temporary directory should exist");
-        let manifest_path = temp_directory.path().join("settings").join("managed-apk-library.json");
+        let manifest_path = temp_directory
+            .path()
+            .join("settings")
+            .join("managed-apk-library.json");
         let library_root = temp_directory.path().join("apk-library");
         let source_root = temp_directory.path().join("downloads");
         fs::create_dir_all(&source_root).expect("source root should exist");
@@ -513,7 +542,10 @@ mod tests {
         let second_result = import_candidate(&manifest_path, &library_root, &managed_copy_path);
 
         assert_eq!(first_result.item.stable_id, second_result.item.stable_id);
-        assert_eq!(first_result.item.managed_path, second_result.item.managed_path);
+        assert_eq!(
+            first_result.item.managed_path,
+            second_result.item.managed_path
+        );
         assert_eq!(
             first_result.item.original_source_path,
             second_result.item.original_source_path
@@ -527,7 +559,10 @@ mod tests {
             first_result.item.original_source_path,
             manifest.items[0].original_source_path
         );
-        assert_eq!(first_result.item.managed_path, manifest.items[0].managed_path);
+        assert_eq!(
+            first_result.item.managed_path,
+            manifest.items[0].managed_path
+        );
     }
 
     #[test]
@@ -556,7 +591,10 @@ mod tests {
     #[test]
     fn import_tracks_confidence_package_and_timestamps() {
         let temp_directory = tempfile::tempdir().expect("temporary directory should exist");
-        let manifest_path = temp_directory.path().join("settings").join("managed-apk-library.json");
+        let manifest_path = temp_directory
+            .path()
+            .join("settings")
+            .join("managed-apk-library.json");
         let library_root = temp_directory.path().join("apk-library");
         let source_root = temp_directory.path().join("downloads");
         fs::create_dir_all(&source_root).expect("source root should exist");
@@ -569,7 +607,10 @@ mod tests {
             Some("fun.board.familymatch"),
             result.item.package_name.as_deref()
         );
-        assert_eq!(crate::apk::ApkConfidence::PossibleMatch, result.item.confidence);
+        assert_eq!(
+            crate::apk::ApkConfidence::PossibleMatch,
+            result.item.confidence
+        );
         assert!(result.item.imported_at_unix_ms > 0);
         assert!(result.item.source_modified_at_unix_ms.is_some());
         assert!(result.item.managed_modified_at_unix_ms.is_some());
@@ -589,8 +630,7 @@ mod tests {
     fn write_apk(path: &Path, include_strong_marker: bool, package_name: &str) {
         let file = File::create(path).expect("apk file should create");
         let mut writer = ZipWriter::new(file);
-        let options =
-            SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
+        let options = SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
 
         writer
             .start_file("AndroidManifest.xml", options)

--- a/src-tauri/src/process_runner.rs
+++ b/src-tauri/src/process_runner.rs
@@ -1,0 +1,91 @@
+use std::io;
+use std::path::Path;
+use std::process::{Command, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+
+#[derive(Clone, Debug)]
+pub(crate) struct ProcessCommandOutput {
+    pub(crate) exit_code: Option<i32>,
+    pub(crate) stdout: String,
+    pub(crate) stderr: String,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ProcessCommandFailureKind {
+    PermissionDenied,
+    NotFound,
+    TimedOut,
+    Other,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct ProcessCommandFailure {
+    pub(crate) kind: ProcessCommandFailureKind,
+    pub(crate) detail: String,
+}
+
+pub(crate) fn run_with_timeout(
+    executable_path: &Path,
+    args: &[&str],
+    timeout: Duration,
+) -> Result<ProcessCommandOutput, ProcessCommandFailure> {
+    let mut child = Command::new(executable_path)
+        .args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(classify_process_failure)?;
+    let started_at = Instant::now();
+
+    loop {
+        match child.try_wait() {
+            Ok(Some(_status)) => {
+                let output = child.wait_with_output().map_err(classify_process_failure)?;
+                return Ok(ProcessCommandOutput {
+                    exit_code: output.status.code(),
+                    stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+                    stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+                });
+            }
+            Ok(None) if started_at.elapsed() >= timeout => {
+                let _ = child.kill();
+                let _ = child.wait_with_output();
+                return Err(ProcessCommandFailure {
+                    kind: ProcessCommandFailureKind::TimedOut,
+                    detail: format!(
+                        "`{}` did not finish within {} seconds.",
+                        build_command_string(executable_path, args),
+                        timeout.as_secs()
+                    ),
+                });
+            }
+            Ok(None) => thread::sleep(Duration::from_millis(25)),
+            Err(error) => {
+                let _ = child.kill();
+                let _ = child.wait_with_output();
+                return Err(classify_process_failure(error));
+            }
+        }
+    }
+}
+
+fn classify_process_failure(error: io::Error) -> ProcessCommandFailure {
+    let detail = error.to_string();
+    let kind = match error.kind() {
+        io::ErrorKind::PermissionDenied => ProcessCommandFailureKind::PermissionDenied,
+        io::ErrorKind::NotFound => ProcessCommandFailureKind::NotFound,
+        _ => ProcessCommandFailureKind::Other,
+    };
+
+    ProcessCommandFailure { kind, detail }
+}
+
+fn build_command_string(executable_path: &Path, args: &[&str]) -> String {
+    let suffix = args.join(" ");
+    if suffix.is_empty() {
+        executable_path.display().to_string()
+    } else {
+        format!("{} {suffix}", executable_path.display())
+    }
+}

--- a/src-tauri/src/setup.rs
+++ b/src-tauri/src/setup.rs
@@ -40,6 +40,7 @@ pub(crate) struct SetupGateState {
 /// Load the current setup-gate state used to decide whether the app can open the workspace.
 pub(crate) fn load_setup_gate_state() -> Result<SetupGateState, String> {
     let desktop_settings = storage::load_desktop_settings()?;
+    let setup_completed = storage::load_setup_completed()?;
     let tool_state = bdb_tool::load_current_bdb_tool_state()?;
 
     Ok(build_setup_gate_state(
@@ -55,6 +56,7 @@ pub(crate) fn load_setup_gate_state() -> Result<SetupGateState, String> {
             .iter()
             .map(|folder| folder.path.clone())
             .collect(),
+        setup_completed,
     ))
 }
 
@@ -62,6 +64,7 @@ fn build_setup_gate_state(
     tool_state: bdb_tool::BdbToolState,
     storage: storage::ManagedStorageSettings,
     default_scan_folders: Vec<String>,
+    setup_completed: bool,
 ) -> SetupGateState {
     let (status, required_step, summary, guidance) = match tool_state.status {
         bdb_tool::BdbToolStatus::Unsupported => (
@@ -69,13 +72,6 @@ fn build_setup_gate_state(
             SetupRequiredStep::SystemCheck,
             "This computer cannot complete the Board install-tool setup yet.".into(),
             tool_state.guidance.clone(),
-        ),
-        bdb_tool::BdbToolStatus::Runnable => (
-            SetupGateStatus::Ready,
-            SetupRequiredStep::Workspace,
-            "Board's install tool is ready, so BE Home can open your desktop workspace."
-                .into(),
-            "You can come back to repair the install tool later if anything changes.".into(),
         ),
         bdb_tool::BdbToolStatus::Missing => (
             SetupGateStatus::RequiresSetup,
@@ -90,6 +86,19 @@ fn build_setup_gate_state(
             "BE Home found Board's install tool, but it still needs attention before installs can start."
                 .into(),
             tool_state.guidance.clone(),
+        ),
+        bdb_tool::BdbToolStatus::Runnable if !setup_completed => (
+            SetupGateStatus::RequiresSetup,
+            SetupRequiredStep::Workspace,
+            "BE Home still needs you to finish setup before the workspace can open.".into(),
+            "Finish setup to confirm where BE Home should look for games and apps and where saved copies should live on this computer.".into(),
+        ),
+        bdb_tool::BdbToolStatus::Runnable => (
+            SetupGateStatus::Ready,
+            SetupRequiredStep::Workspace,
+            "Board's install tool is ready, so BE Home can open your desktop workspace."
+                .into(),
+            "You can come back to repair the install tool later if anything changes.".into(),
         ),
     };
 
@@ -142,6 +151,7 @@ mod tests {
             sample_tool_state(BdbToolStatus::Missing, BdbRunnableStatus::Missing),
             sample_storage_settings(),
             vec!["/tmp/Downloads".into()],
+            false,
         );
 
         assert_eq!(SetupGateStatus::RequiresSetup, state.status);
@@ -154,6 +164,7 @@ mod tests {
             sample_tool_state(BdbToolStatus::Runnable, BdbRunnableStatus::Runnable),
             sample_storage_settings(),
             vec!["/tmp/Downloads".into()],
+            true,
         );
 
         assert_eq!(SetupGateStatus::Ready, state.status);
@@ -166,10 +177,24 @@ mod tests {
             sample_tool_state(BdbToolStatus::Unsupported, BdbRunnableStatus::Unsupported),
             sample_storage_settings(),
             Vec::new(),
+            false,
         );
 
         assert_eq!(SetupGateStatus::Unsupported, state.status);
         assert_eq!(SetupRequiredStep::SystemCheck, state.required_step);
+    }
+
+    #[test]
+    fn runnable_tool_stays_in_setup_until_the_wizard_is_finished() {
+        let state = build_setup_gate_state(
+            sample_tool_state(BdbToolStatus::Runnable, BdbRunnableStatus::Runnable),
+            sample_storage_settings(),
+            vec!["/tmp/Downloads".into()],
+            false,
+        );
+
+        assert_eq!(SetupGateStatus::RequiresSetup, state.status);
+        assert_eq!(SetupRequiredStep::Workspace, state.required_step);
     }
 
     fn sample_tool_state(

--- a/src-tauri/src/shell.rs
+++ b/src-tauri/src/shell.rs
@@ -1,37 +1,15 @@
 use crate::setup::{self, SetupGateStatus};
-use serde::Serialize;
-use tauri::menu::{MenuBuilder, MenuItem, SubmenuBuilder};
-use tauri::{AppHandle, Emitter, Manager, Runtime, WebviewUrl, WebviewWindow, WebviewWindowBuilder};
+use std::path::PathBuf;
+use tauri::{
+    AppHandle, Emitter, Manager, Runtime, WebviewUrl, WebviewWindow, WebviewWindowBuilder,
+};
 
 pub(crate) const MAIN_WINDOW_LABEL: &str = "main";
 pub(crate) const SETUP_WIZARD_WINDOW_LABEL: &str = "setup-wizard";
 pub(crate) const SETTINGS_WINDOW_LABEL: &str = "settings";
 pub(crate) const ABOUT_WINDOW_LABEL: &str = "about";
 
-pub(crate) const MAIN_WORKSPACE_NAVIGATE_EVENT: &str = "desktop-shell://navigate";
-pub(crate) const MAIN_WORKSPACE_RESCAN_EVENT: &str = "desktop-shell://rescan-games-and-apps";
 pub(crate) const SETTINGS_UPDATED_EVENT: &str = "desktop-shell://settings-updated";
-
-const MENU_FILE_SETUP_WIZARD: &str = "shell.file.setupWizard";
-const MENU_FILE_SETTINGS: &str = "shell.file.settings";
-const MENU_FILE_EXIT: &str = "shell.file.exit";
-const MENU_VIEW_GAMES_AND_APPS: &str = "shell.view.gamesAndApps";
-const MENU_VIEW_INSTALLED_ON_BOARD: &str = "shell.view.installedOnBoard";
-const MENU_VIEW_RESCAN_GAMES_AND_APPS: &str = "shell.view.rescanGamesAndApps";
-const MENU_HELP_ABOUT: &str = "shell.help.about";
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub(crate) enum MainWorkspaceTarget {
-    GamesAndApps,
-    InstalledOnBoard,
-}
-
-#[derive(Clone, Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub(crate) struct MainWorkspaceNavigationEvent {
-    pub(crate) target: MainWorkspaceTarget,
-}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum StartupMode {
@@ -40,9 +18,6 @@ enum StartupMode {
 }
 
 pub(crate) fn initialize_native_shell<R: Runtime>(app: &AppHandle<R>) -> Result<(), String> {
-    let menu = build_app_menu(app)?;
-    app.set_menu(menu)
-        .map_err(|error| format!("failed to register the app menu: {error}"))?;
     sync_shell_to_setup_state(app)
 }
 
@@ -63,42 +38,74 @@ pub(crate) fn sync_shell_to_setup_state<R: Runtime>(app: &AppHandle<R>) -> Resul
 }
 
 pub(crate) fn open_setup_wizard_window<R: Runtime>(app: &AppHandle<R>) -> Result<(), String> {
+    let setup_state = setup::load_setup_gate_state()?;
+    let parent_label = if setup_state.status == SetupGateStatus::Ready {
+        Some(MAIN_WINDOW_LABEL)
+    } else {
+        None
+    };
+
     show_or_focus_window(
         app,
-        SETUP_WIZARD_WINDOW_LABEL,
-        "Setup Wizard",
-        920.0,
-        760.0,
-        700.0,
-        620.0,
-        true,
+        WindowPresentation {
+            label: SETUP_WIZARD_WINDOW_LABEL,
+            title: "BE Home for Desktop",
+            width: 920.0,
+            height: 760.0,
+            min_width: 700.0,
+            min_height: 620.0,
+            resizable: true,
+            maximizable: false,
+            minimizable: false,
+            skip_taskbar: parent_label.is_some(),
+            always_on_top: true,
+            parent_label,
+        },
     )
 }
 
 pub(crate) fn open_settings_window<R: Runtime>(app: &AppHandle<R>) -> Result<(), String> {
     show_or_focus_window(
         app,
-        SETTINGS_WINDOW_LABEL,
-        "Settings",
-        980.0,
-        820.0,
-        760.0,
-        620.0,
-        true,
+        WindowPresentation {
+            label: SETTINGS_WINDOW_LABEL,
+            title: "BE Home for Desktop",
+            width: 980.0,
+            height: 820.0,
+            min_width: 760.0,
+            min_height: 620.0,
+            resizable: true,
+            maximizable: false,
+            minimizable: false,
+            skip_taskbar: true,
+            always_on_top: true,
+            parent_label: Some(MAIN_WINDOW_LABEL),
+        },
     )
 }
 
 pub(crate) fn open_about_window<R: Runtime>(app: &AppHandle<R>) -> Result<(), String> {
     show_or_focus_window(
         app,
-        ABOUT_WINDOW_LABEL,
-        "About BE Home for Desktop",
-        560.0,
-        440.0,
-        420.0,
-        320.0,
-        false,
+        WindowPresentation {
+            label: ABOUT_WINDOW_LABEL,
+            title: "About BE Home for Desktop",
+            width: 520.0,
+            height: 420.0,
+            min_width: 420.0,
+            min_height: 320.0,
+            resizable: false,
+            maximizable: false,
+            minimizable: false,
+            skip_taskbar: true,
+            always_on_top: false,
+            parent_label: Some(MAIN_WINDOW_LABEL),
+        },
     )
+}
+
+pub(crate) fn close_about_window<R: Runtime>(app: &AppHandle<R>) -> Result<(), String> {
+    close_window_if_open(app, ABOUT_WINDOW_LABEL)
 }
 
 pub(crate) fn show_main_workspace_window<R: Runtime>(app: &AppHandle<R>) -> Result<(), String> {
@@ -129,98 +136,101 @@ pub(crate) fn dismiss_setup_wizard_or_exit<R: Runtime>(app: &AppHandle<R>) -> Re
     Ok(())
 }
 
+pub(crate) fn finish_setup_wizard_window<R: Runtime>(app: &AppHandle<R>) -> Result<(), String> {
+    crate::storage::save_setup_completed(true)?;
+    close_window_if_open(app, SETUP_WIZARD_WINDOW_LABEL)?;
+    show_main_workspace_window(app)?;
+    emit_settings_updated(app)
+}
+
 pub(crate) fn emit_settings_updated<R: Runtime>(app: &AppHandle<R>) -> Result<(), String> {
     app.emit_to(MAIN_WINDOW_LABEL, SETTINGS_UPDATED_EVENT, ())
-        .map_err(|error| format!("failed to notify the main workspace about settings changes: {error}"))
+        .map_err(|error| {
+            format!("failed to notify the main workspace about settings changes: {error}")
+        })
 }
 
-pub(crate) fn handle_menu_event<R: Runtime>(app: &AppHandle<R>, menu_id: &str) -> Result<(), String> {
-    match menu_id {
-        MENU_FILE_SETUP_WIZARD => open_setup_wizard_window(app),
-        MENU_FILE_SETTINGS => open_settings_window(app),
-        MENU_HELP_ABOUT => open_about_window(app),
-        MENU_FILE_EXIT => {
-            app.exit(0);
-            Ok(())
-        }
-        MENU_VIEW_GAMES_AND_APPS => navigate_main_workspace(app, MainWorkspaceTarget::GamesAndApps),
-        MENU_VIEW_INSTALLED_ON_BOARD => {
-            navigate_main_workspace(app, MainWorkspaceTarget::InstalledOnBoard)
-        }
-        MENU_VIEW_RESCAN_GAMES_AND_APPS => rescan_games_and_apps(app),
-        _ => Ok(()),
-    }
-}
-
-fn navigate_main_workspace<R: Runtime>(
-    app: &AppHandle<R>,
-    target: MainWorkspaceTarget,
-) -> Result<(), String> {
-    let setup_state = setup::load_setup_gate_state()?;
-    if setup_state.status != SetupGateStatus::Ready {
-        return open_setup_wizard_window(app);
-    }
-
-    show_main_workspace_window(app)?;
-    app.emit_to(
-        MAIN_WINDOW_LABEL,
-        MAIN_WORKSPACE_NAVIGATE_EVENT,
-        MainWorkspaceNavigationEvent { target },
-    )
-    .map_err(|error| format!("failed to navigate the main workspace: {error}"))
-}
-
-fn rescan_games_and_apps<R: Runtime>(app: &AppHandle<R>) -> Result<(), String> {
-    let setup_state = setup::load_setup_gate_state()?;
-    if setup_state.status != SetupGateStatus::Ready {
-        return open_setup_wizard_window(app);
-    }
-
-    show_main_workspace_window(app)?;
-    app.emit_to(MAIN_WINDOW_LABEL, MAIN_WORKSPACE_RESCAN_EVENT, ())
-        .map_err(|error| format!("failed to trigger a games-and-apps rescan: {error}"))
-}
-
-fn show_or_focus_window<R: Runtime>(
-    app: &AppHandle<R>,
-    label: &str,
-    title: &str,
+struct WindowPresentation<'a> {
+    label: &'a str,
+    title: &'a str,
     width: f64,
     height: f64,
     min_width: f64,
     min_height: f64,
     resizable: bool,
+    maximizable: bool,
+    minimizable: bool,
+    skip_taskbar: bool,
+    always_on_top: bool,
+    parent_label: Option<&'a str>,
+}
+
+fn show_or_focus_window<R: Runtime>(
+    app: &AppHandle<R>,
+    presentation: WindowPresentation<'_>,
 ) -> Result<(), String> {
-    if let Some(existing_window) = app.get_webview_window(label) {
+    if let Some(existing_window) = app.get_webview_window(presentation.label) {
         return show_and_focus_window(&existing_window);
     }
 
-    let created_window = WebviewWindowBuilder::new(app, label, WebviewUrl::App("index.html".into()))
-        .title(title)
-        .inner_size(width, height)
-        .min_inner_size(min_width, min_height)
-        .resizable(resizable)
-        .center()
-        .build()
-        .map_err(|error| format!("failed to build the `{label}` window: {error}"))?;
+    let mut builder = WebviewWindowBuilder::new(
+        app,
+        presentation.label,
+        app_url_for_label(presentation.label),
+    )
+    .title(presentation.title)
+    .inner_size(presentation.width, presentation.height)
+    .min_inner_size(presentation.min_width, presentation.min_height)
+    .resizable(presentation.resizable)
+    .maximizable(presentation.maximizable)
+    .minimizable(presentation.minimizable)
+    .closable(true)
+    .skip_taskbar(presentation.skip_taskbar)
+    .always_on_top(presentation.always_on_top)
+    .decorations(true)
+    .center();
+
+    if let Some(parent_label) = presentation.parent_label {
+        let parent_window = app
+            .get_webview_window(parent_label)
+            .ok_or_else(|| format!("the `{parent_label}` window is unavailable"))?;
+        builder = builder.parent(&parent_window).map_err(|error| {
+            format!("failed to set `{parent_label}` as the owner window: {error}")
+        })?;
+    }
+
+    let created_window = builder.build().map_err(|error| {
+        format!(
+            "failed to build the `{}` window: {error}",
+            presentation.label
+        )
+    })?;
 
     show_and_focus_window(&created_window)
 }
 
+fn app_url_for_label(_label: &str) -> WebviewUrl {
+    WebviewUrl::App(PathBuf::from("index.html"))
+}
+
 fn show_and_focus_window<R: Runtime>(window: &WebviewWindow<R>) -> Result<(), String> {
-    if window
-        .is_minimized()
-        .map_err(|error| format!("failed to inspect the `{}` window state: {error}", window.label()))?
-    {
-        window
-            .unminimize()
-            .map_err(|error| format!("failed to restore the `{}` window: {error}", window.label()))?;
+    if window.is_minimized().map_err(|error| {
+        format!(
+            "failed to inspect the `{}` window state: {error}",
+            window.label()
+        )
+    })? {
+        window.unminimize().map_err(|error| {
+            format!("failed to restore the `{}` window: {error}", window.label())
+        })?;
     }
 
-    if !window
-        .is_visible()
-        .map_err(|error| format!("failed to inspect the `{}` visibility: {error}", window.label()))?
-    {
+    if !window.is_visible().map_err(|error| {
+        format!(
+            "failed to inspect the `{}` visibility: {error}",
+            window.label()
+        )
+    })? {
         window
             .show()
             .map_err(|error| format!("failed to show the `{}` window: {error}", window.label()))?;
@@ -234,90 +244,25 @@ fn show_and_focus_window<R: Runtime>(window: &WebviewWindow<R>) -> Result<(), St
 fn close_window_if_open<R: Runtime>(app: &AppHandle<R>, label: &str) -> Result<(), String> {
     if let Some(window) = app.get_webview_window(label) {
         window
-            .close()
+            .destroy()
             .map_err(|error| format!("failed to close the `{label}` window: {error}"))?;
     }
 
     Ok(())
 }
 
-fn build_app_menu<R: Runtime>(app: &AppHandle<R>) -> Result<tauri::menu::Menu<R>, String> {
-    let setup_wizard_item =
-        MenuItem::with_id(app, MENU_FILE_SETUP_WIZARD, "Setup Wizard...", true, None::<&str>)
-            .map_err(|error| format!("failed to create the setup wizard menu item: {error}"))?;
-    let settings_item =
-        MenuItem::with_id(app, MENU_FILE_SETTINGS, "Settings...", true, Some("CmdOrCtrl+,"))
-            .map_err(|error| format!("failed to create the settings menu item: {error}"))?;
-    let exit_item = MenuItem::with_id(app, MENU_FILE_EXIT, "Exit", true, None::<&str>)
-        .map_err(|error| format!("failed to create the exit menu item: {error}"))?;
-    let games_and_apps_item = MenuItem::with_id(
-        app,
-        MENU_VIEW_GAMES_AND_APPS,
-        "Games && Apps",
-        true,
-        None::<&str>,
-    )
-    .map_err(|error| format!("failed to create the Games & Apps menu item: {error}"))?;
-    let installed_on_board_item = MenuItem::with_id(
-        app,
-        MENU_VIEW_INSTALLED_ON_BOARD,
-        "Installed on Board",
-        true,
-        None::<&str>,
-    )
-    .map_err(|error| format!("failed to create the Installed on Board menu item: {error}"))?;
-    let rescan_games_and_apps_item = MenuItem::with_id(
-        app,
-        MENU_VIEW_RESCAN_GAMES_AND_APPS,
-        "Rescan Games && Apps",
-        true,
-        None::<&str>,
-    )
-    .map_err(|error| format!("failed to create the rescan menu item: {error}"))?;
-    let about_item =
-        MenuItem::with_id(app, MENU_HELP_ABOUT, "About BE Home for Desktop", true, None::<&str>)
-            .map_err(|error| format!("failed to create the About menu item: {error}"))?;
-
-    let file_menu = SubmenuBuilder::new(app, "File")
-        .item(&setup_wizard_item)
-        .item(&settings_item)
-        .separator()
-        .item(&exit_item)
-        .build()
-        .map_err(|error| format!("failed to build the File menu: {error}"))?;
-    let view_menu = SubmenuBuilder::new(app, "View")
-        .item(&games_and_apps_item)
-        .item(&installed_on_board_item)
-        .separator()
-        .item(&rescan_games_and_apps_item)
-        .build()
-        .map_err(|error| format!("failed to build the View menu: {error}"))?;
-    let help_menu = SubmenuBuilder::new(app, "Help")
-        .item(&about_item)
-        .build()
-        .map_err(|error| format!("failed to build the Help menu: {error}"))?;
-
-    MenuBuilder::new(app)
-        .item(&file_menu)
-        .item(&view_menu)
-        .item(&help_menu)
-        .build()
-        .map_err(|error| format!("failed to build the application menu: {error}"))
-}
-
 fn startup_mode_for_status(status: SetupGateStatus) -> StartupMode {
     match status {
         SetupGateStatus::Ready => StartupMode::ShowMainWorkspace,
-        SetupGateStatus::RequiresSetup | SetupGateStatus::Unsupported => StartupMode::OpenSetupWizard,
+        SetupGateStatus::RequiresSetup | SetupGateStatus::Unsupported => {
+            StartupMode::OpenSetupWizard
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        startup_mode_for_status, MainWorkspaceTarget, StartupMode, MENU_VIEW_GAMES_AND_APPS,
-        MENU_VIEW_INSTALLED_ON_BOARD,
-    };
+    use super::{app_url_for_label, startup_mode_for_status, StartupMode};
     use crate::setup::SetupGateStatus;
 
     #[test]
@@ -341,16 +286,8 @@ mod tests {
     }
 
     #[test]
-    fn menu_target_routes_stay_stable_for_the_main_workspace() {
-        assert_eq!("shell.view.gamesAndApps", MENU_VIEW_GAMES_AND_APPS);
-        assert_eq!(
-            MainWorkspaceTarget::GamesAndApps,
-            MainWorkspaceTarget::GamesAndApps
-        );
-        assert_eq!("shell.view.installedOnBoard", MENU_VIEW_INSTALLED_ON_BOARD);
-        assert_eq!(
-            MainWorkspaceTarget::InstalledOnBoard,
-            MainWorkspaceTarget::InstalledOnBoard
-        );
+    fn secondary_windows_load_the_bundled_renderer_document() {
+        assert_eq!("index.html", app_url_for_label("about").to_string());
+        assert_eq!("index.html", app_url_for_label("setup-wizard").to_string());
     }
 }

--- a/src-tauri/src/storage.rs
+++ b/src-tauri/src/storage.rs
@@ -111,6 +111,7 @@ struct PersistedDesktopSettings {
     apk_library_override: Option<String>,
     board_connection_poll_interval_seconds: Option<u32>,
     scan_folder_paths: Option<Vec<String>>,
+    setup_completed: Option<bool>,
 }
 
 #[derive(Clone, Debug)]
@@ -133,6 +134,16 @@ pub(crate) fn load_desktop_settings() -> Result<DesktopSettings, String> {
     let context = current_storage_context()?;
     let persisted = load_persisted_settings(&context.settings_file_path)?;
     Ok(build_desktop_settings(&context, &persisted))
+}
+
+/// Load whether the player has finished the setup wizard on this computer.
+pub(crate) fn load_setup_completed() -> Result<bool, String> {
+    let context = current_storage_context()?;
+    let persisted = load_persisted_settings(&context.settings_file_path)?;
+    Ok(resolve_setup_completed(
+        &context.settings_file_path,
+        &persisted,
+    ))
 }
 
 /// Resolve the app-owned root directory used for desktop settings, tools, and cached files.
@@ -171,6 +182,14 @@ pub(crate) fn save_desktop_settings(
     Ok(build_desktop_settings(&context, &persisted))
 }
 
+/// Persist whether the player has finished the setup wizard.
+pub(crate) fn save_setup_completed(setup_completed: bool) -> Result<(), String> {
+    let context = current_storage_context()?;
+    let mut persisted = load_persisted_settings(&context.settings_file_path)?;
+    persisted.setup_completed = Some(setup_completed);
+    save_persisted_settings(&context.settings_file_path, &persisted)
+}
+
 fn build_managed_storage_settings(
     context: &ManagedStorageContext,
     persisted: &PersistedDesktopSettings,
@@ -193,7 +212,7 @@ fn build_desktop_settings(
     persisted: &PersistedDesktopSettings,
 ) -> DesktopSettings {
     let managed_storage = build_managed_storage_settings(context, persisted);
-        DesktopSettings {
+    DesktopSettings {
         operating_system: managed_storage.operating_system,
         settings_file_path: managed_storage.settings_file_path.clone(),
         bdb_tools: managed_storage.bdb_tools.clone(),
@@ -283,13 +302,20 @@ fn normalize_loaded_scan_folder_paths(values: &[String]) -> Vec<String> {
     normalized
 }
 
-fn resolve_board_connection_poll_interval_seconds(
-    persisted: &PersistedDesktopSettings,
-) -> u32 {
+fn resolve_board_connection_poll_interval_seconds(persisted: &PersistedDesktopSettings) -> u32 {
     persisted
         .board_connection_poll_interval_seconds
         .filter(|value| BOARD_CONNECTION_POLL_INTERVAL_OPTIONS.contains(value))
         .unwrap_or(DEFAULT_BOARD_CONNECTION_POLL_INTERVAL_SECONDS)
+}
+
+fn resolve_setup_completed(
+    settings_file_path: &Path,
+    persisted: &PersistedDesktopSettings,
+) -> bool {
+    persisted
+        .setup_completed
+        .unwrap_or_else(|| settings_file_path.exists())
 }
 
 fn normalize_board_connection_poll_interval(
@@ -539,14 +565,24 @@ mod tests {
     use super::{
         build_desktop_settings, build_managed_storage_settings,
         current_storage_context_from_environment, load_persisted_settings, normalize_override,
-        normalize_scan_folder_paths, save_desktop_settings, save_managed_storage_settings,
-        save_persisted_settings, DesktopSettingsInput,
-        DEFAULT_BOARD_CONNECTION_POLL_INTERVAL_SECONDS, ManagedStorageContext,
-        ManagedStorageOverridesInput, PersistedDesktopSettings, StorageOperatingSystem,
+        normalize_scan_folder_paths, resolve_setup_completed, save_desktop_settings,
+        save_managed_storage_settings, save_persisted_settings, save_setup_completed,
+        DesktopSettingsInput, ManagedStorageContext, ManagedStorageOverridesInput,
+        PersistedDesktopSettings, StorageOperatingSystem,
+        DEFAULT_BOARD_CONNECTION_POLL_INTERVAL_SECONDS,
     };
     use std::collections::BTreeMap;
     use std::ffi::OsString;
     use std::path::{Path, PathBuf};
+    use std::sync::{Mutex, MutexGuard};
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn lock_env() -> MutexGuard<'static, ()> {
+        ENV_LOCK
+            .lock()
+            .expect("environment lock should be available")
+    }
 
     fn sample_tools_override_path() -> String {
         if cfg!(target_os = "windows") {
@@ -705,6 +741,7 @@ mod tests {
             apk_library_override: Some(sample_apk_library_override_path()),
             board_connection_poll_interval_seconds: Some(30),
             scan_folder_paths: Some(vec![sample_scan_folder_path()]),
+            setup_completed: None,
         };
 
         save_persisted_settings(&context.settings_file_path, &persisted)
@@ -740,6 +777,7 @@ mod tests {
             apk_library_override: Some(sample_apk_library_override_path()),
             board_connection_poll_interval_seconds: Some(12),
             scan_folder_paths: Some(vec!["relative/Downloads".into()]),
+            setup_completed: None,
         };
 
         let settings = build_managed_storage_settings(&context, &persisted);
@@ -778,11 +816,15 @@ mod tests {
                 .and_then(|value| value.as_str())
                 .expect("source should serialize")
         );
-        assert_eq!(DEFAULT_BOARD_CONNECTION_POLL_INTERVAL_SECONDS, settings.board_connection.poll_interval_seconds);
+        assert_eq!(
+            DEFAULT_BOARD_CONNECTION_POLL_INTERVAL_SECONDS,
+            settings.board_connection.poll_interval_seconds
+        );
     }
 
     #[test]
     fn save_desktop_settings_persists_scan_folders_and_library_override() {
+        let _guard = lock_env();
         let temp_directory = tempfile::tempdir().expect("temporary directory should exist");
         let previous_home = std::env::var_os("HOME");
         let previous_local_app_data = std::env::var_os("LOCALAPPDATA");
@@ -822,7 +864,91 @@ mod tests {
     }
 
     #[test]
+    fn existing_settings_file_defaults_setup_completion_to_true_for_migration() {
+        let temp_directory = tempfile::tempdir().expect("temporary directory should exist");
+        let context = sample_context(temp_directory.path());
+
+        save_persisted_settings(
+            &context.settings_file_path,
+            &PersistedDesktopSettings {
+                bdb_tools_override: None,
+                apk_library_override: None,
+                board_connection_poll_interval_seconds: None,
+                scan_folder_paths: Some(vec![sample_scan_folder_path()]),
+                setup_completed: None,
+            },
+        )
+        .expect("seed settings should save");
+
+        let persisted =
+            load_persisted_settings(&context.settings_file_path).expect("settings should load");
+        let result = resolve_setup_completed(&context.settings_file_path, &persisted);
+
+        assert!(result);
+    }
+
+    #[test]
+    fn save_setup_completed_persists_false_until_the_wizard_finishes() {
+        let _guard = lock_env();
+        let temp_directory = tempfile::tempdir().expect("temporary directory should exist");
+        let previous_home = std::env::var_os("HOME");
+        let previous_local_app_data = std::env::var_os("LOCALAPPDATA");
+        let previous_user_profile = std::env::var_os("USERPROFILE");
+
+        if cfg!(target_os = "windows") {
+            unsafe {
+                std::env::set_var("LOCALAPPDATA", temp_directory.path().join("local-app-data"));
+                std::env::set_var("USERPROFILE", temp_directory.path().join("home"));
+            }
+        } else {
+            unsafe {
+                std::env::set_var("HOME", temp_directory.path().join("home"));
+            }
+        }
+
+        let settings_file_path = if cfg!(target_os = "windows") {
+            temp_directory
+                .path()
+                .join("local-app-data")
+                .join("Board Enthusiasts")
+                .join("BE Home for Desktop")
+                .join("settings")
+                .join("managed-storage.json")
+        } else {
+            temp_directory
+                .path()
+                .join("home")
+                .join(".local")
+                .join("share")
+                .join("Board Enthusiasts")
+                .join("BE Home for Desktop")
+                .join("settings")
+                .join("managed-storage.json")
+        };
+
+        save_setup_completed(false).expect("setup completion should save");
+        let incomplete = load_persisted_settings(&settings_file_path)
+            .expect("setup completion should load")
+            .setup_completed;
+
+        save_setup_completed(true).expect("setup completion should save");
+        let complete = load_persisted_settings(&settings_file_path)
+            .expect("setup completion should load")
+            .setup_completed;
+
+        restore_env(
+            previous_home,
+            previous_local_app_data,
+            previous_user_profile,
+        );
+
+        assert_eq!(Some(false), incomplete);
+        assert_eq!(Some(true), complete);
+    }
+
+    #[test]
     fn saving_managed_storage_keeps_existing_scan_folders() {
+        let _guard = lock_env();
         let temp_directory = tempfile::tempdir().expect("temporary directory should exist");
         let settings_file_path = temp_directory
             .path()
@@ -850,6 +976,7 @@ mod tests {
                 apk_library_override: None,
                 board_connection_poll_interval_seconds: None,
                 scan_folder_paths: Some(vec![sample_scan_folder_path()]),
+                setup_completed: None,
             },
         )
         .expect("seed settings should save");

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -17,7 +17,9 @@
         "height": 960,
         "minWidth": 960,
         "minHeight": 720,
-        "visible": false
+        "visible": false,
+        "decorations": false,
+        "shadow": true
       }
     ],
     "security": {

--- a/src/App.css
+++ b/src/App.css
@@ -1,61 +1,151 @@
 .desktop-shell {
-  padding: clamp(1rem, 2vw, 1.75rem);
+  min-height: 100vh;
+  padding: clamp(1rem, 2vw, 1.5rem);
 }
 
 .desktop-shell--workspace {
-  min-height: 100vh;
+  height: 100vh;
+  min-height: 0;
+  height: 100dvh;
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  overflow: hidden;
+  padding: 0;
+  border: 1px solid var(--desktop-window-border);
+  border-radius: 0.7rem;
+  background: var(--desktop-bg);
 }
 
 .desktop-grid {
+  width: 100%;
   max-width: 96rem;
   margin: 0 auto;
 }
 
-.desktop-state-card {
-  margin-top: clamp(1rem, 4vw, 4rem);
+.desktop-state-view,
+.desktop-utility-dialog {
+  display: grid;
+  gap: 1rem;
+  width: 100%;
+}
+
+.desktop-utility-dialog {
+  height: 100%;
+  min-height: 0;
+  align-self: stretch;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+}
+
+.desktop-utility-dialog--about {
+  grid-template-rows: minmax(0, 1fr) auto;
+}
+
+.desktop-state-view {
+  max-width: 36rem;
+  align-content: start;
+}
+
+.desktop-state-view--warning {
+  color: var(--desktop-text);
 }
 
 .desktop-utility-window {
+  height: 100vh;
   min-height: 100vh;
+  height: 100dvh;
+  min-height: 100dvh;
   display: grid;
-  align-items: center;
+  grid-template-rows: minmax(0, 1fr);
+  align-items: stretch;
+  padding: 0.8rem 1rem 1rem;
 }
 
 .desktop-utility-grid {
-  padding-block: 1rem;
-}
-
-.desktop-utility-card {
   display: grid;
-  gap: 1.5rem;
-  padding: 1.5rem;
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+  grid-template-rows: minmax(0, 1fr);
+  align-items: stretch;
+  max-width: 58rem;
+  margin: 0 auto;
+  padding-block: 0.2rem;
 }
 
 .desktop-utility-header,
-.desktop-app-header {
+.desktop-app-header,
+.desktop-state-view {
   display: grid;
   gap: 1rem;
 }
 
 .desktop-utility-heading,
-.desktop-app-heading {
+.desktop-app-heading,
+.desktop-about-copy {
   display: grid;
-  gap: 0.35rem;
+  gap: 0.55rem;
+}
+
+.desktop-utility-dialog h1,
+.desktop-utility-dialog h2,
+.desktop-state-view h2,
+.desktop-modal-card h2,
+.desktop-about-copy h1 {
+  margin: 0;
+  font-family: var(--font-display);
+  color: var(--desktop-text);
+}
+
+.desktop-utility-dialog h1,
+.desktop-about-copy h1 {
+  font-size: clamp(1.6rem, 2.2vw, 2rem);
+  line-height: 1.12;
+}
+
+.desktop-utility-dialog h2,
+.desktop-state-view h2,
+.desktop-modal-card h2 {
+  font-size: clamp(1.15rem, 1.6vw, 1.45rem);
+  line-height: 1.2;
 }
 
 .desktop-utility-body,
 .desktop-main-content,
 .desktop-section-stack {
   display: grid;
-  gap: 1rem;
+  gap: 0.9rem;
+}
+
+.desktop-utility-body {
+  align-content: start;
+  min-height: 0;
+}
+
+.desktop-utility-dialog--wizard .desktop-utility-body {
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding-right: 0.2rem;
+}
+
+.desktop-utility-dialog--about .desktop-about-copy {
+  align-content: start;
+  min-height: 0;
+  overflow-y: auto;
+  padding-right: 0.2rem;
 }
 
 .desktop-utility-footer {
   display: flex;
   justify-content: space-between;
   gap: 1rem;
+  align-items: center;
   border-top: 1px solid var(--desktop-border);
-  padding-top: 1rem;
+  padding-top: 0.85rem;
+}
+
+.desktop-utility-footer--about {
+  justify-content: flex-end;
 }
 
 .desktop-utility-footer-actions,
@@ -65,30 +155,45 @@
   gap: 0.75rem;
 }
 
+.desktop-utility-footer-actions {
+  flex-wrap: nowrap;
+}
+
 .desktop-wizard-step-row {
   display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem;
+  flex-wrap: nowrap;
+  align-items: center;
+  gap: 0.45rem;
   margin: 0;
   padding: 0;
   list-style: none;
+  overflow: hidden;
 }
 
 .desktop-wizard-step {
   display: inline-flex;
   align-items: center;
-  gap: 0.55rem;
-  padding: 0.55rem 0.8rem;
-  border-radius: 999px;
-  border: 1px solid var(--desktop-border);
-  background: var(--desktop-surface-muted);
+  gap: 0.4rem;
+  padding: 0.25rem 0;
+  border: none;
+  background: transparent;
   color: var(--desktop-text-soft);
-  font-size: 0.92rem;
+  font-size: 0.82rem;
   font-weight: 600;
+  white-space: nowrap;
+}
+
+.desktop-wizard-step::after {
+  content: "/";
+  margin-left: 0.05rem;
+  color: var(--desktop-text-soft);
+}
+
+.desktop-wizard-step:last-child::after {
+  content: none;
 }
 
 .desktop-wizard-step--current {
-  border-color: var(--desktop-border-strong);
   color: var(--desktop-text);
 }
 
@@ -100,19 +205,19 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 1.6rem;
-  height: 1.6rem;
+  width: 1.2rem;
+  height: 1.2rem;
   border-radius: 999px;
   background: rgba(75, 224, 154, 0.16);
   color: var(--desktop-text);
-  font-size: 0.82rem;
+  font-size: 0.72rem;
   font-weight: 700;
 }
 
 .desktop-wizard-page,
 .desktop-settings-page {
   display: grid;
-  gap: 1rem;
+  gap: 0.85rem;
 }
 
 .desktop-wizard-checklist,
@@ -221,7 +326,7 @@
 .desktop-radio-copy {
   margin: 0;
   color: var(--desktop-text-soft);
-  line-height: 1.65;
+  line-height: 1.55;
 }
 
 .desktop-inline-card,
@@ -229,8 +334,8 @@
 .desktop-content-card,
 .desktop-manual-card {
   display: grid;
-  gap: 0.6rem;
-  padding: 1rem 1.1rem;
+  gap: 0.55rem;
+  padding: 0.9rem 1rem;
   border-radius: var(--desktop-radius-md);
   border: 1px solid var(--desktop-border);
   background: var(--desktop-surface-muted);
@@ -261,6 +366,173 @@
 .desktop-inline-message--success {
   border-color: rgba(75, 224, 154, 0.28);
   background: rgba(75, 224, 154, 0.08);
+}
+
+.desktop-titlebar {
+  position: relative;
+  z-index: 20;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+  align-items: center;
+  height: 2.9rem;
+  min-height: 0;
+  padding-left: 0.35rem;
+  border-bottom: 1px solid var(--desktop-titlebar-border);
+  background: var(--desktop-titlebar-bg);
+  isolation: isolate;
+}
+
+.desktop-titlebar-drag-region {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+}
+
+.desktop-titlebar > *:not(.desktop-titlebar-drag-region) {
+  position: relative;
+  z-index: 1;
+}
+
+.desktop-titlebar-left,
+.desktop-titlebar-right {
+  display: flex;
+  align-items: center;
+}
+
+.desktop-titlebar-left {
+  gap: 0.2rem;
+  min-width: 0;
+}
+
+.desktop-titlebar-right {
+  justify-self: end;
+}
+
+.desktop-titlebar-title {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  display: inline-flex;
+  align-items: center;
+  height: 100%;
+  transform: translate(-50%, -50%);
+  pointer-events: none;
+  font-size: 0.96rem;
+  font-weight: 700;
+  letter-spacing: 0;
+  line-height: 1;
+  color: var(--desktop-text);
+  white-space: nowrap;
+}
+
+.desktop-titlebar-menu-wrap {
+  position: relative;
+}
+
+.desktop-titlebar-menu-strip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.1rem;
+}
+
+.desktop-titlebar-icon-button,
+.desktop-titlebar-menu-trigger,
+.desktop-window-control {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background: transparent;
+  color: var(--desktop-text);
+  cursor: pointer;
+  transition:
+    background-color 140ms ease,
+    color 140ms ease;
+}
+
+.desktop-titlebar-icon-button,
+.desktop-titlebar-menu-trigger {
+  min-height: 2.4rem;
+  border-radius: 0.55rem;
+}
+
+.desktop-titlebar-icon-button {
+  width: 2.4rem;
+  padding: 0;
+}
+
+.desktop-titlebar-menu-trigger {
+  padding: 0 0.65rem;
+  font-size: 0.95rem;
+}
+
+.desktop-titlebar-app-icon {
+  width: 1.4rem;
+  height: 1.4rem;
+  border-radius: 0.3rem;
+  display: block;
+}
+
+.desktop-window-control {
+  width: 2.9rem;
+  min-height: 2.9rem;
+}
+
+.desktop-window-control .material-symbols-outlined {
+  font-size: 1rem;
+}
+
+.desktop-titlebar-icon-button:hover,
+.desktop-titlebar-menu-trigger:hover,
+.desktop-window-control:hover {
+  background: var(--desktop-titlebar-button-hover);
+}
+
+.desktop-window-control--danger:hover {
+  background: rgba(240, 105, 105, 0.22);
+}
+
+.desktop-titlebar-menu {
+  position: absolute;
+  top: calc(100% + 0.3rem);
+  left: 0;
+  min-width: 14rem;
+  padding: 0.35rem;
+  border-radius: 0.8rem;
+  border: 1px solid var(--desktop-titlebar-border);
+  background: var(--desktop-menu-bg);
+  box-shadow: var(--desktop-shadow);
+}
+
+.desktop-titlebar-menu-row {
+  display: grid;
+  gap: 0.3rem;
+}
+
+.desktop-titlebar-menu-separator {
+  height: 1px;
+  margin: 0.15rem 0;
+  background: var(--desktop-border);
+}
+
+.desktop-titlebar-menu-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  width: 100%;
+  padding: 0.65rem 0.7rem;
+  border: none;
+  border-radius: 0.6rem;
+  background: var(--desktop-menu-bg);
+  color: var(--desktop-text);
+  text-align: left;
+  cursor: pointer;
+}
+
+.desktop-titlebar-menu-item:hover,
+.desktop-titlebar-menu-item--selected {
+  background: var(--desktop-menu-item-hover);
 }
 
 .desktop-icon-button,
@@ -347,7 +619,7 @@
 .desktop-list-editor,
 .desktop-settings-section {
   display: grid;
-  gap: 0.8rem;
+  gap: 0.7rem;
 }
 
 .desktop-list-editor-header {
@@ -355,6 +627,23 @@
   align-items: start;
   justify-content: space-between;
   gap: 0.8rem;
+}
+
+.desktop-list-editor-header--stacked {
+  flex-direction: column;
+  align-items: start;
+  justify-content: start;
+}
+
+.desktop-list-editor-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.desktop-list-editor-footer {
+  display: flex;
+  justify-content: flex-end;
 }
 
 .desktop-empty-note {
@@ -376,9 +665,9 @@
 
 .desktop-folder-item,
 .desktop-entity-item {
-  display: flex;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
-  justify-content: space-between;
   gap: 1rem;
   padding: 0.9rem 1rem;
   border-radius: var(--desktop-radius-md);
@@ -388,7 +677,8 @@
 
 .desktop-folder-copy,
 .desktop-entity-copy,
-.desktop-entity-actions {
+.desktop-entity-actions,
+.desktop-folder-actions {
   display: grid;
   gap: 0.25rem;
 }
@@ -409,6 +699,7 @@
   font-weight: 700;
 }
 
+.desktop-folder-actions,
 .desktop-entity-actions {
   justify-items: end;
 }
@@ -520,9 +811,14 @@
 }
 
 .desktop-app-shell {
+  min-height: 0;
   display: grid;
   gap: 1rem;
-  padding: 1.25rem;
+  align-content: start;
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding: 1rem 1.25rem 1.25rem;
 }
 
 .desktop-status-strip {
@@ -588,6 +884,7 @@
   display: grid;
   grid-template-columns: minmax(15rem, 18rem) minmax(0, 1fr);
   gap: 1rem;
+  min-height: 0;
 }
 
 .desktop-sidebar {
@@ -622,13 +919,25 @@
   width: min(100%, 42rem);
   display: grid;
   gap: 1rem;
+  padding: 1.2rem;
+  border-radius: var(--desktop-radius-md);
+  border: 1px solid var(--desktop-border);
+  background: var(--desktop-surface-strong);
+  box-shadow: var(--desktop-shadow);
 }
 
 .desktop-detail-value-block {
   white-space: pre-wrap;
 }
 
-@media (max-width: 960px) {
+.desktop-support-link {
+  color: var(--desktop-accent-strong);
+  font-weight: 700;
+  text-decoration: underline;
+  text-decoration-color: color-mix(in srgb, var(--desktop-accent-strong) 50%, transparent);
+}
+
+@media (max-width: 760px) {
   .desktop-shell {
     padding: 1rem;
   }
@@ -638,8 +947,6 @@
     grid-template-columns: 1fr;
   }
 
-  .desktop-folder-item,
-  .desktop-entity-item,
   .desktop-utility-footer,
   .desktop-section-header,
   .desktop-list-editor-header,
@@ -648,8 +955,35 @@
     align-items: stretch;
   }
 
+  .desktop-folder-item,
+  .desktop-entity-item {
+    grid-template-columns: 1fr;
+  }
+
   .desktop-entity-actions {
     justify-items: stretch;
+  }
+
+  .desktop-folder-actions {
+    justify-items: start;
+  }
+
+  .desktop-titlebar {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+    padding-left: 0.25rem;
+  }
+
+  .desktop-titlebar-title {
+    display: none;
+  }
+
+  .desktop-titlebar-menu-strip {
+    overflow-x: auto;
+  }
+
+  .desktop-wizard-step-row {
+    flex-wrap: wrap;
+    overflow: visible;
   }
 
   .primary-button,

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,8 +1,9 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { open } from "@tauri-apps/plugin-dialog";
+import { readFileSync } from "node:fs";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import App from "./App";
 import type {
@@ -22,24 +23,41 @@ vi.mock("@tauri-apps/api/core", () => ({
 const currentWindowState = vi.hoisted(() => ({
   label: undefined as string | undefined,
   theme: "dark" as "light" | "dark" | null,
+  throwOnGet: false,
 }));
 
 const onFocusChangedMock = vi.hoisted(() => vi.fn().mockResolvedValue(() => {}));
 const onThemeChangedMock = vi.hoisted(() => vi.fn().mockResolvedValue(() => {}));
 const onCloseRequestedMock = vi.hoisted(() => vi.fn().mockResolvedValue(() => {}));
+const onResizedMock = vi.hoisted(() => vi.fn().mockResolvedValue(() => {}));
+const isMaximizedMock = vi.hoisted(() => vi.fn().mockResolvedValue(false));
+const minimizeWindowMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const toggleMaximizeMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 const closeWindowMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const destroyWindowMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 
 vi.mock("@tauri-apps/api/window", () => ({
-  getCurrentWindow: vi.fn(() => ({
-    get label() {
-      return currentWindowState.label;
-    },
-    theme: vi.fn(() => Promise.resolve(currentWindowState.theme)),
-    onThemeChanged: onThemeChangedMock,
-    onFocusChanged: onFocusChangedMock,
-    onCloseRequested: onCloseRequestedMock,
-    close: closeWindowMock,
-  })),
+  getCurrentWindow: vi.fn(() => {
+    if (currentWindowState.throwOnGet) {
+      throw new Error("Tauri window metadata is unavailable");
+    }
+
+    return {
+      get label() {
+        return currentWindowState.label;
+      },
+      theme: vi.fn(() => Promise.resolve(currentWindowState.theme)),
+      onThemeChanged: onThemeChangedMock,
+      onFocusChanged: onFocusChangedMock,
+      onCloseRequested: onCloseRequestedMock,
+      onResized: onResizedMock,
+      isMaximized: isMaximizedMock,
+      minimize: minimizeWindowMock,
+      toggleMaximize: toggleMaximizeMock,
+      close: closeWindowMock,
+      destroy: destroyWindowMock,
+    };
+  }),
 }));
 
 vi.mock("@tauri-apps/api/event", () => ({
@@ -48,6 +66,10 @@ vi.mock("@tauri-apps/api/event", () => ({
 
 vi.mock("@tauri-apps/plugin-dialog", () => ({
   open: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/plugin-opener", () => ({
+  openUrl: vi.fn().mockResolvedValue(undefined),
 }));
 
 const invokeHandlers = vi.hoisted(
@@ -294,12 +316,15 @@ function installDefaultInvokeHandlers(options?: {
     load_installed_titles_snapshot: () => installedTitlesFixture,
     load_apk_discovery_snapshot: () => apkDiscoveryFixture,
     load_managed_apk_library_snapshot: () => managedLibraryFixture,
-    open_setup_wizard_window: () => undefined,
-    open_settings_window: () => undefined,
-    open_about_window: () => undefined,
-    dismiss_setup_wizard_window: () => undefined,
-    show_main_workspace_window: () => undefined,
-    emit_settings_updated: () => undefined,
+        open_setup_wizard_window: () => undefined,
+        open_settings_window: () => undefined,
+        open_about_window: () => undefined,
+        close_about_window: () => undefined,
+        complete_setup_wizard: () => undefined,
+        dismiss_setup_wizard_window: () => undefined,
+        finish_setup_wizard_window: () => undefined,
+        show_main_workspace_window: () => undefined,
+        emit_settings_updated: () => undefined,
     exit_application: () => undefined,
     acquire_bdb_tool: () => ({
       outcome: "downloaded",
@@ -316,6 +341,8 @@ describe("App", () => {
     vi.clearAllMocks();
     currentWindowState.label = undefined;
     currentWindowState.theme = "dark";
+    currentWindowState.throwOnGet = false;
+    window.history.replaceState(null, "", "/");
     document.documentElement.dataset.theme = "";
     document.documentElement.style.colorScheme = "";
 
@@ -333,22 +360,33 @@ describe("App", () => {
     onFocusChangedMock.mockResolvedValue(() => {});
     onThemeChangedMock.mockResolvedValue(() => {});
     onCloseRequestedMock.mockResolvedValue(() => {});
-    closeWindowMock.mockResolvedValue(undefined);
+    onResizedMock.mockResolvedValue(() => {});
+    isMaximizedMock.mockResolvedValue(false);
+    minimizeWindowMock.mockResolvedValue(undefined);
+      toggleMaximizeMock.mockResolvedValue(undefined);
+      closeWindowMock.mockResolvedValue(undefined);
+      destroyWindowMock.mockResolvedValue(undefined);
 
-    installDefaultInvokeHandlers();
-  });
+      installDefaultInvokeHandlers();
+    });
 
   it("defaults to the main workspace window when the label is missing", async () => {
     render(<App />);
 
-    expect(await screen.findByText("Keep your Board installs close by.")).toBeInTheDocument();
+    expect(await screen.findByText("Choose a game or app from this computer.")).toBeInTheDocument();
+    expect(screen.getByText("BE Home for Desktop")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "File" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "View" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Help" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Games & Apps/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Installed on Board/i })).toBeInTheDocument();
     expect(screen.getByLabelText("What this Board status means")).toHaveAttribute(
       "aria-describedby",
       "board-status-help-tooltip",
     );
-    expect(screen.getByText("BE Home is checking for your Board now.")).toBeInTheDocument();
+    expect(screen.getByRole("tooltip")).toHaveTextContent(
+      /BE Home is checking for your Board now\.|Green means BE Home can see your Board right now\./,
+    );
   });
 
   it("routes the setup wizard window", async () => {
@@ -361,13 +399,11 @@ describe("App", () => {
     render(<App />);
 
     expect(await screen.findByText("Set up BE Home for Desktop")).toBeInTheDocument();
-    expect(
-      screen.getByText(/helps you choose games and apps on this computer/i),
-    ).toBeInTheDocument();
+    expect(screen.getByText(/setup gets be home ready to find games and apps/i)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Next" })).toBeInTheDocument();
   });
 
-  it("allows ready setup-wizard close requests to proceed without interception", async () => {
+  it("confirms before closing the setup wizard even when setup is already ready", async () => {
     currentWindowState.label = "setup-wizard";
     installDefaultInvokeHandlers({
       setupState: readySetupFixture,
@@ -376,7 +412,7 @@ describe("App", () => {
 
     render(<App />);
 
-    await screen.findByText("Here’s what setup will help you do.");
+    await screen.findByText("Here’s what setup will do.");
 
     const closeRequestHandler =
       onCloseRequestedMock.mock.calls[onCloseRequestedMock.mock.calls.length - 1]?.[0];
@@ -385,9 +421,12 @@ describe("App", () => {
     };
 
     invokeMock.mockClear();
-    await closeRequestHandler?.(closeEvent);
+    await act(async () => {
+      await closeRequestHandler?.(closeEvent);
+    });
 
-    expect(closeEvent.preventDefault).not.toHaveBeenCalled();
+    expect(closeEvent.preventDefault).toHaveBeenCalled();
+    expect(await screen.findByText("Cancel setup?")).toBeInTheDocument();
     expect(invokeMock).not.toHaveBeenCalledWith("dismiss_setup_wizard_window");
   });
 
@@ -407,6 +446,24 @@ describe("App", () => {
 
     expect(await screen.findByText("BE Home for Desktop")).toBeInTheDocument();
     expect(screen.getByText(/Board Developer Bridge \(bdb\)/)).toBeInTheDocument();
+    expect(screen.getByText("support@boardenthusiasts.com")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+
+    await waitFor(() => {
+      expect(invokeMock).toHaveBeenCalledWith("close_about_window");
+    });
+  });
+
+  it("routes secondary windows from the URL when Tauri metadata is unavailable", async () => {
+    currentWindowState.throwOnGet = true;
+    window.history.replaceState(null, "", "/#about");
+
+    render(<App />);
+
+    expect(await screen.findByText("BE Home for Desktop")).toBeInTheDocument();
+    expect(screen.getByText(/Board Developer Bridge \(bdb\)/)).toBeInTheDocument();
+    expect(screen.getByText("support@boardenthusiasts.com")).toBeInTheDocument();
   });
 
   it("shows the main-window setup blocker and opens the setup wizard", async () => {
@@ -426,7 +483,7 @@ describe("App", () => {
     });
   });
 
-  it("refreshes the main workspace before opening it from ready setup", async () => {
+  it("hands setup completion to the native shell in one finish action", async () => {
     currentWindowState.label = "setup-wizard";
     installDefaultInvokeHandlers({
       setupState: readySetupFixture,
@@ -447,14 +504,17 @@ describe("App", () => {
     fireEvent.click(screen.getByRole("button", { name: "Next" }));
     await screen.findByText("Your setup choices are ready.");
 
-    fireEvent.click(screen.getByRole("button", { name: "Finish" }));
+      fireEvent.click(screen.getByRole("button", { name: "Finish" }));
 
-    await waitFor(() => {
-      expect(invokeMock).toHaveBeenCalledWith("emit_settings_updated");
-      expect(invokeMock).toHaveBeenCalledWith("show_main_workspace_window");
-      expect(invokeMock).toHaveBeenCalledWith("dismiss_setup_wizard_window");
+      await waitFor(() => {
+        expect(invokeMock).toHaveBeenCalledWith("finish_setup_wizard_window");
+        expect(invokeMock).not.toHaveBeenCalledWith("emit_settings_updated");
+        expect(invokeMock).not.toHaveBeenCalledWith("complete_setup_wizard");
+        expect(invokeMock).not.toHaveBeenCalledWith("show_main_workspace_window");
+        expect(invokeMock).not.toHaveBeenCalledWith("dismiss_setup_wizard_window");
+        expect(destroyWindowMock).not.toHaveBeenCalled();
+      });
     });
-  });
 
   it("lazy-loads installed titles only after that section is opened", async () => {
     render(<App />);
@@ -493,10 +553,79 @@ describe("App", () => {
     render(<App />);
 
     fireEvent.click(await screen.findByRole("button", { name: "Cancel" }));
+    expect(await screen.findByText("Cancel setup?")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Yes, Cancel Setup" }));
 
     await waitFor(() => {
       expect(invokeMock).toHaveBeenCalledWith("dismiss_setup_wizard_window");
     });
+  });
+
+  it("hides the check-for-update button until the Board Install Tool is installed", async () => {
+    currentWindowState.label = "setup-wizard";
+    installDefaultInvokeHandlers({
+      setupState: needsSetupFixture,
+      toolState: missingToolFixture,
+    });
+
+    render(<App />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Next" }));
+    await screen.findByText("Get the Board Install Tool ready.");
+
+    expect(screen.queryByRole("button", { name: "Check for Update" })).not.toBeInTheDocument();
+    expect(screen.getByText("Latest version available from Board")).toBeInTheDocument();
+  });
+
+  it("shows a modal when setup cannot move past the Board Install Tool step yet", async () => {
+    currentWindowState.label = "setup-wizard";
+    installDefaultInvokeHandlers({
+      setupState: needsSetupFixture,
+      toolState: missingToolFixture,
+    });
+
+    render(<App />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Next" }));
+    await screen.findByText("Get the Board Install Tool ready.");
+
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+
+    expect(await screen.findByText("Download the Board Install Tool first.")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "BE Home can't move to the next step until the Board Install Tool is downloaded and ready. Choose Download in this step, then try Next again.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Got it" })).toBeInTheDocument();
+    expect(screen.getByText("Get the Board Install Tool ready.")).toBeInTheDocument();
+  });
+
+  it("blocks adding a nested scan folder when an existing parent folder already covers it", async () => {
+    currentWindowState.label = "setup-wizard";
+    installDefaultInvokeHandlers({
+      setupState: readySetupFixture,
+      toolState: runnableToolFixture,
+    });
+    openMock.mockResolvedValue("C:\\Users\\Matt\\Downloads\\ApkDumps");
+
+    render(<App />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Next" }));
+    await screen.findByText("Get the Board Install Tool ready.");
+
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+    await screen.findByText("Choose the folders BE Home should check.");
+
+    fireEvent.click(screen.getByLabelText("Add folder"));
+
+    expect(await screen.findByText("That folder is already covered by another rule.")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "BE Home is already checking C:\\Users\\Matt\\Downloads, so you don't need to add C:\\Users\\Matt\\Downloads\\ApkDumps separately.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByLabelText("Remove C:\\Users\\Matt\\Downloads\\ApkDumps")).not.toBeInTheDocument();
   });
 
   it("applies the current window theme to the document", async () => {
@@ -513,11 +642,23 @@ describe("App", () => {
   it("keeps Tauri window listeners wired for the routed shell", async () => {
     render(<App />);
 
-    await screen.findByText("Keep your Board installs close by.");
+    await screen.findByText("Choose a game or app from this computer.");
 
     expect(getCurrentWindowMock).toHaveBeenCalled();
     expect(onFocusChangedMock).toHaveBeenCalled();
     expect(onThemeChangedMock).toHaveBeenCalled();
-    expect(listenMock).toHaveBeenCalledTimes(3);
+    expect(onResizedMock).toHaveBeenCalled();
+    expect(listenMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows the custom titlebar buttons to use native minimize and maximize commands", () => {
+    const capability = JSON.parse(
+      readFileSync("src-tauri/capabilities/default.json", "utf8"),
+    ) as { permissions: string[] };
+
+    expect(capability.permissions).toContain("core:window:allow-close");
+    expect(capability.permissions).toContain("core:window:allow-destroy");
+    expect(capability.permissions).toContain("core:window:allow-minimize");
+    expect(capability.permissions).toContain("core:window:allow-toggle-maximize");
   });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,12 +11,48 @@ import MainWorkspaceApp from "./main-window/MainWorkspaceApp";
 import SettingsWindowApp from "./settings-window/SettingsWindowApp";
 import SetupWizardApp from "./setup-window/SetupWizardApp";
 
+const knownWindowLabels = new Set([
+  MAIN_WINDOW_LABEL,
+  SETUP_WIZARD_WINDOW_LABEL,
+  SETTINGS_WINDOW_LABEL,
+  ABOUT_WINDOW_LABEL,
+]);
+
+function normalizedWindowLabel(value: string | null | undefined): string | null {
+  if (value === undefined || value === null || !knownWindowLabels.has(value)) {
+    return null;
+  }
+
+  return value;
+}
+
+function routedWindowLabel(): string | null {
+  const hashLabel = normalizedWindowLabel(window.location.hash.replace(/^#/, ""));
+  if (hashLabel !== null) {
+    return hashLabel;
+  }
+
+  return normalizedWindowLabel(new URLSearchParams(window.location.search).get("window"));
+}
+
+function currentWindowLabel(): string {
+  const routeLabel = routedWindowLabel();
+  if (routeLabel !== null) {
+    return routeLabel;
+  }
+
+  try {
+    return normalizedWindowLabel(getCurrentWindow().label) ?? MAIN_WINDOW_LABEL;
+  } catch {
+    return MAIN_WINDOW_LABEL;
+  }
+}
+
 function UnsupportedWindow() {
   return (
     <main className="page-shell desktop-shell desktop-utility-window">
-      <section className="page-grid narrow">
-        <section className="panel desktop-state-card">
-          <div className="eyebrow">Desktop Shell</div>
+      <section className="desktop-utility-grid">
+        <section className="desktop-state-view">
           <h2>This desktop window is not recognized.</h2>
           <p className="panel-description">
             Please close the extra window and reopen the desktop app from the main workspace.
@@ -29,7 +65,7 @@ function UnsupportedWindow() {
 
 export default function App() {
   useWindowTheme();
-  const windowLabel = getCurrentWindow().label ?? MAIN_WINDOW_LABEL;
+  const windowLabel = currentWindowLabel();
 
   switch (windowLabel) {
     case MAIN_WINDOW_LABEL:

--- a/src/about-window/AboutWindowApp.tsx
+++ b/src/about-window/AboutWindowApp.tsx
@@ -1,6 +1,33 @@
+import { getCurrentWindow } from "@tauri-apps/api/window";
+import { openUrl } from "@tauri-apps/plugin-opener";
+import type { MouseEvent } from "react";
 import { useEffect, useState } from "react";
-import { loadSetupGateState } from "../desktop/client";
+import { closeAboutWindow, loadSetupGateState } from "../desktop/client";
 import type { SetupGateState } from "../desktop/types";
+
+async function handleOpenSupportEmail(event: MouseEvent<HTMLAnchorElement>): Promise<void> {
+  event.preventDefault();
+  try {
+    await openUrl("mailto:support@boardenthusiasts.com");
+  } catch {
+    window.location.href = "mailto:support@boardenthusiasts.com";
+  }
+}
+
+async function handleCloseWindow(): Promise<void> {
+  try {
+    await closeAboutWindow();
+    return;
+  } catch {
+    // Fall through to the local window handle for non-Tauri test and preview contexts.
+  }
+
+  try {
+    await getCurrentWindow().close();
+  } catch {
+    window.close();
+  }
+}
 
 export default function AboutWindowApp() {
   const [setupGateState, setSetupGateState] = useState<SetupGateState | null>(null);
@@ -17,15 +44,14 @@ export default function AboutWindowApp() {
 
   return (
     <main className="page-shell desktop-shell desktop-utility-window">
-      <section className="page-grid narrow">
-        <section className="panel desktop-state-card">
-          <div className="eyebrow">About</div>
-          <h2>BE Home for Desktop</h2>
-          <p className="panel-description">
-            BE Home for Desktop helps players keep Board game and app installs in one guided
-            desktop workspace instead of working through terminal steps by hand.
-          </p>
-          <div className="desktop-about-list">
+      <section className="desktop-utility-grid">
+        <section className="desktop-utility-dialog desktop-utility-dialog--about">
+          <div className="desktop-about-copy">
+            <h1>BE Home for Desktop</h1>
+            <p className="panel-description">
+              BE Home for Desktop helps players keep Board game and app installs in one guided
+              desktop workspace instead of working through terminal steps by hand.
+            </p>
             <p>
               Version: <strong>{setupGateState?.version ?? "0.1.0"}</strong>
             </p>
@@ -36,7 +62,27 @@ export default function AboutWindowApp() {
               The desktop app keeps Board checks, local game files, and saved library locations
               close by in one place.
             </p>
+            <p>
+              Need help? Contact{" "}
+              <a
+                className="desktop-support-link"
+                href="mailto:support@boardenthusiasts.com"
+                onClick={(event) => void handleOpenSupportEmail(event)}
+              >
+                support@boardenthusiasts.com
+              </a>
+              .
+            </p>
           </div>
+          <footer className="desktop-utility-footer desktop-utility-footer--about">
+            <button
+              className="primary-button"
+              onClick={() => void handleCloseWindow()}
+              type="button"
+            >
+              Close
+            </button>
+          </footer>
         </section>
       </section>
     </main>

--- a/src/desktop-shell/MainWindowTitleBar.tsx
+++ b/src/desktop-shell/MainWindowTitleBar.tsx
@@ -1,0 +1,295 @@
+import { getCurrentWindow } from "@tauri-apps/api/window";
+import { useEffect, useRef, useState } from "react";
+import {
+  exitApplication,
+  openAboutWindow,
+  openSettingsWindow,
+  openSetupWizardWindow,
+} from "../desktop/client";
+import type { MainWorkspaceTarget } from "./constants";
+
+type OpenMenuId = "system" | "file" | "view" | "help" | null;
+
+interface MainWindowTitleBarProps {
+  activeSection: MainWorkspaceTarget;
+  onNavigate: (target: MainWorkspaceTarget) => void;
+  onRescanGamesAndApps: () => void;
+}
+
+interface TitleBarMenuItem {
+  id: string;
+  label: string;
+  action: () => Promise<void> | void;
+  selected?: boolean;
+  separatorBefore?: boolean;
+}
+
+function TitleBarMenu({
+  items,
+  onDismiss,
+}: {
+  items: TitleBarMenuItem[];
+  onDismiss: () => void;
+}) {
+  return (
+    <div className="desktop-titlebar-menu" role="menu">
+      {items.map((item) => (
+        <div className="desktop-titlebar-menu-row" key={item.id}>
+          {item.separatorBefore ? <div className="desktop-titlebar-menu-separator" /> : null}
+          <button
+            className={
+              item.selected
+                ? "desktop-titlebar-menu-item desktop-titlebar-menu-item--selected"
+                : "desktop-titlebar-menu-item"
+            }
+            onClick={() => {
+              onDismiss();
+              void item.action();
+            }}
+            role="menuitem"
+            type="button"
+          >
+            <span>{item.label}</span>
+            {item.selected ? <span aria-hidden="true">•</span> : null}
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default function MainWindowTitleBar({
+  activeSection,
+  onNavigate,
+  onRescanGamesAndApps,
+}: MainWindowTitleBarProps) {
+  const titleBarRef = useRef<HTMLElement | null>(null);
+  const currentWindow = getCurrentWindow();
+  const [openMenuId, setOpenMenuId] = useState<OpenMenuId>(null);
+  const [isMaximized, setIsMaximized] = useState(false);
+
+  useEffect(() => {
+    let mounted = true;
+    let removeResizeListener: (() => void) | null = null;
+
+    const syncMaximizedState = async () => {
+      try {
+        const nextValue = await currentWindow.isMaximized();
+        if (mounted) {
+          setIsMaximized(nextValue);
+        }
+      } catch {
+        if (mounted) {
+          setIsMaximized(false);
+        }
+      }
+    };
+
+    void syncMaximizedState();
+    void currentWindow
+      .onResized(() => {
+        void syncMaximizedState();
+      })
+      .then((unlisten) => {
+        removeResizeListener = unlisten;
+      })
+      .catch(() => undefined);
+
+    return () => {
+      mounted = false;
+      if (removeResizeListener !== null) {
+        removeResizeListener();
+      }
+    };
+  }, [currentWindow]);
+
+  useEffect(() => {
+    if (openMenuId === null) {
+      return;
+    }
+
+    const handlePointerDown = (event: PointerEvent) => {
+      if (!titleBarRef.current?.contains(event.target as Node)) {
+        setOpenMenuId(null);
+      }
+    };
+
+    window.addEventListener("pointerdown", handlePointerDown);
+    return () => {
+      window.removeEventListener("pointerdown", handlePointerDown);
+    };
+  }, [openMenuId]);
+
+  const fileMenuItems: TitleBarMenuItem[] = [
+    {
+      id: "setup-wizard",
+      label: "Setup Wizard...",
+      action: () => openSetupWizardWindow(),
+    },
+    {
+      id: "settings",
+      label: "Settings...",
+      action: () => openSettingsWindow(),
+    },
+    {
+      id: "exit",
+      label: "Exit",
+      action: () => exitApplication(),
+      separatorBefore: true,
+    },
+  ];
+
+  const viewMenuItems: TitleBarMenuItem[] = [
+    {
+      id: "games-and-apps",
+      label: "Games & Apps",
+      action: () => onNavigate("gamesAndApps"),
+      selected: activeSection === "gamesAndApps",
+    },
+    {
+      id: "installed-on-board",
+      label: "Installed on Board",
+      action: () => onNavigate("installedOnBoard"),
+      selected: activeSection === "installedOnBoard",
+    },
+    {
+      id: "rescan",
+      label: "Rescan Games & Apps",
+      action: () => onRescanGamesAndApps(),
+      separatorBefore: true,
+    },
+  ];
+
+  const helpMenuItems: TitleBarMenuItem[] = [
+    {
+      id: "about",
+      label: "About BE Home for Desktop",
+      action: () => openAboutWindow(),
+    },
+  ];
+
+  const systemMenuItems: TitleBarMenuItem[] = [
+    {
+      id: "minimize",
+      label: "Minimize",
+      action: () => currentWindow.minimize(),
+    },
+    {
+      id: "toggle-maximize",
+      label: isMaximized ? "Restore" : "Maximize",
+      action: () => currentWindow.toggleMaximize(),
+    },
+    {
+      id: "close",
+      label: "Close",
+      action: () => exitApplication(),
+      separatorBefore: true,
+    },
+  ];
+
+  const titleBarMenus: Array<{
+    id: Exclude<OpenMenuId, "system" | null>;
+    label: string;
+    items: TitleBarMenuItem[];
+  }> = [
+    { id: "file", label: "File", items: fileMenuItems },
+    { id: "view", label: "View", items: viewMenuItems },
+    { id: "help", label: "Help", items: helpMenuItems },
+  ];
+
+  return (
+    <header className="desktop-titlebar" ref={titleBarRef}>
+      <div
+        className="desktop-titlebar-drag-region"
+        data-tauri-drag-region
+        onDoubleClick={() => void currentWindow.toggleMaximize()}
+      />
+
+      <div className="desktop-titlebar-left">
+        <div className="desktop-titlebar-menu-wrap">
+          <button
+            aria-expanded={openMenuId === "system"}
+            aria-haspopup="menu"
+            aria-label="Window menu"
+            className="desktop-titlebar-icon-button"
+            onClick={() => setOpenMenuId((previous) => (previous === "system" ? null : "system"))}
+            type="button"
+          >
+            <img alt="" className="desktop-titlebar-app-icon" src="/favicon.png" />
+          </button>
+          {openMenuId === "system" ? (
+            <TitleBarMenu
+              items={systemMenuItems}
+              onDismiss={() => {
+                setOpenMenuId(null);
+              }}
+            />
+          ) : null}
+        </div>
+
+        <nav aria-label="Window menu" className="desktop-titlebar-menu-strip">
+          {titleBarMenus.map((menu) => (
+            <div className="desktop-titlebar-menu-wrap" key={menu.id}>
+              <button
+                aria-expanded={openMenuId === menu.id}
+                aria-haspopup="menu"
+                className="desktop-titlebar-menu-trigger"
+                onClick={() =>
+                  setOpenMenuId((previous) => (previous === menu.id ? null : menu.id))
+                }
+                type="button"
+              >
+                {menu.label}
+              </button>
+              {openMenuId === menu.id ? (
+                <TitleBarMenu
+                  items={menu.items}
+                  onDismiss={() => {
+                    setOpenMenuId(null);
+                  }}
+                />
+              ) : null}
+            </div>
+          ))}
+        </nav>
+      </div>
+
+      <div aria-hidden="true" className="desktop-titlebar-title">
+        BE Home for Desktop
+      </div>
+
+      <div className="desktop-titlebar-right">
+        <button
+          aria-label="Minimize"
+          className="desktop-window-control"
+          onClick={() => void currentWindow.minimize()}
+          type="button"
+        >
+          <span aria-hidden="true" className="material-symbols-outlined">
+            remove
+          </span>
+        </button>
+        <button
+          aria-label={isMaximized ? "Restore" : "Maximize"}
+          className="desktop-window-control"
+          onClick={() => void currentWindow.toggleMaximize()}
+          type="button"
+        >
+          <span aria-hidden="true" className="material-symbols-outlined">
+            {isMaximized ? "filter_none" : "crop_square"}
+          </span>
+        </button>
+        <button
+          aria-label="Close"
+          className="desktop-window-control desktop-window-control--danger"
+          onClick={() => void exitApplication()}
+          type="button"
+        >
+          <span aria-hidden="true" className="material-symbols-outlined">
+            close
+          </span>
+        </button>
+      </div>
+    </header>
+  );
+}

--- a/src/desktop-shell/constants.ts
+++ b/src/desktop-shell/constants.ts
@@ -3,12 +3,6 @@ export const SETUP_WIZARD_WINDOW_LABEL = "setup-wizard";
 export const SETTINGS_WINDOW_LABEL = "settings";
 export const ABOUT_WINDOW_LABEL = "about";
 
-export const MAIN_WORKSPACE_NAVIGATE_EVENT = "desktop-shell://navigate";
-export const MAIN_WORKSPACE_RESCAN_EVENT = "desktop-shell://rescan-games-and-apps";
 export const SETTINGS_UPDATED_EVENT = "desktop-shell://settings-updated";
 
 export type MainWorkspaceTarget = "gamesAndApps" | "installedOnBoard";
-
-export interface MainWorkspaceNavigationEvent {
-  target: MainWorkspaceTarget;
-}

--- a/src/desktop-shell/useWindowTheme.ts
+++ b/src/desktop-shell/useWindowTheme.ts
@@ -37,7 +37,16 @@ export function useWindowTheme(): DesktopTheme {
   useEffect(() => {
     let mounted = true;
     let unlistenThemeChange: (() => void) | null = null;
-    const currentWindow = getCurrentWindow();
+    let currentWindow: ReturnType<typeof getCurrentWindow>;
+
+    try {
+      currentWindow = getCurrentWindow();
+    } catch {
+      setTheme(fallbackTheme());
+      return () => {
+        mounted = false;
+      };
+    }
 
     if (typeof currentWindow.theme === "function") {
       void currentWindow

--- a/src/desktop/client.ts
+++ b/src/desktop/client.ts
@@ -170,6 +170,13 @@ export function saveDesktopSettings(input: DesktopSettingsInput): Promise<Deskto
 }
 
 /**
+ * Marks the setup wizard as complete for future app launches.
+ */
+export function completeSetupWizard(): Promise<void> {
+  return invoke<void>("complete_setup_wizard");
+}
+
+/**
  * Opens or focuses the native setup wizard window.
  */
 export function openSetupWizardWindow(): Promise<void> {
@@ -191,6 +198,13 @@ export function openAboutWindow(): Promise<void> {
 }
 
 /**
+ * Closes the native About window if it is open.
+ */
+export function closeAboutWindow(): Promise<void> {
+  return invoke<void>("close_about_window");
+}
+
+/**
  * Shows the main workspace window after setup is complete.
  */
 export function showMainWorkspaceWindow(): Promise<void> {
@@ -202,6 +216,13 @@ export function showMainWorkspaceWindow(): Promise<void> {
  */
 export function dismissSetupWizardWindow(): Promise<void> {
   return invoke<void>("dismiss_setup_wizard_window");
+}
+
+/**
+ * Completes setup, closes the wizard, and opens the main workspace in one native handoff.
+ */
+export function finishSetupWizardWindow(): Promise<void> {
+  return invoke<void>("finish_setup_wizard_window");
 }
 
 /**

--- a/src/main-window/MainWorkspaceApp.tsx
+++ b/src/main-window/MainWorkspaceApp.tsx
@@ -30,12 +30,8 @@ import type {
   UninstallInstalledTitleResult,
 } from "../desktop/types";
 import { formatBoardInstallToolVersion } from "../desktop/presentation";
-import {
-  MAIN_WORKSPACE_NAVIGATE_EVENT,
-  MAIN_WORKSPACE_RESCAN_EVENT,
-  SETTINGS_UPDATED_EVENT,
-  type MainWorkspaceNavigationEvent,
-} from "../desktop-shell/constants";
+import { SETTINGS_UPDATED_EVENT } from "../desktop-shell/constants";
+import MainWindowTitleBar from "../desktop-shell/MainWindowTitleBar";
 
 type WorkspaceSectionId = "gamesAndApps" | "installedOnBoard";
 type NoticeTone = "success" | "warning" | "neutral";
@@ -162,6 +158,7 @@ export default function MainWorkspaceApp() {
   const [gamesAndAppsLoaded, setGamesAndAppsLoaded] = useState(false);
   const [installedLoaded, setInstalledLoaded] = useState(false);
   const apkInstallInFlightRef = useRef(false);
+  const deviceStatusInFlightRef = useRef(false);
 
   useEffect(() => {
     void refreshSetupGateState();
@@ -230,6 +227,12 @@ export default function MainWorkspaceApp() {
         return;
       }
 
+      if (deviceStatusInFlightRef.current) {
+        return;
+      }
+
+      deviceStatusInFlightRef.current = true;
+
       if (source !== "poll") {
         setDeviceState((previous) => ({
           ...previous,
@@ -257,6 +260,8 @@ export default function MainWorkspaceApp() {
               ? "It will keep trying again while the window stays visible."
               : "Please try again in a moment.",
         }));
+      } finally {
+        deviceStatusInFlightRef.current = false;
       }
     },
   );
@@ -371,6 +376,7 @@ export default function MainWorkspaceApp() {
   const devicePollIntervalMs =
     deviceState.snapshot?.pollIntervalMs ??
     (desktopSettings?.boardConnection.pollIntervalSeconds ?? 5) * 1000;
+
   useEffect(() => {
     if (setupGateState?.status !== "ready") {
       setDeviceState({
@@ -387,6 +393,13 @@ export default function MainWorkspaceApp() {
     }
 
     void refreshDeviceStatus("initial");
+  }, [documentVisible, setupGateState?.status, windowFocused]);
+
+  useEffect(() => {
+    if (setupGateState?.status !== "ready" || !documentVisible || !windowFocused) {
+      return;
+    }
+
     const timer = window.setInterval(() => {
       void refreshDeviceStatus("poll");
     }, devicePollIntervalMs);
@@ -413,16 +426,6 @@ export default function MainWorkspaceApp() {
     }
   }, [activeSectionId, gamesAndAppsLoaded, installedLoaded, setupGateState?.status]);
 
-  const handleShellNavigation = useEffectEvent((payload: MainWorkspaceNavigationEvent) => {
-    setActiveSectionId(payload.target);
-  });
-
-  const handleShellRescan = useEffectEvent(() => {
-    setActiveSectionId("gamesAndApps");
-    void refreshApkDiscovery("manual");
-    void refreshManagedLibrary("manual");
-  });
-
   const handleSettingsUpdated = useEffectEvent(() => {
     void refreshSetupGateState();
     void refreshDesktopSettings();
@@ -438,33 +441,24 @@ export default function MainWorkspaceApp() {
 
   useEffect(() => {
     let mounted = true;
-    let unlistenFunctions: Array<() => void> = [];
+    let removeSettingsListener: (() => void) | null = null;
 
-    void Promise.all([
-      listen<MainWorkspaceNavigationEvent>(MAIN_WORKSPACE_NAVIGATE_EVENT, ({ payload }) => {
-        handleShellNavigation(payload);
-      }),
-      listen(MAIN_WORKSPACE_RESCAN_EVENT, () => {
-        handleShellRescan();
-      }),
-      listen(SETTINGS_UPDATED_EVENT, () => {
-        handleSettingsUpdated();
-      }),
-    ]).then((unlisten) => {
-      if (mounted) {
-        unlistenFunctions = unlisten;
-        return;
-      }
+    void listen(SETTINGS_UPDATED_EVENT, () => {
+      handleSettingsUpdated();
+    })
+      .then((unlisten) => {
+        if (mounted) {
+          removeSettingsListener = unlisten;
+          return;
+        }
 
-      for (const removeListener of unlisten) {
-        removeListener();
-      }
-    });
+        unlisten();
+      });
 
     return () => {
       mounted = false;
-      for (const removeListener of unlistenFunctions) {
-        removeListener();
+      if (removeSettingsListener !== null) {
+        removeSettingsListener();
       }
     };
   }, []);
@@ -707,9 +701,8 @@ export default function MainWorkspaceApp() {
   if (windowError !== null) {
     return (
       <main className="page-shell desktop-shell">
-        <section className="page-grid narrow">
-          <section className="panel desktop-state-card" aria-live="polite">
-            <div className="eyebrow">BE Home for Desktop</div>
+        <section className="desktop-grid">
+          <section className="desktop-state-view" aria-live="polite">
             <h2>Please close the app and try again.</h2>
             <p className="panel-description">{windowError}</p>
           </section>
@@ -721,9 +714,8 @@ export default function MainWorkspaceApp() {
   if (setupGateState === null) {
     return (
       <main className="page-shell desktop-shell">
-        <section className="page-grid narrow">
-          <section className="panel desktop-state-card" aria-live="polite">
-            <div className="eyebrow">Opening BE Home for Desktop</div>
+        <section className="desktop-grid">
+          <section className="desktop-state-view" aria-live="polite">
             <h2>Getting your desktop workspace ready</h2>
             <p className="panel-description">
               BE Home is checking your setup and Board status.
@@ -737,9 +729,8 @@ export default function MainWorkspaceApp() {
   if (setupGateState.status !== "ready") {
     return (
       <main className="page-shell desktop-shell">
-        <section className="page-grid narrow">
-          <section className="panel desktop-state-card desktop-inline-message--warning" aria-live="polite">
-            <div className="eyebrow">Setup Needed</div>
+        <section className="desktop-grid">
+          <section className="desktop-state-view desktop-state-view--warning" aria-live="polite">
             <h2>Finish setup in the Setup Wizard first.</h2>
             <p className="panel-description">{setupGateState.summary}</p>
             <div className="desktop-inline-button-row">
@@ -755,90 +746,87 @@ export default function MainWorkspaceApp() {
 
   return (
     <main className="page-shell desktop-shell desktop-shell--workspace">
-      <section className="page-grid desktop-grid">
-        <section className="panel desktop-app-shell">
-          <header className="desktop-app-header">
-            <div className="desktop-app-heading">
-              <div className="eyebrow">BE Home for Desktop</div>
-              <h1>Keep your Board installs close by.</h1>
-              <p className="panel-description">
-                Choose between the files on this computer and what is already installed on your
-                Board.
-              </p>
-            </div>
-          </header>
+      <MainWindowTitleBar
+        activeSection={activeSectionId}
+        onNavigate={setActiveSectionId}
+        onRescanGamesAndApps={() => {
+          setActiveSectionId("gamesAndApps");
+          void refreshApkDiscovery("manual");
+          void refreshManagedLibrary("manual");
+        }}
+      />
 
-          <section className="desktop-status-strip" aria-label="Board status">
-            <span className={`desktop-status-chip desktop-status-chip--${boardStatus.tone}`}>
-              {boardStatus.label}
+      <section className="desktop-app-shell">
+        <section className="desktop-status-strip" aria-label="Board status">
+          <span className={`desktop-status-chip desktop-status-chip--${boardStatus.tone}`}>
+            {boardStatus.label}
+          </span>
+          <div className="desktop-help-chip-wrap">
+            <button
+              aria-describedby="board-status-help-tooltip"
+              aria-label="What this Board status means"
+              className="desktop-help-chip"
+              type="button"
+            >
+              ?
+            </button>
+            <span className="desktop-help-tooltip" id="board-status-help-tooltip" role="tooltip">
+              {boardStatus.tooltip}
             </span>
-            <div className="desktop-help-chip-wrap">
+          </div>
+          <StatusValueChip label="bdb" value={bdbVersionValue} />
+          <StatusValueChip label="Board OS" value={boardOsVersionValue} />
+        </section>
+
+        <section className="desktop-main-layout">
+          <aside className="desktop-sidebar" aria-label="Workspace sections">
+            {workspaceSections.map((section) => (
               <button
-                aria-describedby="board-status-help-tooltip"
-                aria-label="What this Board status means"
-                className="desktop-help-chip"
+                className={
+                  section.id === activeSectionId
+                    ? "desktop-sidebar-button desktop-sidebar-button--active"
+                    : "desktop-sidebar-button"
+                }
+                key={section.id}
+                onClick={() => setActiveSectionId(section.id)}
                 type="button"
               >
-                ?
+                <span className="desktop-sidebar-button-label">{section.label}</span>
+                <span className="desktop-sidebar-button-summary">{section.summary}</span>
               </button>
-              <span className="desktop-help-tooltip" id="board-status-help-tooltip" role="tooltip">
-                {boardStatus.tooltip}
-              </span>
-            </div>
-            <StatusValueChip label="bdb" value={bdbVersionValue} />
-            <StatusValueChip label="Board OS" value={boardOsVersionValue} />
-          </section>
+            ))}
+          </aside>
 
-          <section className="desktop-main-layout">
-            <aside className="desktop-sidebar" aria-label="Workspace sections">
-              {workspaceSections.map((section) => (
-                <button
-                  className={
-                    section.id === activeSectionId
-                      ? "desktop-sidebar-button desktop-sidebar-button--active"
-                      : "desktop-sidebar-button"
-                  }
-                  key={section.id}
-                  onClick={() => setActiveSectionId(section.id)}
-                  type="button"
-                >
-                  <span className="desktop-sidebar-button-label">{section.label}</span>
-                  <span className="desktop-sidebar-button-summary">{section.summary}</span>
-                </button>
-              ))}
-            </aside>
-
-            <section className="desktop-main-content">
-              {activeSectionId === "gamesAndApps" ? (
-                <GamesAndAppsSection
-                  apkDiscoveryState={apkDiscoveryState}
-                  apkInstallState={apkInstallState}
-                  desktopSettings={desktopSettings}
-                  managedLibraryState={managedLibraryState}
-                  onChooseManualApk={() => void handleChooseManualApk()}
-                  onImportCandidate={(sourcePath) => void handleImportApkIntoManagedLibrary(sourcePath)}
-                  onInstallApk={(apkPath) => void handleInstallApk(apkPath)}
-                  onRescan={() => {
-                    void refreshApkDiscovery("manual");
-                    void refreshManagedLibrary("manual");
-                  }}
-                />
-              ) : (
-                <InstalledOnBoardSection
-                  installedTitleActionState={installedTitleActionState}
-                  installedTitlesState={installedTitlesState}
-                  onCancelUninstall={handleCancelUninstall}
-                  onLaunchTitle={(packageName, displayName) =>
-                    void handleLaunchInstalledTitle(packageName, displayName)
-                  }
-                  onRefresh={() => void refreshInstalledTitles("manual")}
-                  onRequestUninstall={handleRequestUninstall}
-                  onUninstallTitle={(packageName, displayName) =>
-                    void handleUninstallInstalledTitle(packageName, displayName)
-                  }
-                />
-              )}
-            </section>
+          <section className="desktop-main-content">
+            {activeSectionId === "gamesAndApps" ? (
+              <GamesAndAppsSection
+                apkDiscoveryState={apkDiscoveryState}
+                apkInstallState={apkInstallState}
+                desktopSettings={desktopSettings}
+                managedLibraryState={managedLibraryState}
+                onChooseManualApk={() => void handleChooseManualApk()}
+                onImportCandidate={(sourcePath) => void handleImportApkIntoManagedLibrary(sourcePath)}
+                onInstallApk={(apkPath) => void handleInstallApk(apkPath)}
+                onRescan={() => {
+                  void refreshApkDiscovery("manual");
+                  void refreshManagedLibrary("manual");
+                }}
+              />
+            ) : (
+              <InstalledOnBoardSection
+                installedTitleActionState={installedTitleActionState}
+                installedTitlesState={installedTitlesState}
+                onCancelUninstall={handleCancelUninstall}
+                onLaunchTitle={(packageName, displayName) =>
+                  void handleLaunchInstalledTitle(packageName, displayName)
+                }
+                onRefresh={() => void refreshInstalledTitles("manual")}
+                onRequestUninstall={handleRequestUninstall}
+                onUninstallTitle={(packageName, displayName) =>
+                  void handleUninstallInstalledTitle(packageName, displayName)
+                }
+              />
+            )}
           </section>
         </section>
       </section>
@@ -898,7 +886,6 @@ function GamesAndAppsSection({
     <section className="desktop-section-stack">
       <section className="desktop-section-header">
         <div>
-          <div className="eyebrow">Games &amp; Apps</div>
           <h2>Choose a game or app from this computer.</h2>
           <p className="panel-description">
             BE Home can check your chosen folders, keep saved copies in one library, or let you
@@ -946,7 +933,6 @@ function GamesAndAppsSection({
 
       <section className="desktop-two-column-grid">
         <article className="desktop-content-card">
-          <div className="eyebrow">Found on This Computer</div>
           <h3>Folders BE Home can already see</h3>
           <p className="desktop-section-copy">
             {scanFolderCount === 0
@@ -1011,7 +997,6 @@ function GamesAndAppsSection({
         </article>
 
         <article className="desktop-content-card">
-          <div className="eyebrow">Chosen Manually</div>
           <h3>Use any game or app file you already trust.</h3>
           <p className="desktop-section-copy">
             If you already know which file you want, you can choose it directly even when no scan
@@ -1072,7 +1057,6 @@ function GamesAndAppsSection({
       </section>
 
       <article className="desktop-content-card">
-        <div className="eyebrow">Saved Library</div>
         <h3>Saved copies you can reuse later</h3>
         <p className="desktop-section-copy">
           BE Home keeps saved copies here so reinstalling later takes fewer steps.
@@ -1155,7 +1139,6 @@ function InstalledOnBoardSection({
     <section className="desktop-section-stack">
       <section className="desktop-section-header">
         <div>
-          <div className="eyebrow">Installed on Board</div>
           <h2>Review what is already on your Board.</h2>
           <p className="panel-description">
             Open a game that is ready to launch, or remove something you no longer want on the
@@ -1188,7 +1171,6 @@ function InstalledOnBoardSection({
       ) : null}
 
       <article className="desktop-content-card">
-        <div className="eyebrow">Current List</div>
         <h3>Titles BE Home can read right now</h3>
         <p className="desktop-section-copy">
           BE Home keeps launch and remove actions next to the title they affect.

--- a/src/settings-window/SettingsWindowApp.tsx
+++ b/src/settings-window/SettingsWindowApp.tsx
@@ -359,9 +359,8 @@ export default function SettingsWindowApp() {
   if (windowError !== null) {
     return (
       <main className="page-shell desktop-shell desktop-utility-window">
-        <section className="page-grid narrow">
-          <section className="panel desktop-state-card" aria-live="polite">
-            <div className="eyebrow">Settings</div>
+        <section className="desktop-utility-grid">
+          <section className="desktop-state-view" aria-live="polite">
             <h2>Please close BE Home for Desktop and try again.</h2>
             <p className="panel-description">{windowError}</p>
           </section>
@@ -373,9 +372,8 @@ export default function SettingsWindowApp() {
   if (desktopSettings === null || toolState === null) {
     return (
       <main className="page-shell desktop-shell desktop-utility-window">
-        <section className="page-grid narrow">
-          <section className="panel desktop-state-card" aria-live="polite">
-            <div className="eyebrow">Settings</div>
+        <section className="desktop-utility-grid">
+          <section className="desktop-state-view" aria-live="polite">
             <h2>Loading settings</h2>
             <p className="panel-description">
               BE Home is loading your folder choices and Board Install Tool details.
@@ -388,11 +386,10 @@ export default function SettingsWindowApp() {
 
   return (
     <main className="page-shell desktop-shell desktop-utility-window">
-      <section className="page-grid narrow desktop-utility-grid">
-        <section className="panel desktop-utility-card">
+      <section className="desktop-utility-grid">
+        <section className="desktop-utility-dialog">
           <header className="desktop-utility-header">
             <div className="desktop-utility-heading">
-              <div className="eyebrow">Settings</div>
               <h1>BE Home for Desktop settings</h1>
               <p className="panel-description">
                 Keep the most important folders, Board checks, and Board Install Tool options in
@@ -439,18 +436,19 @@ export default function SettingsWindowApp() {
           <section className="desktop-utility-body" aria-live="polite">
             {activeTabId === "locations" ? (
               <section className="desktop-settings-page">
-                <div className="eyebrow">Locations</div>
                 <h2>Choose where BE Home looks and saves.</h2>
 
                 <section className="desktop-settings-section">
-                  <div className="desktop-list-editor-header">
+                  <div className="desktop-list-editor-header desktop-list-editor-header--stacked">
                     <div>
                       <span className="desktop-field-label">Games and apps folders</span>
                       <p className="desktop-section-copy">
                         BE Home checks these folders when you rescan this computer.
                       </p>
                     </div>
-                    {iconButton("add", "Add folder", () => void handleAddScanFolder(), busy)}
+                    <div className="desktop-list-editor-actions">
+                      {iconButton("add", "Add folder", () => void handleAddScanFolder(), busy)}
+                    </div>
                   </div>
 
                   {desktopSettings.scanFolders.length === 0 ? (
@@ -467,12 +465,14 @@ export default function SettingsWindowApp() {
                               {folder.source === "default" ? "Recommended folder" : "Custom folder"}
                             </p>
                           </div>
-                          {iconButton(
-                            "remove",
-                            `Remove ${folder.path}`,
-                            () => void handleRemoveScanFolder(folder.path),
-                            busy,
-                          )}
+                          <div className="desktop-folder-actions">
+                            {iconButton(
+                              "remove",
+                              `Remove ${folder.path}`,
+                              () => void handleRemoveScanFolder(folder.path),
+                              busy,
+                            )}
+                          </div>
                         </li>
                       ))}
                     </ul>
@@ -525,7 +525,6 @@ export default function SettingsWindowApp() {
 
             {activeTabId === "boardConnection" ? (
               <section className="desktop-settings-page">
-                <div className="eyebrow">Board Connection</div>
                 <h2>Choose how often BE Home checks your Board.</h2>
                 <p className="panel-description">
                   BE Home only refreshes while its main window is visible.
@@ -563,7 +562,6 @@ export default function SettingsWindowApp() {
 
             {activeTabId === "boardTool" ? (
               <section className="desktop-settings-page">
-                <div className="eyebrow">Board Install Tool</div>
                 <h2>Keep the Board Install Tool ready.</h2>
                 <p className="panel-description">
                   BE Home uses this helper to talk to your Board and install games and apps.
@@ -577,7 +575,7 @@ export default function SettingsWindowApp() {
                     </div>
                   </label>
                   <label className="desktop-field">
-                    <span className="desktop-field-label">Latest version in BE Home</span>
+                    <span className="desktop-field-label">Latest version available from Board</span>
                     <div className="desktop-readonly-field">
                       {formatBoardInstallToolVersion(
                         toolState.updateStatus.availableVersion,
@@ -621,14 +619,16 @@ export default function SettingsWindowApp() {
                   >
                     {busy ? "Working..." : toolActionLabel(toolState)}
                   </button>
-                  <button
-                    className="secondary-button"
-                    disabled={busy}
-                    onClick={() => void handleCheckForUpdate()}
-                    type="button"
-                  >
-                    Check for Update
-                  </button>
+                  {toolState.executableExists ? (
+                    <button
+                      className="secondary-button"
+                      disabled={busy}
+                      onClick={() => void handleCheckForUpdate()}
+                      type="button"
+                    >
+                      Check for Update
+                    </button>
+                  ) : null}
                 </div>
               </section>
             ) : null}
@@ -664,10 +664,9 @@ export default function SettingsWindowApp() {
         <section className="desktop-modal-scrim" role="presentation">
           <article
             aria-labelledby="settings-support-request-title"
-            className="panel desktop-modal-card"
+            className="desktop-modal-card"
             role="dialog"
           >
-            <div className="eyebrow">Board Support</div>
             <h2 id="settings-support-request-title">Email Board Support</h2>
             <p className="panel-description">
               BE Home can open this draft in your mail app for you.

--- a/src/setup-window/SetupWizardApp.tsx
+++ b/src/setup-window/SetupWizardApp.tsx
@@ -1,17 +1,16 @@
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { open } from "@tauri-apps/plugin-dialog";
 import { openUrl } from "@tauri-apps/plugin-opener";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   acquireBdbTool,
   dismissSetupWizardWindow,
-  emitSettingsUpdated,
+  finishSetupWizardWindow,
   loadBdbToolState,
   loadDesktopSettings,
   loadSetupGateState,
   refreshBdbToolState,
   saveDesktopSettings,
-  showMainWorkspaceWindow,
 } from "../desktop/client";
 import type {
   BdbToolState,
@@ -33,6 +32,12 @@ interface InlineNotice {
   tone: "neutral" | "warning" | "success";
   title: string;
   detail: string | null;
+}
+
+interface WizardAlertDialog {
+  title: string;
+  detail: string | null;
+  acknowledgeLabel?: string;
 }
 
 const wizardSteps: WizardStep[] = [
@@ -81,6 +86,32 @@ function normalizeLibraryOverride(defaultPath: string, draftValue: string): stri
   return normalizedDraft;
 }
 
+function normalizeFolderPathForComparison(path: string, operatingSystem: DesktopSettings["operatingSystem"]): string {
+  const normalized = path.replace(/[\\/]+/g, "/").replace(/\/+$/, "");
+  return operatingSystem === "windows" ? normalized.toLowerCase() : normalized;
+}
+
+function findCoveringScanFolder(
+  scanFolders: string[],
+  candidatePath: string,
+  operatingSystem: DesktopSettings["operatingSystem"],
+): string | null {
+  const normalizedCandidate = normalizeFolderPathForComparison(candidatePath, operatingSystem);
+
+  for (const existingPath of scanFolders) {
+    const normalizedExisting = normalizeFolderPathForComparison(existingPath, operatingSystem);
+
+    if (
+      normalizedCandidate.length > normalizedExisting.length &&
+      normalizedCandidate.startsWith(`${normalizedExisting}/`)
+    ) {
+      return existingPath;
+    }
+  }
+
+  return null;
+}
+
 function supportInstructionText(): string {
   return "Please enter your email address in the From field and add your name at the end before sending.";
 }
@@ -107,7 +138,11 @@ export default function SetupWizardApp() {
   const [windowError, setWindowError] = useState<string | null>(null);
   const [inlineNotice, setInlineNotice] = useState<InlineNotice | null>(null);
   const [busy, setBusy] = useState(false);
+  const [latestVersionRefreshing, setLatestVersionRefreshing] = useState(false);
+  const [cancelDialogOpen, setCancelDialogOpen] = useState(false);
   const [supportDialogDraft, setSupportDialogDraft] = useState<SupportRequestDraft | null>(null);
+  const [wizardAlertDialog, setWizardAlertDialog] = useState<WizardAlertDialog | null>(null);
+  const allowWindowCloseRef = useRef(false);
 
   const currentStepIndex = wizardSteps.findIndex((step) => step.id === currentStepId);
   const toolStepBlocked = toolState?.supportRequestDraft !== null;
@@ -118,16 +153,32 @@ export default function SetupWizardApp() {
   }, []);
 
   useEffect(() => {
-    let unlistenCloseRequest: (() => void) | null = null;
+    if (currentStepId !== "boardTool") {
+      return;
+    }
 
-    void getCurrentWindow()
+    void refreshBoardToolDetails({ announceResult: false });
+  }, [currentStepId]);
+
+  useEffect(() => {
+    let unlistenCloseRequest: (() => void) | null = null;
+    let currentWindow: ReturnType<typeof getCurrentWindow>;
+
+    try {
+      currentWindow = getCurrentWindow();
+    } catch {
+      return () => undefined;
+    }
+
+    void currentWindow
       .onCloseRequested(async (event) => {
-        if (setupGateState?.status === "ready") {
+        if (allowWindowCloseRef.current) {
           return;
         }
 
         event.preventDefault();
-        await handleCancelSetup();
+        setSupportDialogDraft(null);
+        setCancelDialogOpen(true);
       })
       .then((unlisten) => {
         unlistenCloseRequest = unlisten;
@@ -139,7 +190,7 @@ export default function SetupWizardApp() {
         unlistenCloseRequest();
       }
     };
-  }, [setupGateState?.status]);
+  }, []);
 
   const readySummaryRows = useMemo(
     () =>
@@ -184,6 +235,11 @@ export default function SetupWizardApp() {
     }
   }
 
+  function showWizardAlert(dialog: WizardAlertDialog): void {
+    setInlineNotice(null);
+    setWizardAlertDialog(dialog);
+  }
+
   async function saveDraftSettings(): Promise<boolean> {
     if (desktopSettings === null) {
       return false;
@@ -205,11 +261,9 @@ export default function SetupWizardApp() {
       setDesktopSettings(savedSettings);
       setScanFolderDraft(savedSettings.scanFolders.map((folder) => folder.path));
       setLibraryPathDraft(savedSettings.apkLibrary.effectivePath);
-      await emitSettingsUpdated();
       return true;
     } catch {
-      setInlineNotice({
-        tone: "warning",
+      showWizardAlert({
         title: "BE Home couldn't save these setup choices yet.",
         detail: "Please try again in a moment.",
       });
@@ -219,14 +273,41 @@ export default function SetupWizardApp() {
     }
   }
 
-  async function handleCancelSetup(): Promise<void> {
-    await dismissSetupWizardWindow();
+  async function dismissWizardOrExitProgrammatically(): Promise<void> {
+    allowWindowCloseRef.current = true;
+
+    try {
+      await dismissSetupWizardWindow();
+    } catch (error) {
+      allowWindowCloseRef.current = false;
+      throw error;
+    }
   }
 
-  async function handleOpenWorkspace(): Promise<void> {
-    await emitSettingsUpdated();
-    await showMainWorkspaceWindow();
-    await dismissSetupWizardWindow();
+  function handleCancelSetup(): void {
+    if (busy) {
+      return;
+    }
+
+    setSupportDialogDraft(null);
+    setCancelDialogOpen(true);
+  }
+
+  async function handleConfirmCancelSetup(): Promise<void> {
+    setBusy(true);
+    setInlineNotice(null);
+    setWizardAlertDialog(null);
+
+    try {
+      await dismissWizardOrExitProgrammatically();
+    } catch {
+      setBusy(false);
+      setCancelDialogOpen(false);
+      showWizardAlert({
+        title: "BE Home couldn't close setup just yet.",
+        detail: "Please try again in a moment.",
+      });
+    }
   }
 
   async function handleDownloadOrRepair(): Promise<void> {
@@ -236,20 +317,27 @@ export default function SetupWizardApp() {
 
     setBusy(true);
     setInlineNotice(null);
+    setWizardAlertDialog(null);
 
     try {
       const result = await acquireBdbTool(toolState.executableExists);
-      setInlineNotice({
-        tone: result.outcome === "failed" ? "warning" : "success",
-        title: result.summary,
-        detail: result.guidance,
-      });
+      if (result.outcome === "failed") {
+        showWizardAlert({
+          title: result.summary,
+          detail: result.guidance,
+        });
+      } else {
+        setInlineNotice({
+          tone: "success",
+          title: result.summary,
+          detail: result.guidance,
+        });
+      }
       await refreshWindowState({
         refreshManifest: result.outcome !== "failed",
       });
     } catch {
-      setInlineNotice({
-        tone: "warning",
+      showWizardAlert({
         title: "BE Home couldn't finish that Board Install Tool step.",
         detail: "Please try again in a moment.",
       });
@@ -258,32 +346,53 @@ export default function SetupWizardApp() {
     }
   }
 
-  async function handleCheckForUpdate(): Promise<void> {
-    setBusy(true);
-    setInlineNotice(null);
+  async function refreshBoardToolDetails(options: {
+    announceResult: boolean;
+  }): Promise<void> {
+    setLatestVersionRefreshing(true);
 
     try {
       const latestToolState = await refreshBdbToolState();
       setToolState(latestToolState);
-      setInlineNotice({
-        tone: latestToolState.updateStatus.status === "updateAvailable" ? "warning" : "neutral",
-        title: "BE Home checked Board's latest Board Install Tool version.",
-        detail:
-          latestToolState.updateStatus.guidance ??
-          "You can review the current version details below.",
-      });
+
+      if (options.announceResult) {
+        setInlineNotice({
+          tone: "neutral",
+          title: "BE Home checked Board's latest Board Install Tool version.",
+          detail:
+            latestToolState.updateStatus.guidance ??
+            "You can review the current version details below.",
+        });
+      }
     } catch {
-      setInlineNotice({
-        tone: "warning",
-        title: "BE Home couldn't check for Board Install Tool updates right now.",
-        detail: "Please try again in a moment.",
-      });
+      if (options.announceResult) {
+        showWizardAlert({
+          title: "BE Home couldn't check for Board Install Tool updates right now.",
+          detail: "Please try again in a moment.",
+        });
+      }
+    } finally {
+      setLatestVersionRefreshing(false);
+    }
+  }
+
+  async function handleCheckForUpdate(): Promise<void> {
+    setBusy(true);
+    setInlineNotice(null);
+    setWizardAlertDialog(null);
+
+    try {
+      await refreshBoardToolDetails({ announceResult: true });
     } finally {
       setBusy(false);
     }
   }
 
   async function handleAddScanFolder(): Promise<void> {
+    if (desktopSettings === null) {
+      return;
+    }
+
     const selectedPath = await pickSinglePath(
       await open({
         directory: true,
@@ -295,11 +404,36 @@ export default function SetupWizardApp() {
       return;
     }
 
-    if (scanFolderDraft.includes(selectedPath)) {
+    const normalizedSelectedPath = normalizeFolderPathForComparison(
+      selectedPath,
+      desktopSettings.operatingSystem,
+    );
+    const existingExactMatch = scanFolderDraft.find(
+      (path) =>
+        normalizeFolderPathForComparison(path, desktopSettings.operatingSystem) ===
+        normalizedSelectedPath,
+    );
+
+    if (existingExactMatch !== undefined) {
       setInlineNotice({
         tone: "neutral",
         title: "That folder is already on the list.",
         detail: "Choose another folder if you want BE Home to watch an additional place.",
+      });
+      return;
+    }
+
+    const coveringFolder = findCoveringScanFolder(
+      scanFolderDraft,
+      selectedPath,
+      desktopSettings.operatingSystem,
+    );
+
+    if (coveringFolder !== null) {
+      showWizardAlert({
+        title: "That folder is already covered by another rule.",
+        detail: `BE Home is already checking ${coveringFolder}, so you don't need to add ${selectedPath} separately.`,
+        acknowledgeLabel: "Got it",
       });
       return;
     }
@@ -338,8 +472,7 @@ export default function SetupWizardApp() {
     try {
       await openUrl(supportDialogDraft.mailtoUrl);
     } catch {
-      setInlineNotice({
-        tone: "warning",
+      showWizardAlert({
         title: "BE Home couldn't open your email app automatically.",
         detail: "You can still copy the email draft from this window.",
       });
@@ -366,8 +499,7 @@ export default function SetupWizardApp() {
         detail: "Paste it into your mail app, then add your email address and name before sending.",
       });
     } catch {
-      setInlineNotice({
-        tone: "warning",
+      showWizardAlert({
         title: "BE Home couldn't copy the email draft automatically.",
         detail: "Please use the text shown in this window instead.",
       });
@@ -379,11 +511,22 @@ export default function SetupWizardApp() {
       return;
     }
 
-    await handleOpenWorkspace();
+    try {
+      allowWindowCloseRef.current = true;
+      setCancelDialogOpen(false);
+      await finishSetupWizardWindow();
+    } catch {
+      allowWindowCloseRef.current = false;
+      showWizardAlert({
+        title: "BE Home couldn't finish setup just yet.",
+        detail: "Please try again in a moment.",
+      });
+    }
   }
 
   async function handleNext(): Promise<void> {
     setInlineNotice(null);
+    setWizardAlertDialog(null);
 
     switch (currentStepId) {
       case "welcome":
@@ -391,26 +534,22 @@ export default function SetupWizardApp() {
         return;
       case "boardTool":
         if (!canAdvancePastToolStep) {
-          setInlineNotice({
-            tone: "warning",
-            title: "Finish the Board Install Tool step first.",
+          showWizardAlert({
+            title: "Download the Board Install Tool first.",
             detail: toolStepBlocked
-              ? "This build of the Board Install Tool is not compatible with this computer yet."
-              : "BE Home needs the Board Install Tool ready before it can open the workspace.",
+              ? "This Board Install Tool download is not compatible with this computer yet. Use Email Board Support in this step if you want to ask Board for support."
+              : "BE Home can't move to the next step until the Board Install Tool is downloaded and ready. Choose Download in this step, then try Next again.",
+            acknowledgeLabel: toolStepBlocked ? "OK" : "Got it",
           });
           return;
         }
         setCurrentStepId("scanFolders");
         return;
       case "scanFolders":
-        if (await saveDraftSettings()) {
-          setCurrentStepId("libraryLocation");
-        }
+        setCurrentStepId("libraryLocation");
         return;
       case "libraryLocation":
-        if (await saveDraftSettings()) {
-          setCurrentStepId("ready");
-        }
+        setCurrentStepId("ready");
         return;
       case "ready":
         await handleFinish();
@@ -422,6 +561,7 @@ export default function SetupWizardApp() {
 
   function handleBack(): void {
     setInlineNotice(null);
+    setWizardAlertDialog(null);
     setCurrentStepId((previousStepId) => {
       const previousIndex = wizardSteps.findIndex((step) => step.id === previousStepId) - 1;
       return wizardSteps[Math.max(previousIndex, 0)]?.id ?? "welcome";
@@ -431,9 +571,8 @@ export default function SetupWizardApp() {
   if (windowError !== null) {
     return (
       <main className="page-shell desktop-shell desktop-utility-window">
-        <section className="page-grid narrow">
-          <section className="panel desktop-state-card" aria-live="polite">
-            <div className="eyebrow">Setup Wizard</div>
+        <section className="desktop-utility-grid">
+          <section className="desktop-state-view" aria-live="polite">
             <h2>Please close BE Home for Desktop and try again.</h2>
             <p className="panel-description">{windowError}</p>
           </section>
@@ -445,9 +584,8 @@ export default function SetupWizardApp() {
   if (setupGateState === null || toolState === null || desktopSettings === null) {
     return (
       <main className="page-shell desktop-shell desktop-utility-window">
-        <section className="page-grid narrow">
-          <section className="panel desktop-state-card" aria-live="polite">
-            <div className="eyebrow">Setup Wizard</div>
+        <section className="desktop-utility-grid">
+          <section className="desktop-state-view" aria-live="polite">
             <h2>Getting setup ready</h2>
             <p className="panel-description">
               BE Home is checking your Board Install Tool, game folders, and saved library
@@ -461,15 +599,14 @@ export default function SetupWizardApp() {
 
   return (
     <main className="page-shell desktop-shell desktop-utility-window">
-      <section className="page-grid narrow desktop-utility-grid">
-        <section className="panel desktop-utility-card">
+      <section className="desktop-utility-grid">
+        <section className="desktop-utility-dialog desktop-utility-dialog--wizard">
           <header className="desktop-utility-header">
             <div className="desktop-utility-heading">
-              <div className="eyebrow">Setup Wizard</div>
               <h1>Set up BE Home for Desktop</h1>
               <p className="panel-description">
-                BE Home for Desktop helps you find games and apps on this computer, keep a saved
-                library close by, and install them on Board without command-line steps.
+                Setup gets BE Home ready to find games and apps on this computer and install them
+                on Board without command-line steps.
               </p>
             </div>
             <ol className="desktop-wizard-step-row" aria-label="Setup steps">
@@ -494,27 +631,16 @@ export default function SetupWizardApp() {
           <section className="desktop-utility-body" aria-live="polite">
             {currentStepId === "welcome" ? (
               <section className="desktop-wizard-page">
-                <div className="eyebrow">Welcome</div>
-                <h2>Here’s what setup will help you do.</h2>
+                <h2>Here’s what setup will do.</h2>
                 <p className="panel-description">
-                  BE Home for Desktop helps you choose games and apps on this computer and install
-                  them on your Board without working through terminal steps by hand.
+                  You’ll download the Board Install Tool, choose which folders BE Home checks for
+                  games and apps, and pick where saved copies should live on this computer.
                 </p>
-                <p className="panel-description">
-                  This quick setup will download the Board Install Tool, choose where BE Home looks
-                  for games and apps, and choose where saved copies should live on this computer.
-                </p>
-                <ul className="desktop-wizard-checklist">
-                  <li>Get the Board Install Tool ready so BE Home can talk to your Board.</li>
-                  <li>Choose the folders BE Home should check for game and app files.</li>
-                  <li>Choose where saved copies should be kept for later installs.</li>
-                </ul>
               </section>
             ) : null}
 
             {currentStepId === "boardTool" ? (
               <section className="desktop-wizard-page">
-                <div className="eyebrow">Board Install Tool</div>
                 <h2>Get the Board Install Tool ready.</h2>
                 <p className="panel-description">
                   BE Home needs Board’s install helper so it can install games and apps on your
@@ -533,11 +659,11 @@ export default function SetupWizardApp() {
                     </div>
                   </label>
                   <label className="desktop-field">
-                    <span className="desktop-field-label">Latest version in BE Home</span>
+                    <span className="desktop-field-label">Latest version available from Board</span>
                     <div className="desktop-readonly-field">
                       {formatBoardInstallToolVersion(
                         toolState.updateStatus.availableVersion,
-                        "Not available yet",
+                        latestVersionRefreshing ? "Checking..." : "Not available yet",
                       )}
                     </div>
                   </label>
@@ -576,14 +702,16 @@ export default function SetupWizardApp() {
                   >
                     {busy ? "Working..." : updateActionLabel(toolState)}
                   </button>
-                  <button
-                    className="secondary-button"
-                    disabled={busy}
-                    onClick={() => void handleCheckForUpdate()}
-                    type="button"
-                  >
-                    Check for Update
-                  </button>
+                  {toolState.executableExists ? (
+                    <button
+                      className="secondary-button"
+                      disabled={busy}
+                      onClick={() => void handleCheckForUpdate()}
+                      type="button"
+                    >
+                      Check for Update
+                    </button>
+                  ) : null}
                 </div>
 
                 <p className="desktop-footnote">
@@ -594,7 +722,6 @@ export default function SetupWizardApp() {
 
             {currentStepId === "scanFolders" ? (
               <section className="desktop-wizard-page">
-                <div className="eyebrow">Look for Games &amp; Apps</div>
                 <h2>Choose the folders BE Home should check.</h2>
                 <p className="panel-description">
                   BE Home can look in these folders when you rescan this computer for games and
@@ -604,7 +731,6 @@ export default function SetupWizardApp() {
                 <section className="desktop-list-editor">
                   <div className="desktop-list-editor-header">
                     <span className="desktop-field-label">Folders to check</span>
-                    {iconButtonLabel("add", "Add folder", () => void handleAddScanFolder(), busy)}
                   </div>
 
                   {scanFolderDraft.length === 0 ? (
@@ -618,23 +744,30 @@ export default function SetupWizardApp() {
                           <div className="desktop-folder-copy">
                             <p className="desktop-folder-path">{path}</p>
                           </div>
-                          {iconButtonLabel(
-                            "remove",
-                            `Remove ${path}`,
-                            () => handleRemoveScanFolder(path),
-                            busy,
-                          )}
+                          <div className="desktop-folder-actions">
+                            {iconButtonLabel(
+                              "remove",
+                              `Remove ${path}`,
+                              () => handleRemoveScanFolder(path),
+                              busy,
+                            )}
+                          </div>
                         </li>
                       ))}
                     </ul>
                   )}
+
+                  <div className="desktop-list-editor-footer">
+                    <div className="desktop-list-editor-actions">
+                      {iconButtonLabel("add", "Add folder", () => void handleAddScanFolder(), busy)}
+                    </div>
+                  </div>
                 </section>
               </section>
             ) : null}
 
             {currentStepId === "libraryLocation" ? (
               <section className="desktop-wizard-page">
-                <div className="eyebrow">Library Location</div>
                 <h2>Choose where saved copies should live.</h2>
                 <p className="panel-description">
                   BE Home can keep reusable copies of your games and apps in one saved library so
@@ -680,7 +813,6 @@ export default function SetupWizardApp() {
 
             {currentStepId === "ready" ? (
               <section className="desktop-wizard-page">
-                <div className="eyebrow">Ready to Go</div>
                 <h2>Your setup choices are ready.</h2>
                 <p className="panel-description">
                   You can finish now and open BE Home, or go back if you want to change anything.
@@ -716,7 +848,7 @@ export default function SetupWizardApp() {
             <button
               className="tertiary-button"
               disabled={busy}
-              onClick={() => void handleCancelSetup()}
+              onClick={handleCancelSetup}
               type="button"
             >
               Cancel
@@ -740,14 +872,46 @@ export default function SetupWizardApp() {
         </section>
       </section>
 
+      {cancelDialogOpen ? (
+        <section className="desktop-modal-scrim" role="presentation">
+          <article
+            aria-labelledby="cancel-setup-title"
+            className="desktop-modal-card"
+            role="dialog"
+          >
+            <h2 id="cancel-setup-title">Cancel setup?</h2>
+            <p className="panel-description">
+              If you cancel setup now, the choices you made in this window will be lost.
+            </p>
+            <div className="desktop-inline-button-row">
+              <button
+                className="primary-button"
+                disabled={busy}
+                onClick={() => void handleConfirmCancelSetup()}
+                type="button"
+              >
+                Yes, Cancel Setup
+              </button>
+              <button
+                className="secondary-button"
+                disabled={busy}
+                onClick={() => setCancelDialogOpen(false)}
+                type="button"
+              >
+                Keep Setup Open
+              </button>
+            </div>
+          </article>
+        </section>
+      ) : null}
+
       {supportDialogDraft !== null ? (
         <section className="desktop-modal-scrim" role="presentation">
           <article
             aria-labelledby="support-request-title"
-            className="panel desktop-modal-card"
+            className="desktop-modal-card"
             role="dialog"
           >
-            <div className="eyebrow">Board Support</div>
             <h2 id="support-request-title">Email Board Support</h2>
             <p className="panel-description">
               BE Home can open a draft in your mail app with the details below.
@@ -784,6 +948,31 @@ export default function SetupWizardApp() {
                 type="button"
               >
                 Close
+              </button>
+            </div>
+          </article>
+        </section>
+      ) : null}
+
+      {wizardAlertDialog !== null ? (
+        <section className="desktop-modal-scrim" role="presentation">
+          <article
+            aria-labelledby="wizard-alert-title"
+            className="desktop-modal-card"
+            role="dialog"
+          >
+            <h2 id="wizard-alert-title">{wizardAlertDialog.title}</h2>
+            {wizardAlertDialog.detail !== null ? (
+              <p className="panel-description">{wizardAlertDialog.detail}</p>
+            ) : null}
+            <div className="desktop-inline-button-row">
+              <button
+                autoFocus
+                className="primary-button"
+                onClick={() => setWizardAlertDialog(null)}
+                type="button"
+              >
+                {wizardAlertDialog.acknowledgeLabel ?? "OK"}
               </button>
             </div>
           </article>

--- a/src/styles.css
+++ b/src/styles.css
@@ -30,6 +30,12 @@
     --desktop-surface-muted: rgba(255, 255, 255, 0.03);
     --desktop-border: rgba(118, 255, 170, 0.18);
     --desktop-border-strong: rgba(118, 255, 170, 0.34);
+    --desktop-window-border: #37644f;
+    --desktop-titlebar-bg: #17141c;
+    --desktop-titlebar-border: #2e4b3e;
+    --desktop-titlebar-button-hover: #24202b;
+    --desktop-menu-bg: #1f1b26;
+    --desktop-menu-item-hover: #2a2531;
     --desktop-text: #f7f2e8;
     --desktop-text-muted: rgba(223, 229, 240, 0.82);
     --desktop-text-soft: rgba(223, 229, 240, 0.68);
@@ -45,6 +51,12 @@
     --desktop-surface-muted: rgba(12, 31, 32, 0.04);
     --desktop-border: rgba(36, 104, 83, 0.18);
     --desktop-border-strong: rgba(36, 104, 83, 0.28);
+    --desktop-window-border: #88ab9f;
+    --desktop-titlebar-bg: #ffffff;
+    --desktop-titlebar-border: #c4d7d1;
+    --desktop-titlebar-button-hover: #e9f1f2;
+    --desktop-menu-bg: #ffffff;
+    --desktop-menu-item-hover: #eef4f6;
     --desktop-text: #142125;
     --desktop-text-muted: rgba(20, 33, 37, 0.82);
     --desktop-text-soft: rgba(20, 33, 37, 0.62);
@@ -120,14 +132,6 @@
 
   .hero-panel {
     padding: 1.75rem;
-  }
-
-  .eyebrow {
-    font-size: 0.75rem;
-    font-weight: 700;
-    letter-spacing: 0.2em;
-    text-transform: uppercase;
-    color: var(--desktop-text-soft);
   }
 
   .panel h2,


### PR DESCRIPTION
## Summary
- Captures the final Tauri/WebView-era desktop shell polish checkpoint before the Unity UI Toolkit cutover.
- Includes async bdb process handling, window chrome polish, setup handoff cleanup, Board OS refresh behavior, and About-window close/load adjustments.

## Verification
- `npm run test:host` passed: 88 tests
- `npm run test:renderer` passed: 17 tests
- `npm run tauri -- build --no-bundle` passed

## Follow-up
- The next desktop work will hard-cut `be-home-for-desktop` to Unity 6.4/UI Toolkit.